### PR TITLE
chore: fix leftover update to go 1.26.1

### DIFF
--- a/extensions/composer/Dockerfile.plugin
+++ b/extensions/composer/Dockerfile.plugin
@@ -8,7 +8,7 @@
 # Dockerfile (e.g., Dockerfile.custom) instead of editing this file.
 
 # Build the manager binary
-FROM golang:1.25.7 AS builder
+FROM golang:1.26.1 AS builder
 
 ARG EXTENSION_PATH
 


### PR DESCRIPTION
Follow-up of https://github.com/tetratelabs/built-on-envoy/pull/263