### PR TITLE
coraza: fix extension name in the plugin

### DIFF
--- a/extensions/composer/goplugin/goplugin.go
+++ b/extensions/composer/goplugin/goplugin.go
@@ -9,9 +9,11 @@ package goplugin
 import (
 	"debug/buildinfo"
 	"fmt"
+	"maps"
 	"os"
 	"plugin"
 	"runtime/debug"
+	"slices"
 	"strings"
 
 	sdk "github.com/envoyproxy/envoy/source/extensions/dynamic_modules/sdk/go"
@@ -108,7 +110,8 @@ func createFactory[T any](binaryPath string, symbolName string, pluginName strin
 	}
 	goPluginModule, ok = factories()[pluginName]
 	if !ok {
-		return goPluginModule, fmt.Errorf("failed to get config factory from plugin: %w", err)
+		plugins := slices.Collect(maps.Keys(factories()))
+		return goPluginModule, fmt.Errorf("failed to get config factory from plugin %q. Plugins: %v", pluginName, plugins)
 	}
 	// Successfully loaded as a Go plugin module.
 	return goPluginModule, nil

--- a/extensions/composer/waf/manifest.yaml
+++ b/extensions/composer/waf/manifest.yaml
@@ -49,4 +49,12 @@ examples:
   - title: Basic Usage
     description: Enable WAF protection with default OWASP CRS rules
     code: |
-      boe run --extension coraza-waf --config '{"directives":["Include @recommended-conf","Include @ftw-conf","Include @crs-setup-conf","Include @owasp_crs/*.conf"]}'
+      boe run --extension coraza-waf --config '
+        {
+          "directives": [
+            "Include @recommended-conf",
+            "Include @ftw-conf",
+            "Include @crs-setup-conf",
+            "Include @owasp_crs/*.conf"
+          ]
+        }'

--- a/extensions/composer/waf/waf.go
+++ b/extensions/composer/waf/waf.go
@@ -480,8 +480,11 @@ func (p *wafPlugin) handleResponseBody() bool {
 	return true
 }
 
+// ExtensionName is the name of the extension that will be used in the `run` command to refer to this embedded plugin.
+const ExtensionName = "coraza-waf"
+
 var wellKnownHTTPFilterConfigFactories = map[string]shared.HttpFilterConfigFactory{
-	"composer.http.coraza_waf": &wafPluginConfigFactory{},
+	ExtensionName: &wafPluginConfigFactory{},
 }
 
 // WellKnownHttpFilterConfigFactories returns the map of well-known HTTP filter config factories.


### PR DESCRIPTION
The name of the extension in the plugin factory needs to match the extension name in the manifest, that will be provided in `boe run`.