### PR TITLE
upgrade SDK version to support new read body utility

### DIFF
--- a/cli/cmd/templates/create/go.mod.tmpl
+++ b/cli/cmd/templates/create/go.mod.tmpl
@@ -3,5 +3,5 @@ module {{ .Name }}
 go 1.25.7
 
 require (
-	github.com/envoyproxy/envoy/source/extensions/dynamic_modules v0.0.0-20260129014508-e8c1dc7dcbcd
+	github.com/envoyproxy/envoy/source/extensions/dynamic_modules v0.0.0-20260224023207-910d516c7b4e
 )

--- a/cli/cmd/templates/create/plugin.go.tmpl
+++ b/cli/cmd/templates/create/plugin.go.tmpl
@@ -51,6 +51,7 @@ func (f *customHttpFilter) OnResponseTrailers(trailers shared.HeaderMap) shared.
 
 // This is the factory for the HTTP filter.
 type customHttpFilterFactory struct {
+	shared.EmptyHttpFilterFactory
 	config *customHttpFilterConfig
 }
 

--- a/extensions/composer/cedar/plugin.go
+++ b/extensions/composer/cedar/plugin.go
@@ -302,6 +302,7 @@ func parsePath(fullPath string) ([]string, map[string][]string) {
 
 // cedarHttpFilterFactory creates filter instances per-request.
 type cedarHttpFilterFactory struct { //nolint:revive
+	shared.EmptyHttpFilterFactory
 	config *cedarParsedConfig
 }
 

--- a/extensions/composer/example/example.go
+++ b/extensions/composer/example/example.go
@@ -238,6 +238,7 @@ func (p *Plugin) OnResponseTrailers(trailers shared.HeaderMap) shared.TrailersSt
 
 // PluginFactory creates instances of Plugin.
 type PluginFactory struct {
+	shared.EmptyHttpFilterFactory
 	statsCollector *statsCollector
 }
 

--- a/extensions/composer/go.mod
+++ b/extensions/composer/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/cedar-policy/cedar-go v1.5.2
 	github.com/corazawaf/coraza/v3 v3.3.3
 	github.com/crewjam/saml v0.5.1
-	github.com/envoyproxy/envoy/source/extensions/dynamic_modules v0.0.0-20260129014508-e8c1dc7dcbcd
+	github.com/envoyproxy/envoy/source/extensions/dynamic_modules v0.0.0-20260224023207-910d516c7b4e
 	github.com/getkin/kin-openapi v0.133.0
 	github.com/lestrrat-go/jwx/v3 v3.0.13
 	github.com/open-policy-agent/opa v1.13.1

--- a/extensions/composer/go.sum
+++ b/extensions/composer/go.sum
@@ -40,8 +40,8 @@ github.com/dgryski/trifles v0.0.0-20230903005119-f50d829f2e54 h1:SG7nF6SRlWhcT7c
 github.com/dgryski/trifles v0.0.0-20230903005119-f50d829f2e54/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
-github.com/envoyproxy/envoy/source/extensions/dynamic_modules v0.0.0-20260129014508-e8c1dc7dcbcd h1:IQMTVU/I2HaXkUUYvHD3gtUrFAGLZm8DcH/4Z20vRQQ=
-github.com/envoyproxy/envoy/source/extensions/dynamic_modules v0.0.0-20260129014508-e8c1dc7dcbcd/go.mod h1:NpQosaDAX20s0ak0o/4b5dLOdvkbk15XqoakhSNX1Gg=
+github.com/envoyproxy/envoy/source/extensions/dynamic_modules v0.0.0-20260224023207-910d516c7b4e h1:M84EqwcPhd/F1ldEml7dLZiSdLlyoP+pt/8J+xNLPXw=
+github.com/envoyproxy/envoy/source/extensions/dynamic_modules v0.0.0-20260224023207-910d516c7b4e/go.mod h1:NpQosaDAX20s0ak0o/4b5dLOdvkbk15XqoakhSNX1Gg=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=

--- a/extensions/composer/jwe-decrypt/plugin.go
+++ b/extensions/composer/jwe-decrypt/plugin.go
@@ -95,6 +95,7 @@ func (f *jweDecryptHttpFilter) OnRequestHeaders(headers shared.HeaderMap, _ bool
 
 // This is the factory for the HTTP filter.
 type jweDecryptHttpFilterFactory struct { //nolint:revive
+	shared.EmptyHttpFilterFactory
 	config *jweDecryptConfig
 }
 

--- a/extensions/composer/opa/plugin.go
+++ b/extensions/composer/opa/plugin.go
@@ -287,6 +287,7 @@ func interpretResult(rs rego.ResultSet) (bool, policyResponse) {
 
 // opaHttpFilterFactory creates filter instances per-request.
 type opaHttpFilterFactory struct { //nolint:revive
+	shared.EmptyHttpFilterFactory
 	config *opaParsedConfig
 }
 

--- a/extensions/composer/openapi-validator/plugin.go
+++ b/extensions/composer/openapi-validator/plugin.go
@@ -283,6 +283,7 @@ func (o *openAPIValidatorHttpFilter) sendDenyResponse(validationErr error) {
 
 // openAPIValidatorHttpFilterFactory creates filter instances per-request.
 type openAPIValidatorHttpFilterFactory struct { //nolint:revive
+	shared.EmptyHttpFilterFactory
 	config *openAPIValidatorParsedConfig
 }
 

--- a/extensions/composer/saml/plugin.go
+++ b/extensions/composer/saml/plugin.go
@@ -32,6 +32,7 @@ type samlFilterConfig struct {
 
 // samlFilterFactory creates per-request filter instances.
 type samlFilterFactory struct {
+	shared.EmptyHttpFilterFactory
 	cfg *samlFilterConfig
 }
 

--- a/extensions/composer/token-exchange/plugin.go
+++ b/extensions/composer/token-exchange/plugin.go
@@ -35,6 +35,7 @@ type tokenExchangeMetrics struct {
 
 // tokenExchangeFilterFactory creates filter instances with the parsed config.
 type tokenExchangeFilterFactory struct {
+	shared.EmptyHttpFilterFactory
 	config  *tokenExchangeConfig
 	metrics *tokenExchangeMetrics
 }
@@ -70,7 +71,7 @@ func (f *tokenExchangeHttpFilterConfigFactory) Create(handle shared.HttpFilterCo
 
 	handle.Log(shared.LogLevelInfo, "token-exchange: loaded token exchange config for cluster=%s url=%s",
 		cfg.Cluster, cfg.TokenExchangeURL)
-	return &tokenExchangeFilterFactory{cfg, metrics}, nil
+	return &tokenExchangeFilterFactory{config: cfg, metrics: metrics}, nil
 }
 
 // WellKnownHttpFilterConfigFactories is used to load the plugin.

--- a/extensions/composer/waf/waf.go
+++ b/extensions/composer/waf/waf.go
@@ -20,6 +20,7 @@ import (
 )
 
 type wafPluginFactory struct {
+	shared.EmptyHttpFilterFactory
 	config coraza.WAF
 	mode   waf.WAFMode
 }


### PR DESCRIPTION
This PR upgrade the dynamic module SDK to latest version of Envoy/v1.37 which contains the utility methods to read the request/response body.