### PR TITLE
Slack link to the boe channel

### DIFF
--- a/website/src/constants.ts
+++ b/website/src/constants.ts
@@ -9,4 +9,4 @@ export const EXTENSIONS_PATH = 'extensions';
 
 export const WEBSITE = 'https://builtonenvoy.io';
 
-export const SLACK = 'https://tetr8.io/tetrate-community';
+export const SLACK = 'https://tetrate-community.slack.com/archives/C0AG8GLT41E';


### PR DESCRIPTION
Updates the Slack  link to point directly to the `#built-on-envoy` channel.