### PR TITLE
cli: listener filter support

### DIFF
--- a/cli/internal/envoy/config.go
+++ b/cli/internal/envoy/config.go
@@ -69,6 +69,8 @@ type GeneratedConfigResources struct {
 	HTTPFilters []*hcmv3.HttpFilter
 	// NetworkFilters are the generated network filters to be included in the Envoy listener filter chain.
 	NetworkFilters []*listenerv3.Filter
+	// ListenerFilters are the generated listener filters to be included in the Envoy listener filter chain.
+	ListenerFilters []*listenerv3.ListenerFilter
 	// Clusters are the generated clusters to be included in the Envoy configuration.
 	Clusters []*clusterv3.Cluster
 }
@@ -128,7 +130,7 @@ func FullConfigRenderer(params *ConfigGenerationParams, gen GeneratedConfigResou
 		hostRewrite = testUpstreamHost
 	}
 
-	cfg, err := buildFullConfig(params.AdminPort, params.ListenerPort, clusterName, hostRewrite, newCluster, gen.HTTPFilters, gen.NetworkFilters, gen.Clusters)
+	cfg, err := buildFullConfig(params.AdminPort, params.ListenerPort, clusterName, hostRewrite, newCluster, gen.HTTPFilters, gen.NetworkFilters, gen.ListenerFilters, gen.Clusters)
 	if err != nil {
 		return "", fmt.Errorf("failed to build config: %w", err)
 	}
@@ -151,6 +153,10 @@ func MinimalConfigRenderer(params *ConfigGenerationParams, gen GeneratedConfigRe
 	if err != nil {
 		return "", fmt.Errorf("failed to serialize network filter configs: %w", err)
 	}
+	listenerFilterConfigs, err := protoListToAny(gen.ListenerFilters)
+	if err != nil {
+		return "", fmt.Errorf("failed to serialize listener filter configs: %w", err)
+	}
 	clusterConfigs, err := protoListToAny(gen.Clusters)
 	if err != nil {
 		return "", fmt.Errorf("failed to serialize cluster configs: %w", err)
@@ -162,6 +168,9 @@ func MinimalConfigRenderer(params *ConfigGenerationParams, gen GeneratedConfigRe
 	}
 	if len(networkFilterConfigs) > 0 {
 		payload["network_filters"] = networkFilterConfigs
+	}
+	if len(listenerFilterConfigs) > 0 {
+		payload["listener_filters"] = listenerFilterConfigs
 	}
 	if len(clusterConfigs) > 0 {
 		payload["clusters"] = clusterConfigs
@@ -178,6 +187,7 @@ func MinimalConfigRenderer(params *ConfigGenerationParams, gen GeneratedConfigRe
 func generateConfig(params *ConfigGenerationParams) (GeneratedConfigResources, error) {
 	httpFilters := make([]*hcmv3.HttpFilter, 0, len(params.Extensions))
 	networkFilters := make([]*listenerv3.Filter, 0)
+	listenerFilters := make([]*listenerv3.ListenerFilter, 0)
 	clusters := make([]*clusterv3.Cluster, 0)
 	for i, ext := range params.Extensions {
 		var config string
@@ -190,6 +200,7 @@ func generateConfig(params *ConfigGenerationParams) (GeneratedConfigResources, e
 		}
 		httpFilters = append(httpFilters, resources.HTTPFilters...)
 		networkFilters = append(networkFilters, resources.NetworkFilters...)
+		listenerFilters = append(listenerFilters, resources.ListenerFilters...)
 		clusters = append(clusters, resources.Clusters...)
 	}
 
@@ -218,9 +229,10 @@ func generateConfig(params *ConfigGenerationParams) (GeneratedConfigResources, e
 	}
 
 	return GeneratedConfigResources{
-		HTTPFilters:    httpFilters,
-		NetworkFilters: networkFilters,
-		Clusters:       clusters,
+		HTTPFilters:     httpFilters,
+		NetworkFilters:  networkFilters,
+		ListenerFilters: listenerFilters,
+		Clusters:        clusters,
 	}, nil
 }
 
@@ -267,7 +279,7 @@ func parseCluster(shortSpec string, tls bool) (*clusterv3.Cluster, error) {
 // and allows us to use the proto marshalling functions. Otherwise, we would have to create a wrapper
 // proto on our own, or marshal the config manually.
 // TODO(nacx): Is there a wrapper for `admin` and `static_resources` we could use other than Bootstrap?
-func buildFullConfig(adminPort, listenerPort uint32, testUpstreamClusterName, testUpstreamHostRewrite string, newCluster *clusterv3.Cluster, httpFilters []*hcmv3.HttpFilter, networkFilters []*listenerv3.Filter, clusters []*clusterv3.Cluster) (*bootstrapv3.Bootstrap, error) {
+func buildFullConfig(adminPort, listenerPort uint32, testUpstreamClusterName, testUpstreamHostRewrite string, newCluster *clusterv3.Cluster, httpFilters []*hcmv3.HttpFilter, networkFilters []*listenerv3.Filter, listenerFilters []*listenerv3.ListenerFilter, clusters []*clusterv3.Cluster) (*bootstrapv3.Bootstrap, error) {
 	hcm, err := buildHTTPConnectionManager(httpFilters, testUpstreamClusterName, testUpstreamHostRewrite)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build HTTP connection manager: %w", err)
@@ -302,6 +314,7 @@ func buildFullConfig(adminPort, listenerPort uint32, testUpstreamClusterName, te
 				Filters: networkFilters,
 			},
 		},
+		ListenerFilters: listenerFilters,
 	}
 
 	admin := &bootstrapv3.Admin{

--- a/cli/internal/envoy/config.go
+++ b/cli/internal/envoy/config.go
@@ -76,7 +76,7 @@ type GeneratedConfigResources struct {
 }
 
 // ConfigRenderer is a function type that renders the Envoy configuration based on the provided parameters and generated resources.
-type ConfigRenderer func(*ConfigGenerationParams, GeneratedConfigResources) (string, error)
+type ConfigRenderer func(*ConfigGenerationParams, *GeneratedConfigResources) (string, error)
 
 // RenderConfig renders the Envoy configuration with the given parameters.
 // The ouyput is a YAML string that is passed to func-e to run Envoy.
@@ -85,7 +85,7 @@ func RenderConfig(params *ConfigGenerationParams, renderer ConfigRenderer) (stri
 	if err != nil {
 		return "", fmt.Errorf("failed to generate config resources: %w", err)
 	}
-	rendered, err := renderer(params, gen)
+	rendered, err := renderer(params, &gen)
 	if err != nil {
 		return "", fmt.Errorf("failed to render config: %w", err)
 	}
@@ -94,7 +94,7 @@ func RenderConfig(params *ConfigGenerationParams, renderer ConfigRenderer) (stri
 }
 
 // FullConfigRenderer is a default ConfigRenderer that generates the full Envoy configuration with listeners, clusters, and admin interface.
-func FullConfigRenderer(params *ConfigGenerationParams, gen GeneratedConfigResources) (string, error) {
+func FullConfigRenderer(params *ConfigGenerationParams, gen *GeneratedConfigResources) (string, error) {
 	params.Logger.Info("rendering full Envoy config")
 
 	var (
@@ -142,7 +142,7 @@ func FullConfigRenderer(params *ConfigGenerationParams, gen GeneratedConfigResou
 }
 
 // MinimalConfigRenderer is a ConfigRenderer that generates a minimal Envoy configuration containing only the generated HTTP filters and clusters.
-func MinimalConfigRenderer(params *ConfigGenerationParams, gen GeneratedConfigResources) (string, error) {
+func MinimalConfigRenderer(params *ConfigGenerationParams, gen *GeneratedConfigResources) (string, error) {
 	params.Logger.Info("rendering minimal Envoy config")
 
 	httpFilterConfigs, err := protoListToAny(gen.HTTPFilters)

--- a/cli/internal/envoy/extension.go
+++ b/cli/internal/envoy/extension.go
@@ -17,8 +17,10 @@ import (
 	dymv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/dynamic_modules/v3"
 	dymhttpv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/dynamic_modules/v3"
 	luav3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/lua/v3"
+	dymlistv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/listener/dynamic_modules/v3"
 	dymnetv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/dynamic_modules/v3"
 	hcmv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	dymudpv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/udp/dynamic_modules/v3"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -46,9 +48,10 @@ type (
 
 	// ExtensionResources holds the resources created by an extension.
 	ExtensionResources struct {
-		HTTPFilters    []*hcmv3.HttpFilter
-		Clusters       []*clusterv3.Cluster
-		NetworkFilters []*listenerv3.Filter
+		HTTPFilters     []*hcmv3.HttpFilter
+		Clusters        []*clusterv3.Cluster
+		NetworkFilters  []*listenerv3.Filter
+		ListenerFilters []*listenerv3.ListenerFilter
 		// TODO(huabing): may need to add more resources
 	}
 )
@@ -160,6 +163,7 @@ func (d DynamicModuleFilterGenerator) GenerateFilterConfig(manifest *extensions.
 
 	var httpFilters []*hcmv3.HttpFilter
 	var networkFilters []*listenerv3.Filter
+	var listenerFilters []*listenerv3.ListenerFilter
 
 	switch manifest.FilterType {
 	case extensions.FilterTypeNetwork:
@@ -178,7 +182,38 @@ func (d DynamicModuleFilterGenerator) GenerateFilterConfig(manifest *extensions.
 				ConfigType: &listenerv3.Filter_TypedConfig{TypedConfig: dynamicModuleAny},
 			},
 		}
-
+	case extensions.FilterTypeListener:
+		protoConfig := &dymlistv3.DynamicModuleListenerFilter{
+			DynamicModuleConfig: moduleConfig,
+			FilterName:          manifest.Name,
+			FilterConfig:        anyConfig,
+		}
+		dynamicModuleAny, err := anypb.New(protoConfig)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal dynamic module listener filter to Any: %w", err)
+		}
+		listenerFilters = []*listenerv3.ListenerFilter{
+			{
+				Name:       manifest.Name,
+				ConfigType: &listenerv3.ListenerFilter_TypedConfig{TypedConfig: dynamicModuleAny},
+			},
+		}
+	case extensions.FilterTypeUDPListener:
+		protoConfig := &dymudpv3.DynamicModuleUdpListenerFilter{
+			DynamicModuleConfig: moduleConfig,
+			FilterName:          manifest.Name,
+			FilterConfig:        anyConfig,
+		}
+		dynamicModuleAny, err := anypb.New(protoConfig)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal dynamic module UDP listener filter to Any: %w", err)
+		}
+		listenerFilters = []*listenerv3.ListenerFilter{
+			{
+				Name:       manifest.Name,
+				ConfigType: &listenerv3.ListenerFilter_TypedConfig{TypedConfig: dynamicModuleAny},
+			},
+		}
 	default:
 		protoConfig := &dymhttpv3.DynamicModuleFilter{
 			DynamicModuleConfig: moduleConfig,
@@ -198,8 +233,9 @@ func (d DynamicModuleFilterGenerator) GenerateFilterConfig(manifest *extensions.
 	}
 
 	return &ExtensionResources{
-		HTTPFilters:    httpFilters,
-		NetworkFilters: networkFilters,
+		HTTPFilters:     httpFilters,
+		NetworkFilters:  networkFilters,
+		ListenerFilters: listenerFilters,
 	}, nil
 }
 

--- a/cli/internal/envoy/extension_test.go
+++ b/cli/internal/envoy/extension_test.go
@@ -16,8 +16,10 @@ import (
 	dymv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/dynamic_modules/v3"
 	dymhttpv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/dynamic_modules/v3"
 	luav3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/lua/v3"
+	dymlistv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/listener/dynamic_modules/v3"
 	dymnetv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/dynamic_modules/v3"
 	hcmv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	dymudpv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/udp/dynamic_modules/v3"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
@@ -280,6 +282,162 @@ func TestDynamicModuleFilterGeneratorNetwork(t *testing.T) {
 	}
 
 	checkProtos(t, wantWithConfig.NetworkFilters, got.NetworkFilters)
+}
+
+func TestDynamicModuleFilterGeneratorListener(t *testing.T) {
+	logger := internaltesting.NewTLogger(t)
+	dirs := &xdg.Directories{DataHome: t.TempDir()}
+	manifest := &extensions.Manifest{
+		Name:       "test-listener-module",
+		Type:       extensions.TypeRust,
+		FilterType: extensions.FilterTypeListener,
+		Version:    "v1.0.0",
+		Remote:     true,
+	}
+
+	// Case 1: Generate config for Listener Filter written as Rust dynamic module
+	got, err := GenerateFilterConfig(logger, manifest, dirs, "")
+	require.NoError(t, err)
+	require.Empty(t, got.HTTPFilters, "listener filter should not produce HTTP filters")
+	require.Empty(t, got.NetworkFilters, "listener filter should not produce network filters")
+
+	want := &ExtensionResources{
+		ListenerFilters: []*listenerv3.ListenerFilter{
+			{
+				Name: manifest.Name,
+				ConfigType: &listenerv3.ListenerFilter_TypedConfig{
+					TypedConfig: func() *anypb.Any {
+						dymConfig := &dymlistv3.DynamicModuleListenerFilter{
+							DynamicModuleConfig: &dymv3.DynamicModuleConfig{
+								Name:         manifest.Name,
+								LoadGlobally: false,
+							},
+							FilterName: manifest.Name,
+						}
+						cfg, anypbErr := anypb.New(dymConfig)
+						require.NoError(t, anypbErr)
+						return cfg
+					}(),
+				},
+			},
+		},
+	}
+
+	checkProtos(t, want.ListenerFilters, got.ListenerFilters)
+
+	// Case 2: Success with config for Listener Filter written as Rust dynamic module
+	configJSON := `{"key":"value","nested":{"foo":"bar"}}`
+	got, err = GenerateFilterConfig(logger, manifest, dirs, configJSON)
+	require.NoError(t, err, "GenerateFilterConfig with config failed")
+	require.Empty(t, got.HTTPFilters, "listener filter should not produce HTTP filters")
+	require.Empty(t, got.NetworkFilters, "listener filter should not produce network filters")
+
+	wantWithConfig := &ExtensionResources{
+		ListenerFilters: []*listenerv3.ListenerFilter{
+			{
+				Name: manifest.Name,
+				ConfigType: &listenerv3.ListenerFilter_TypedConfig{
+					TypedConfig: func() *anypb.Any {
+						dymConfig := &dymlistv3.DynamicModuleListenerFilter{
+							DynamicModuleConfig: &dymv3.DynamicModuleConfig{
+								Name:         manifest.Name,
+								LoadGlobally: false,
+							},
+							FilterName: manifest.Name,
+							FilterConfig: func() *anypb.Any {
+								cfg, err := anypb.New(wrapperspb.String(configJSON))
+								require.NoError(t, err, "marshal StringValue to Any failed")
+								return cfg
+							}(),
+						}
+						cfg, err := anypb.New(dymConfig)
+						require.NoError(t, err, "marshal DynamicModuleListenerFilter to Any failed")
+						return cfg
+					}(),
+				},
+			},
+		},
+	}
+
+	checkProtos(t, wantWithConfig.ListenerFilters, got.ListenerFilters)
+}
+
+func TestDynamicModuleFilterGeneratorUDPListener(t *testing.T) {
+	logger := internaltesting.NewTLogger(t)
+	dirs := &xdg.Directories{DataHome: t.TempDir()}
+	manifest := &extensions.Manifest{
+		Name:       "test-udp-listener-module",
+		Type:       extensions.TypeRust,
+		FilterType: extensions.FilterTypeUDPListener,
+		Version:    "v1.0.0",
+		Remote:     true,
+	}
+
+	// Case 1: Generate config for UDP Listener Filter written as Rust dynamic module
+	got, err := GenerateFilterConfig(logger, manifest, dirs, "")
+	require.NoError(t, err)
+	require.Empty(t, got.HTTPFilters, "UDP listener filter should not produce HTTP filters")
+	require.Empty(t, got.NetworkFilters, "UDP listener filter should not produce network filters")
+
+	want := &ExtensionResources{
+		ListenerFilters: []*listenerv3.ListenerFilter{
+			{
+				Name: manifest.Name,
+				ConfigType: &listenerv3.ListenerFilter_TypedConfig{
+					TypedConfig: func() *anypb.Any {
+						dymConfig := &dymudpv3.DynamicModuleUdpListenerFilter{
+							DynamicModuleConfig: &dymv3.DynamicModuleConfig{
+								Name:         manifest.Name,
+								LoadGlobally: false,
+							},
+							FilterName: manifest.Name,
+						}
+						cfg, anypbErr := anypb.New(dymConfig)
+						require.NoError(t, anypbErr)
+						return cfg
+					}(),
+				},
+			},
+		},
+	}
+
+	checkProtos(t, want.ListenerFilters, got.ListenerFilters)
+
+	// Case 2: Success with config for UDP Listener Filter written as Rust dynamic module
+	configJSON := `{"key":"value","nested":{"foo":"bar"}}`
+	got, err = GenerateFilterConfig(logger, manifest, dirs, configJSON)
+	require.NoError(t, err, "GenerateFilterConfig with config failed")
+	require.Empty(t, got.HTTPFilters, "UDP listener filter should not produce HTTP filters")
+	require.Empty(t, got.NetworkFilters, "UDP listener filter should not produce network filters")
+
+	wantWithConfig := &ExtensionResources{
+		ListenerFilters: []*listenerv3.ListenerFilter{
+			{
+				Name: manifest.Name,
+				ConfigType: &listenerv3.ListenerFilter_TypedConfig{
+					TypedConfig: func() *anypb.Any {
+						dymConfig := &dymudpv3.DynamicModuleUdpListenerFilter{
+							DynamicModuleConfig: &dymv3.DynamicModuleConfig{
+								Name:         manifest.Name,
+								LoadGlobally: false,
+							},
+							FilterName: manifest.Name,
+							FilterConfig: func() *anypb.Any {
+								cfg, err := anypb.New(wrapperspb.String(configJSON))
+								require.NoError(t, err, "marshal StringValue to Any failed")
+								return cfg
+							}(),
+						}
+						cfg, err := anypb.New(dymConfig)
+						require.NoError(t, err, "marshal DynamicModuleUdpListenerFilter to Any failed")
+						return cfg
+					}(),
+				},
+			},
+		},
+	}
+
+	checkProtos(t, wantWithConfig.ListenerFilters, got.ListenerFilters)
 }
 
 func TestComposerFilterGenerator(t *testing.T) {

--- a/cli/internal/extensions/manifest.go
+++ b/cli/internal/extensions/manifest.go
@@ -136,7 +136,7 @@ const (
 	FilterTypeHTTP FilterType = "http"
 	// FilterTypeNetwork represents a network filter extension.
 	FilterTypeNetwork FilterType = "network"
-	// FilterTypeListener represents a UDP listener filter extension.
+	// FilterTypeListener represents a listener filter extension.
 	FilterTypeListener FilterType = "listener"
 	// FilterTypeUDPListener represents a UDP listener filter extension.
 	FilterTypeUDPListener FilterType = "udp_listener"

--- a/cli/internal/extensions/manifest.go
+++ b/cli/internal/extensions/manifest.go
@@ -136,6 +136,8 @@ const (
 	FilterTypeHTTP FilterType = "http"
 	// FilterTypeNetwork represents a network filter extension.
 	FilterTypeNetwork FilterType = "network"
+	// FilterTypeListener represents a UDP listener filter extension.
+	FilterTypeListener FilterType = "listener"
 	// FilterTypeUDPListener represents a UDP listener filter extension.
 	FilterTypeUDPListener FilterType = "udp_listener"
 

--- a/extensions/manifest.schema.json
+++ b/extensions/manifest.schema.json
@@ -94,7 +94,9 @@
       "description": "Envoy filter type. Defaults to `http` if not specified.",
       "enum": [
         "http",
-        "network"
+        "network",
+        "listener",
+        "udp_listener"
       ],
       "default": "http"
     },

--- a/website/src/pages/docs/reference/manifest.mdx
+++ b/website/src/pages/docs/reference/manifest.mdx
@@ -140,7 +140,7 @@ Envoy filter type. Defaults to `http` if not specified.
 |---|---|
 | **Type** | `string` |
 | **Required** | No |
-| **Allowed values** | `http`, `network` |
+| **Allowed values** | `http`, `network`, `listener`, `udp_listener` |
 
 
 


### PR DESCRIPTION
Related to: https://github.com/tetratelabs/built-on-envoy/issues/375
Follow up to: https://github.com/tetratelabs/built-on-envoy/pull/368

Currently, listener filters and UDP listener filters are not supported currently. This PR adds support for registering both listener filters and UDP listener filters.

This is a preflight for https://github.com/tetratelabs/built-on-envoy/pull/366, as I want to register both a network filter and a UDP listener filter.