### PR TITLE
ci: remove unncessary field to simplify it

### DIFF
--- a/.github/workflows/release-extensions-dev.yaml
+++ b/.github/workflows/release-extensions-dev.yaml
@@ -56,17 +56,7 @@ jobs:
             type=$(grep "^type:" "$manifest" | sed 's/type: *//' | tr -d '\r')
             version=$(grep '^version:' "$manifest" | sed 's/[^:]*:[[:space:]]*//g' | tr -d '"' || echo "")
 
-            # Detect language
-            lang=""
-            if [ -f "$ext_dir/Cargo.toml" ]; then
-              lang="rust"
-            elif [ -f "$ext_dir/go.mod" ]; then
-              lang="go"
-            elif grep -q "^lua:" "$manifest"; then
-              lang="lua"
-            fi
-
-            echo "Extension: $ext_name (type=$type, lang=$lang, path=$ext_path)"
+            echo "Extension: $ext_name (type=$type, path=$ext_path)"
             echo "Version: $version"
 
             # Check if version matches x.y.z-dev
@@ -76,10 +66,8 @@ jobs:
               changed_extensions=$(echo "$changed_extensions" | jq -c \
                 --arg name "$ext_name" \
                 --arg type "$type" \
-                --arg lang "$lang" \
                 --arg path "$ext_path" \
-                --arg version "$version" \
-                '. + [{name: $name, type: $type, language: $lang, path: $path, version: $version}]')
+                '. + [{name: $name, type: $type, path: $path}]')
               has_changes="true"
             else
               echo "Skipping $ext_name: version '$version' does not match x.y.z-dev format"

--- a/.github/workflows/release-extensions-impl.yaml
+++ b/.github/workflows/release-extensions-impl.yaml
@@ -12,12 +12,10 @@ on:
         description: |
           JSON array of extensions to release. Each element must have the following fields:
             - name:     extension name as defined in manifest.yaml (e.g. "composer")
-            - type:     extension type as defined in manifest.yaml (e.g. "envoy.filters.http")
-            - language: detected language of the extension, one of "rust", "go", or "lua"
+            - type:     extension type as defined in manifest.yaml (e.g. "rust", "lua", "go")
             - path:     top-level directory name under extensions/ (e.g. "composer")
-            - version:  version string to release (e.g. "1.2.3" or "1.2.3-dev")
           Example:
-            [{"name":"composer","type":"go","language":"go","path":"composer","version":"1.0.0"}]
+            [{"name":"composer","type":"go","path":"composer"}]
         required: true
         type: string
 
@@ -47,25 +45,25 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Release Rust Extension
-        if: matrix.extension.language == 'rust'
+        if: matrix.extension.type == 'rust'
         env:
           EXTENSION_PATH: ${{ matrix.extension.path }}
         run: |
-          echo "Releasing Rust extension: ${{ matrix.extension.name }} (version: ${{ matrix.extension.version }})"
+          echo "Releasing Rust extension: ${{ matrix.extension.name }}"
           make -C extensions push_rust
 
       - name: Release Lua Extension
-        if: matrix.extension.language == 'lua'
+        if: matrix.extension.type == 'lua'
         env:
           EXTENSION_PATH: ${{ matrix.extension.path }}
         run: |
-          echo "Releasing Lua extension: ${{ matrix.extension.name }} (version: ${{ matrix.extension.version }})"
+          echo "Releasing Lua extension: ${{ matrix.extension.name }}"
           make -C extensions push_lua
 
       - name: Release Composer
         if: matrix.extension.name == 'composer'
         run: |
-          echo "Releasing Composer extension (version: ${{ matrix.extension.version }})"
+          echo "Releasing Composer extension"
           make -C extensions/composer push_image
 
       - name: Release Composer Lite

--- a/.github/workflows/release-extensions.yaml
+++ b/.github/workflows/release-extensions.yaml
@@ -65,18 +65,7 @@ jobs:
             old_version=$(git show HEAD~1:"$manifest" 2>/dev/null | grep '^version:' | sed 's/[^:]*:[[:space:]]*//g' | tr -d '"' || echo "")
             new_version=$(grep '^version:' "$manifest" | sed 's/[^:]*:[[:space:]]*//g' | tr -d '"' || echo "")
             
-            # Detect language
-            lang=""
-            ext_dir="extensions/$ext_path"
-            if [ -f "$ext_dir/Cargo.toml" ]; then
-              lang="rust"
-            elif [ -f "$ext_dir/go.mod" ]; then
-              lang="go"
-            elif grep -q "^lua:" "$manifest"; then
-              lang="lua"
-            fi
-            
-            echo "Extension: $ext_name (type=$type, lang=$lang, path=$ext_path)"
+            echo "Extension: $ext_name (type=$type, path=$ext_path)"
             echo "Old version: ${old_version:-<new extension>}"
             echo "New version: $new_version"
             
@@ -92,10 +81,8 @@ jobs:
               changed_extensions=$(echo "$changed_extensions" | jq -c \
                 --arg name "$ext_name" \
                 --arg type "$type" \
-                --arg lang "$lang" \
                 --arg path "$ext_path" \
-                --arg version "$new_version" \
-                '. + [{name: $name, type: $type, language: $lang, path: $path, version: $version}]')
+                '. + [{name: $name, type: $type, path: $path}]')
               has_changes="true"
             else
               echo "Skipping $ext_name: old version: ${old_version:-<none>}, new version: $new_version"


### PR DESCRIPTION
- Now the type will indicate the language and we needn't check it and add a new `language` field.
- The `version` field is also make no sense because the ci will extract the version from manifest.yaml