### PR TITLE
example: add per route configuraion support

### DIFF
--- a/extensions/composer/example/example.go
+++ b/extensions/composer/example/example.go
@@ -313,6 +313,13 @@ func (f *PluginConfigFactory) Create(handle shared.HttpFilterConfigHandle,
 	return &PluginFactory{statsCollector: stats}, nil
 }
 
+type emptyPerRouteConfig struct{}
+
+// CreatePerRoute creates an empty per-route config. This can be extended to parse and return route-specific configuration.
+func (f *PluginConfigFactory) CreatePerRoute(_ []byte) (any, error) {
+	return &emptyPerRouteConfig{}, nil
+}
+
 // ExtensionName is the name of the extension that will be used in the
 // `run` command to refer to this plugin.
 const ExtensionName = "example-go"

--- a/extensions/composer/example/example_test.go
+++ b/extensions/composer/example/example_test.go
@@ -121,6 +121,17 @@ func TestPluginConfigFactoryCreate(t *testing.T) {
 		assert.False(t, pf.statsCollector.hasHistogramMetric)
 		assert.False(t, pf.statsCollector.hasHistogramMetricWithTags)
 	})
+
+	t.Run("per route configuration", func(t *testing.T) {
+		factory := &PluginConfigFactory{}
+		result, err := factory.CreatePerRoute([]byte(`{}`))
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		perRouteConfig, ok := result.(*emptyPerRouteConfig)
+		require.True(t, ok)
+		assert.NotNil(t, perRouteConfig)
+	})
 }
 
 func TestPluginFactoryCreate(t *testing.T) {


### PR DESCRIPTION
- This makes it's possible to enable filter in the per route level.