### PR TITLE
run: best effort to select a compatible Envoy version

### DIFF
--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -134,23 +134,29 @@ func (r *Run) Run(ctx context.Context, dirs *xdg.Directories, logger *slog.Logge
 	if err != nil {
 		return err
 	}
-	extensions, err := r.extensionPositions.sort(append(downloaded, local...))
+	extensionsToRun, err := r.extensionPositions.sort(append(downloaded, local...))
 	if err != nil {
 		return err
 	}
 
-	// TODO(nacx): Find a way to eagerly get from func-e the Envoy version that will
-	// be used when r.EnvoyVersion is empty, without starting the download or run.
-	if r.EnvoyVersion != "" {
+	// If no Envoy version is specified, check if the extensions have Envoy version constraints defined
+	// and if so, use them to determine a compatible Envoy version to run.
+	if r.EnvoyVersion == "" {
+		r.EnvoyVersion, err = extensions.ResolveMinimumCompatibleEnvoyVersion(extensionsToRun)
+		if err != nil {
+			return err
+		}
+		logger.Debug("resolved Envoy version from manifests", "envoy_version", r.EnvoyVersion)
+	} else {
 		logger.Debug("validating Envoy version compatibility for extensions", "envoy_version", r.EnvoyVersion)
-		if err = validateEnvoyCompat(r.EnvoyVersion, extensions); err != nil {
+		if err = validateEnvoyCompat(r.EnvoyVersion, extensionsToRun); err != nil {
 			return err
 		}
 	}
 
 	// Make sure all composer extensions use the same version of composer
 	logger.Debug("validating composer version compatibility for extensions")
-	if err = validateComposerCompat(extensions); err != nil {
+	if err = validateComposerCompat(extensionsToRun); err != nil {
 		return err
 	}
 
@@ -163,7 +169,7 @@ func (r *Run) Run(ctx context.Context, dirs *xdg.Directories, logger *slog.Logge
 		RunID:             r.RunID,
 		ListenPort:        r.ListenPort,
 		AdminPort:         r.AdminPort,
-		Extensions:        extensions,
+		Extensions:        extensionsToRun,
 		Configs:           r.Configs,
 		Clusters:          r.Clusters.Secure,
 		ClustersInsecure:  r.Clusters.Insecure,
@@ -178,7 +184,7 @@ func downloadExtensions(ctx context.Context, downloader *extensions.Downloader, 
 	downloaded := make([]*extensions.Manifest, 0, len(refs))
 	for _, ext := range refs {
 		name, tag := splitRef(ext)
-		fmt.Printf("→ %sFetching %s...%s\n", internal.ANSIBold, name, internal.ANSIReset)
+		_, _ = fmt.Fprintf(os.Stderr, "→ %sFetching %s...%s\n", internal.ANSIBold, name, internal.ANSIReset)
 		artifact, err := downloader.DownloadExtension(ctx, name, tag)
 		if err != nil {
 			return nil, err

--- a/cli/internal/extensions/manifest.go
+++ b/cli/internal/extensions/manifest.go
@@ -308,3 +308,49 @@ func ValidateManifest(manifest *Manifest) error {
 
 	return manifestSchema.Validate(v)
 }
+
+// HighestMinEnvoyVersion returns the highest minimum Envoy version among the given manifests.
+func HighestMinEnvoyVersion(manifests []*Manifest) string {
+	highest := "0.0.0"
+	for _, m := range manifests {
+		if m.MinEnvoyVersion != "" && semver.Compare("v"+m.MinEnvoyVersion, "v"+highest) > 0 {
+			highest = m.MinEnvoyVersion
+		}
+	}
+	if highest == "0.0.0" {
+		return ""
+	}
+	return highest
+}
+
+// LowestMaxEnvoyVersion returns the lowest maximum Envoy version among the given manifests.
+func LowestMaxEnvoyVersion(manifests []*Manifest) string {
+	lowest := "9999.9999.9999"
+	for _, m := range manifests {
+		if m.MaxEnvoyVersion != "" && semver.Compare("v"+m.MaxEnvoyVersion, "v"+lowest) < 0 {
+			lowest = m.MaxEnvoyVersion
+		}
+	}
+	if lowest == "9999.9999.9999" {
+		return ""
+	}
+	return lowest
+}
+
+// ResolveMinimumCompatibleEnvoyVersion returns the minimum Envoy version that is compatible with all given manifests.
+func ResolveMinimumCompatibleEnvoyVersion(manifests []*Manifest) (string, error) {
+	highestMin := HighestMinEnvoyVersion(manifests)
+	lowestMax := LowestMaxEnvoyVersion(manifests)
+
+	if highestMin != "" && lowestMax != "" && semver.Compare("v"+highestMin, "v"+lowestMax) > 0 {
+		return "", fmt.Errorf("no compatible Envoy version found: highest minimum %s, lowest maximum %s", highestMin, lowestMax)
+	}
+
+	if highestMin != "" {
+		return highestMin, nil
+	}
+	if lowestMax != "" {
+		return lowestMax, nil
+	}
+	return "", nil
+}

--- a/cli/internal/extensions/manifest_test.go
+++ b/cli/internal/extensions/manifest_test.go
@@ -275,6 +275,170 @@ func TestValidateParentManifest(t *testing.T) {
 	}
 }
 
+func TestHighestMinEnvoyVersion(t *testing.T) {
+	tests := []struct {
+		name      string
+		manifests []*Manifest
+		want      string
+	}{
+		{
+			name:      "empty list",
+			manifests: nil,
+			want:      "",
+		},
+		{
+			name:      "no min versions set",
+			manifests: []*Manifest{{}, {MaxEnvoyVersion: "1.30.0"}},
+			want:      "",
+		},
+		{
+			name: "single manifest with min",
+			manifests: []*Manifest{
+				{MinEnvoyVersion: "1.28.0"},
+			},
+			want: "1.28.0",
+		},
+		{
+			name: "multiple manifests - picks highest",
+			manifests: []*Manifest{
+				{MinEnvoyVersion: "1.28.0"},
+				{MinEnvoyVersion: "1.31.0"},
+				{MinEnvoyVersion: "1.31.1"},
+				{},
+				{MinEnvoyVersion: "1.29.0"},
+			},
+			want: "1.31.1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := HighestMinEnvoyVersion(tt.manifests)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestLowestMaxEnvoyVersion(t *testing.T) {
+	tests := []struct {
+		name      string
+		manifests []*Manifest
+		want      string
+	}{
+		{
+			name:      "empty list",
+			manifests: nil,
+			want:      "",
+		},
+		{
+			name:      "no max versions set",
+			manifests: []*Manifest{{}, {MinEnvoyVersion: "1.28.0"}},
+			want:      "",
+		},
+		{
+			name: "single manifest with max",
+			manifests: []*Manifest{
+				{MaxEnvoyVersion: "1.32.0"},
+			},
+			want: "1.32.0",
+		},
+		{
+			name: "multiple manifests - picks lowest",
+			manifests: []*Manifest{
+				{MaxEnvoyVersion: "1.35.0"},
+				{MaxEnvoyVersion: "1.30.0"},
+				{MaxEnvoyVersion: "1.30.1"},
+				{},
+				{MaxEnvoyVersion: "1.33.0"},
+			},
+			want: "1.30.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := LowestMaxEnvoyVersion(tt.manifests)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestResolveMinimumCompatibleEnvoyVersion(t *testing.T) {
+	tests := []struct {
+		name      string
+		manifests []*Manifest
+		want      string
+		wantErr   bool
+	}{
+		{
+			name:      "empty list",
+			manifests: nil,
+			want:      "",
+		},
+		{
+			name: "no version constraints",
+			manifests: []*Manifest{
+				{Name: "ext1"},
+				{Name: "ext2"},
+			},
+			want: "",
+		},
+		{
+			name: "only min versions - returns highest min",
+			manifests: []*Manifest{
+				{MinEnvoyVersion: "1.28.0"},
+				{MinEnvoyVersion: "1.31.0"},
+			},
+			want: "1.31.0",
+		},
+		{
+			name: "only max versions - returns lowest max",
+			manifests: []*Manifest{
+				{MaxEnvoyVersion: "1.35.0"},
+				{MaxEnvoyVersion: "1.32.0"},
+			},
+			want: "1.32.0",
+		},
+		{
+			name: "compatible range - returns highest min",
+			manifests: []*Manifest{
+				{MinEnvoyVersion: "1.28.0"},
+				{MinEnvoyVersion: "1.30.0", MaxEnvoyVersion: "1.35.0"},
+				{MaxEnvoyVersion: "1.33.0"},
+			},
+			want: "1.30.0",
+		},
+		{
+			name: "min equals max - compatible",
+			manifests: []*Manifest{
+				{MinEnvoyVersion: "1.30.0"},
+				{MaxEnvoyVersion: "1.30.0"},
+			},
+			want: "1.30.0",
+		},
+		{
+			name: "incompatible range - error",
+			manifests: []*Manifest{
+				{MinEnvoyVersion: "1.33.0"},
+				{MaxEnvoyVersion: "1.30.0"},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ResolveMinimumCompatibleEnvoyVersion(tt.manifests)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
 func TestResolveVersionsMissingParent(t *testing.T) {
 	m := &Manifest{
 		Name:   "child",

--- a/cli/internal/logging.go
+++ b/cli/internal/logging.go
@@ -3,7 +3,6 @@
 // The full text of the Apache license is available in the LICENSE file at
 // the root of the repo.
 
-// Package internal provides internal utilities for the CLI.
 package internal
 
 import "reflect"

--- a/extensions/composer/goplugin/imagefetcher/env.go
+++ b/extensions/composer/goplugin/imagefetcher/env.go
@@ -25,7 +25,7 @@ import (
 //
 // Pull secret:
 //
-//	GOPLUGIN_PULL_SECRET — path to Docker config JSON file
+//	GOPLUGIN_PULL_SECRET - path to Docker config JSON file
 func OptionFromEnv() Option {
 	opt := Option{}
 


### PR DESCRIPTION
If no Envoy version has been explicitly set, get the Envoy version constraints in all the given extensions and try to find the minimum version compatible with all extensions.