### PR TITLE
cli: preserve order of extensions when remote and local are combined

### DIFF
--- a/cli/cmd/flags.go
+++ b/cli/cmd/flags.go
@@ -1,0 +1,71 @@
+// Copyright Built On Envoy
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package cmd
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/tetratelabs/built-on-envoy/cli/internal/extensions"
+)
+
+// extensionPositions keeps track of the original position of extensions specified via --extension and --local flags.
+type extensionPositions struct {
+	local  map[string][]int // maps local extension flag values to their positions
+	remote map[string][]int // maps remote extension flag values to their positions
+}
+
+// sort takes a list of extension manifests and returns a new list sorted according to the original positions of the extension
+// specified via --extension and --local flags.
+func (e extensionPositions) sort(manifests []*extensions.Manifest) ([]*extensions.Manifest, error) {
+	sorted := make([]*extensions.Manifest, len(manifests))
+	for _, m := range manifests {
+		if m.Remote {
+			pos := e.remote[m.Name][0]
+			sorted[pos] = m
+			e.remote[m.Name] = e.remote[m.Name][1:]
+		} else {
+			flagValue, err := filepath.Abs(filepath.Dir(m.Path))
+			if err != nil {
+				return nil, fmt.Errorf("failed to get absolute path for manifest %s: %w", m.Path, err)
+			}
+			pos := e.local[flagValue][0]
+			sorted[pos] = m
+			e.local[flagValue] = e.local[flagValue][1:]
+		}
+	}
+	return sorted, nil
+}
+
+// saveExtensionPositions iterates through os.Args to find the positions of --extension and --local flags and
+// saves them in GenConfig.extensionPositions.
+func saveExtensionPositions(args []string) (extensionPositions, error) {
+	var (
+		extensionIndex int
+		positions      = extensionPositions{
+			local:  make(map[string][]int),
+			remote: make(map[string][]int),
+		}
+	)
+
+	for i, arg := range args {
+		switch arg {
+		case "--local":
+			key, err := filepath.Abs(args[i+1])
+			if err != nil {
+				return positions, fmt.Errorf("failed to get absolute path for local extension flag value %s: %w", args[i+1], err)
+			}
+			positions.local[key] = append(positions.local[key], extensionIndex)
+			extensionIndex++
+		case "--extension":
+			key := args[i+1]
+			positions.remote[key] = append(positions.remote[key], extensionIndex)
+			extensionIndex++
+		}
+	}
+
+	return positions, nil
+}

--- a/cli/cmd/flags_test.go
+++ b/cli/cmd/flags_test.go
@@ -1,0 +1,109 @@
+// Copyright Built On Envoy
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package cmd
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tetratelabs/built-on-envoy/cli/internal/extensions"
+)
+
+func TestExtensionPositionsSort(t *testing.T) {
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+
+	localDir1 := cwd + "/testdata/input_lua_inline"
+	localDir2 := "./testdata/invalid_manifest/"
+
+	tests := []struct {
+		name      string
+		args      []string
+		manifests []*extensions.Manifest
+		want      []*extensions.Manifest
+	}{
+		{
+			name: "single remote extension",
+			args: []string{"boe", "gen-config", "--extension", "ext1"},
+			manifests: []*extensions.Manifest{
+				{Name: "ext1", Remote: true},
+			},
+			want: []*extensions.Manifest{
+				{Name: "ext1", Remote: true},
+			},
+		},
+		{
+			name: "single local extension",
+			args: []string{"boe", "gen-config", "--local", localDir1},
+			manifests: []*extensions.Manifest{
+				{Name: "local1", Path: localDir1 + "/manifest.yaml"},
+			},
+			want: []*extensions.Manifest{
+				{Name: "local1", Path: localDir1 + "/manifest.yaml"},
+			},
+		},
+		{
+			name: "local before remote",
+			args: []string{"boe", "gen-config", "--local", localDir1, "--extension", "ext1"},
+			manifests: []*extensions.Manifest{
+				{Name: "ext1", Remote: true},
+				{Name: "local1", Path: localDir1 + "/manifest.yaml"},
+			},
+			want: []*extensions.Manifest{
+				{Name: "local1", Path: localDir1 + "/manifest.yaml"},
+				{Name: "ext1", Remote: true},
+			},
+		},
+		{
+			name: "remote before local",
+			args: []string{"boe", "gen-config", "--extension", "ext1", "--local", localDir1},
+			manifests: []*extensions.Manifest{
+				{Name: "ext1", Remote: true},
+				{Name: "local1", Path: localDir1 + "/manifest.yaml"},
+			},
+			want: []*extensions.Manifest{
+				{Name: "ext1", Remote: true},
+				{Name: "local1", Path: localDir1 + "/manifest.yaml"},
+			},
+		},
+		{
+			name: "interleaved and duplicate remote and local",
+			args: []string{
+				"boe", "gen-config", "--extension", "ext1",
+				"--local", localDir1, "--extension", "ext2", "--local", localDir2, "--extension", "ext1", "--local", localDir1,
+			},
+			manifests: []*extensions.Manifest{
+				{Name: "ext1", Remote: true},
+				{Name: "ext2", Remote: true},
+				{Name: "ext1", Remote: true},
+				{Name: "local1", Path: localDir1 + "/manifest.yaml"},
+				{Name: "local2", Path: localDir2 + "/manifest.yaml"},
+				{Name: "local1", Path: localDir1 + "/manifest.yaml"},
+			},
+			want: []*extensions.Manifest{
+				{Name: "ext1", Remote: true},
+				{Name: "local1", Path: localDir1 + "/manifest.yaml"},
+				{Name: "ext2", Remote: true},
+				{Name: "local2", Path: localDir2 + "/manifest.yaml"},
+				{Name: "ext1", Remote: true},
+				{Name: "local1", Path: localDir1 + "/manifest.yaml"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			positions, err := saveExtensionPositions(tt.args)
+			require.NoError(t, err)
+
+			sorted, err := positions.sort(tt.manifests)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, sorted)
+		})
+	}
+}

--- a/cli/cmd/genconfig.go
+++ b/cli/cmd/genconfig.go
@@ -31,56 +31,67 @@ type GenConfig struct {
 	Configs []string `name:"config" sep:"none" help:"Optional JSON config string for extensions. Applied in order to combined --extension and --local flags."`
 	OCI     OCIFlags `embed:""`
 
-	extensions []*extensions.Manifest `kong:"-"` // Internal field: loaded extension manifests
-	output     io.Writer              `kong:"-"` // Internal field for testing
+	extensionPositions extensionPositions `kong:"-"` // Internal field: tracks the original position of extensions specified via both --extension and --local flags
+	output             io.Writer          `kong:"-"` // Internal field for testing
 }
 
 //go:embed genconfig_help.md
 var genConfigHelp string
 
 // Help provides detailed help for the config command.
-func (c *GenConfig) Help() string { return genConfigHelp }
+func (g *GenConfig) Help() string { return genConfigHelp }
+
+// BeforeResolve is called by Kong before resolving the command to save the positions of extensions specified
+// via --extension and --local flags, to ensure they are considered in the expected order.
+func (g *GenConfig) BeforeResolve() error {
+	var err error
+	g.extensionPositions, err = saveExtensionPositions(os.Args)
+	return err
+}
 
 // Run executes the GenConfig command.
-func (c *GenConfig) Run(ctx context.Context, dirs *xdg.Directories) error {
-	out := c.output
+func (g *GenConfig) Run(ctx context.Context, dirs *xdg.Directories) error {
+	out := g.output
 	if out == nil {
 		out = os.Stdout
 	}
 
 	downloader := &extensions.Downloader{
-		Registry: c.OCI.Registry,
-		Username: c.OCI.Username,
-		Password: c.OCI.Password,
-		Insecure: c.OCI.Insecure,
+		Registry: g.OCI.Registry,
+		Username: g.OCI.Username,
+		Password: g.OCI.Password,
+		Insecure: g.OCI.Insecure,
 		Dirs:     dirs,
 		OS:       runtime.GOOS,
 		Arch:     runtime.GOARCH,
 	}
 
-	downloaded, err := downloadExtensions(ctx, downloader, c.Extensions)
+	downloaded, err := downloadExtensions(ctx, downloader, g.Extensions)
 	if err != nil {
 		return err
 	}
-	local, err := loadLocalManifests(dirs, c.Local, false)
+	local, err := loadLocalManifests(dirs, g.Local, false)
 	if err != nil {
 		return err
 	}
-	c.extensions = append(downloaded, local...) //nolint: gocritic
+	extensions, err := g.extensionPositions.sort(append(downloaded, local...))
+	if err != nil {
+		return err
+	}
 
 	var renderer envoy.ConfigRenderer
-	if c.Minimal {
+	if g.Minimal {
 		renderer = envoy.MinimalConfigRenderer
 	} else {
 		renderer = envoy.FullConfigRenderer
 	}
 
 	config, err := envoy.RenderConfig(envoy.ConfigGenerationParams{
-		AdminPort:    c.AdminPort,
-		ListenerPort: c.ListenPort,
+		AdminPort:    g.AdminPort,
+		ListenerPort: g.ListenPort,
 		Dirs:         dirs,
-		Extensions:   c.extensions,
-		Configs:      c.Configs,
+		Extensions:   extensions,
+		Configs:      g.Configs,
 	}, renderer)
 	if err != nil {
 		return err

--- a/cli/cmd/genconfig_test.go
+++ b/cli/cmd/genconfig_test.go
@@ -101,6 +101,14 @@ func TestGenConfig(t *testing.T) {
 				output:     &buf,
 			}
 
+			var args []string
+			var err error
+			for _, local := range tt.local {
+				args = append(args, "--local", local)
+			}
+			cmd.extensionPositions, err = saveExtensionPositions(args)
+			require.NoError(t, err)
+
 			require.NoError(t, cmd.Run(t.Context(), &xdg.Directories{DataHome: t.TempDir()}))
 
 			want, err := os.ReadFile(tt.wantFile)

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -17,6 +17,11 @@ import (
 	"github.com/tetratelabs/built-on-envoy/cli/internal/xdg"
 )
 
+// NewCLI creates a new instance of the CLI with default values.
+func NewCLI() *CLI {
+	return &CLI{}
+}
+
 // CLIName is the name of the CLI binary.
 const CLIName = "boe"
 

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -3,7 +3,6 @@
 // The full text of the Apache license is available in the LICENSE file at
 // the root of the repo.
 
-// Package cmd contains the CLI commands
 package cmd
 
 import (
@@ -12,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"os"
 	"runtime"
 	"slices"
 	"strings"
@@ -40,8 +40,9 @@ type Run struct {
 	Configs []string `name:"config" sep:"none" help:"Optional JSON config string for extensions. Applied in order to combined --extension and --local flags."`
 	OCI     OCIFlags `embed:""`
 
-	defaultLogLevel   string `kong:"-"` // Internal field: parsed defaut log level
-	componentLogLevel string `kong:"-"` // Internal field: parsed component log levels
+	extensionPositions extensionPositions `kong:"-"` // Internal field: tracks the original position of extensions specified via both --extension and --local flags
+	defaultLogLevel    string             `kong:"-"` // Internal field: parsed defaut log level
+	componentLogLevel  string             `kong:"-"` // Internal field: parsed component log levels
 }
 
 // OCIFlags holds flags for OCI registry authentication and configuration.
@@ -57,6 +58,14 @@ var runHelp string
 
 // Help provides detailed help for the run command.
 func (r *Run) Help() string { return runHelp }
+
+// BeforeResolve is called by Kong before resolving the command to save the positions of extensions specified
+// via --extension and --local flags, to ensure they are considered in the expected order.
+func (r *Run) BeforeResolve() error {
+	var err error
+	r.extensionPositions, err = saveExtensionPositions(os.Args)
+	return err
+}
 
 // BeforeApply is called by Kong before applying defaults to set computed default values.
 func (r *Run) BeforeApply() error {
@@ -98,7 +107,10 @@ func (r *Run) Run(ctx context.Context, dirs *xdg.Directories) error {
 	if err != nil {
 		return err
 	}
-	extensions := append(downloaded, local...) //nolint: gocritic
+	extensions, err := r.extensionPositions.sort(append(downloaded, local...))
+	if err != nil {
+		return err
+	}
 
 	// TODO(nacx): Find a way to eagerly get from func-e the Envoy version that will
 	// be used when r.EnvoyVersion is empty, without starting the download or run.

--- a/cli/cmd/run_test.go
+++ b/cli/cmd/run_test.go
@@ -455,7 +455,12 @@ func TestRunIncomaptibleEnvoyVersion(t *testing.T) {
 		EnvoyVersion: "1.37.0",
 		Local:        []string{"./testdata/input_lua_inline"},
 	}
-	err := r.Run(t.Context(), nil)
+
+	var err error
+	r.extensionPositions, err = saveExtensionPositions([]string{"--local", "./testdata/input_lua_inline"})
+	require.NoError(t, err)
+
+	err = r.Run(t.Context(), nil)
 	require.ErrorIs(t, err, errIncompatibleEnvoyVersion)
 }
 

--- a/cli/cmd/templates/create/Dockerfile.code.tmpl
+++ b/cli/cmd/templates/create/Dockerfile.code.tmpl
@@ -11,7 +11,7 @@
 FROM scratch
 
 # Copy all source files
-COPY . /src/
+COPY . /
 
 # Set working directory metadata
-WORKDIR /src
+WORKDIR /

--- a/cli/internal/extensions/directories.go
+++ b/cli/internal/extensions/directories.go
@@ -13,7 +13,7 @@ import (
 
 // LocalCacheManifest returns the local cache path for the manifest.yaml file of the extension based on the manifest.
 func LocalCacheManifest(dirs *xdg.Directories, manifest *Manifest) string {
-	return filepath.Join(LocalCacheExtensionDir(dirs, manifest), "src", "manifest.yaml")
+	return filepath.Join(LocalCacheExtensionDir(dirs, manifest), "manifest.yaml")
 }
 
 // LocalCacheExtensionDir returns the local cache directory for the given extension manifest.

--- a/cli/internal/extensions/directories_test.go
+++ b/cli/internal/extensions/directories_test.go
@@ -16,10 +16,10 @@ import (
 func TestLocalCacheManifest(t *testing.T) {
 	dirs := &xdg.Directories{DataHome: "/home/user/.local/share"}
 
-	require.Equal(t, "/home/user/.local/share/extensions/test/1.0.1/src/manifest.yaml",
+	require.Equal(t, "/home/user/.local/share/extensions/test/1.0.1/manifest.yaml",
 		LocalCacheManifest(dirs, &Manifest{Name: "test", Version: "1.0.1", Type: "dynamic_module"}))
 
-	require.Equal(t, "/home/user/.local/share/extensions/goplugin/test/1.0.1/src/manifest.yaml",
+	require.Equal(t, "/home/user/.local/share/extensions/goplugin/test/1.0.1/manifest.yaml",
 		LocalCacheManifest(dirs, &Manifest{Name: "test", Version: "1.0.1", Type: "composer"}))
 }
 

--- a/cli/internal/extensions/testdata/extension-with-manifest/Dockerfile
+++ b/cli/internal/extensions/testdata/extension-with-manifest/Dockerfile
@@ -5,5 +5,5 @@
 
 FROM scratch
 
-COPY ./manifest.yaml /src/manifest.yaml
+COPY ./manifest.yaml /manifest.yaml
 COPY ./libcomposer.so.txt /libcomposer.so

--- a/cli/main.go
+++ b/cli/main.go
@@ -29,7 +29,7 @@ func main() {
 		cancel()
 	}()
 
-	kongCtx := kong.Parse(&cmd.CLI{},
+	kongCtx := kong.Parse(cmd.NewCLI(),
 		kong.Name(cmd.CLIName),
 		kong.Description("Built On Envoy CLI - Discover, run, and build custom filters with zero friction"),
 		kong.UsageOnError(),

--- a/extensions/Dockerfile.lua
+++ b/extensions/Dockerfile.lua
@@ -5,7 +5,5 @@
 
 FROM scratch
 
-ARG EXTENSION_PATH
 # Copy all lua extension files from the specified path
-WORKDIR /src
-COPY . .
+COPY . /

--- a/extensions/Makefile
+++ b/extensions/Makefile
@@ -74,6 +74,5 @@ push_lua: create_builder
 		--output type=registry,oci-mediatypes=true$(registry_output) \
 		--provenance=false \
 		$(BASE_OCI_ANNOTATIONS) \
-		--build-arg EXTENSION_PATH=$(EXTENSION_PATH) \
 		--tag $(IMAGE) \
 		--file Dockerfile.lua ./$(EXTENSION_PATH)

--- a/extensions/composer/Dockerfile.code
+++ b/extensions/composer/Dockerfile.code
@@ -11,7 +11,7 @@
 FROM scratch
 
 # Copy all source files
-COPY . /src/
+COPY . /
 
 # Set working directory metadata
-WORKDIR /src
+WORKDIR /

--- a/extensions/composer/Makefile
+++ b/extensions/composer/Makefile
@@ -110,10 +110,6 @@ create_builder:
 build:
 	CGO_ENABLED=1 go build -buildmode=c-shared -tags $(COMPOSER_BUILD_TAG) -o lib$(NAME).so ./main
 
-.PHONY: test
-test:
-	go test $(GO_TEST_ARGS) ./...
-
 .PHONY: install
 install: build
 	@echo "Installing $(NAME)..."


### PR DESCRIPTION
Fixes https://github.com/tetratelabs/built-on-envoy/issues/136

It also updates how we package the `src` artifacts to put the files in the root instead of `/src`. This allows the code in the local cache to have the same structure as the extensions that may be in a local directory, where there is no `src`. This helps keep all the code consistent.