### PR TITLE
chore: remove unnecessary website publish workflow

### DIFF
--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -29,9 +29,6 @@ jobs:
           filters: |
             website:
               - 'website/**'
-              - 'cli/cmd/**'
-              - 'extensions/manifest.schema.json'
-              - 'extensions/**/manifest.yaml'
           predicate-quantifier: some  # Make the filters be OR-ed
           token: "" # don't use github api
     outputs:
@@ -56,14 +53,6 @@ jobs:
       - run: make -C ../cli gen 
       - run: npm ci
       - run: npm run build
-  
-  publish:
-    needs: website
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Trigger Netlify Build
-        run: curl -X POST -d '{}' ${{ secrets.NETLIFY_BUILD_HOOK }}
 
   # Aggregate all the required jobs and make it easier to customize CI required jobs
   website-checks:


### PR DESCRIPTION
Now that we're generating the extension index in the website directly, we don't need the job to force the site publish to Netlify, as changes will be naturally picked up.