### PR TITLE
run: always build local rust dynamic module in local mode

### DIFF
--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -318,7 +318,7 @@ func loadLocalManifests(ctx context.Context, logger *slog.Logger, downloader *ex
 				fmt.Printf("→ %sBuilding %s...%s\n", internal.ANSIBold, manifest.Name, internal.ANSIReset)
 				downloader.Logger.Info("building local dynamic module extension", "name", manifest.Name, "version", manifest.Version)
 				// Build dynamic module (currently supports Rust)
-				if err := extensions.CheckOrBuildDynamicModule(downloader.Logger, downloader.Dirs, manifest, path); err != nil {
+				if err := extensions.BuildDynamicModule(downloader.Logger, downloader.Dirs, manifest, path); err != nil {
 					return nil, err
 				}
 			}

--- a/cli/internal/extensions/dynamic_module.go
+++ b/cli/internal/extensions/dynamic_module.go
@@ -34,6 +34,14 @@ func CheckOrBuildDynamicModule(logger *slog.Logger, dirs *xdg.Directories, manif
 		return nil
 	}
 
+	return BuildDynamicModule(logger, dirs, manifest, path)
+}
+
+// BuildDynamicModule builds the dynamic module from source. The source code is expected to be at the given path.
+// The built library will be saved in the local cache directory.
+func BuildDynamicModule(logger *slog.Logger, dirs *xdg.Directories, manifest *Manifest, path string) error {
+	destLib := LocalCacheExtension(dirs, manifest)
+
 	// Build the Rust project and make sure the output is in current path.
 	// #nosec G204
 	cmd := exec.Command("cargo", "build", "--release", "--target-dir", "./target")


### PR DESCRIPTION
For downloaded extensions, we check if the extension is in the cache, but for local ones we always build it (like we do for Go ones), so that the local development loop is seamless.