### PR TITLE
chore: remove netlify badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 ---
 
 [![CLI](https://github.com/tetratelabs/built-on-envoy/actions/workflows/build.yaml/badge.svg)](https://github.com/tetratelabs/built-on-envoy/actions/workflows/build.yaml)
-[![Netlify Status](https://api.netlify.com/api/v1/badges/3c996526-432a-4962-ad31-82fbabacbac6/deploy-status)](https://builtonenvoy.netlify.app/)
 [![codecov](https://codecov.io/gh/tetratelabs/built-on-envoy/graph/badge.svg?token=v4u6VpZSqZ)](https://codecov.io/gh/tetratelabs/built-on-envoy)
 [![License](https://img.shields.io/badge/License-Apache%202.0-red)](LICENSE)
 [![Slack](https://img.shields.io/badge/Slack-Tetrate%20Community-purple)](https://tetr8.io/tetrate-community)


### PR DESCRIPTION
When there are no changes to the website in hte commit, the badge shows "cancelled", which looks not nice, so I'll just remove the netlify abdge.