### PR TITLE
Fix config parsing in gen and run

### DIFF
--- a/cli/cmd/config.go
+++ b/cli/cmd/config.go
@@ -31,7 +31,7 @@ type GenConfig struct {
 	AdminPort  uint32   `help:"Port for Envoy admin interface." default:"9901"`
 	Extensions []string `name:"extension" help:"Extensions to enable (in the format: \"name\" or \"name:version\")." sep:","`
 	Local      []string `name:"local" help:"Path to a directory containing a local Extension to enable." type:"existingdir" sep:","`
-	Configs    []string `name:"config" help:"Optional JSON config string for extensions. Applied in order to combined --extension and --local flags."`
+	Configs    []string `name:"config" sep:none help:"Optional JSON config string for extensions. Applied in order to combined --extension and --local flags."`
 	OCI        OCIFlags `embed:""`
 
 	extensions []*extensions.Manifest `kong:"-"` // Internal field: loaded extension manifests

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -32,7 +32,7 @@ type Run struct {
 	AdminPort    uint32   `help:"Port for Envoy admin interface." default:"9901"`
 	Extensions   []string `name:"extension" help:"Extensions to enable (in the format: \"name\" or \"name:version\")." sep:","`
 	Local        []string `name:"local" help:"Path to a directory containing a local Extension to enable." type:"existingdir" sep:","`
-	Configs      []string `name:"config" help:"Optional JSON config string for extensions. Applied in order to combined --extension and --local flags."`
+	Configs      []string `name:"config" sep:none help:"Optional JSON config string for extensions. Applied in order to combined --extension and --local flags."`
 	OCI          OCIFlags `embed:""`
 
 	defaultLogLevel   string `kong:"-"` // Internal field: parsed defaut log level


### PR DESCRIPTION
Remove the separator for the `config` flag. Otherwise, JSON strings that cotain `,` are getting split, and parsing fails.