### PR TITLE
fix(waf): ProcessPartial buffering

### DIFF
--- a/extensions/composer/waf/waf.go
+++ b/extensions/composer/waf/waf.go
@@ -237,8 +237,7 @@ func (p *wafPlugin) OnRequestHeaders(headers shared.HeaderMap, endOfStream bool)
 }
 
 func (p *wafPlugin) OnRequestBody(body shared.BodyBuffer, endOfStream bool) shared.BodyStatus {
-	if p.txContext.IsRuleEngineOff() || (p.mode == waf.ModeResponseOnly ||
-		p.requestBodyProcessed) {
+	if p.txContext.IsRuleEngineOff() || p.mode == waf.ModeResponseOnly || p.requestBodyProcessed {
 		return shared.BodyStatusContinue
 	}
 
@@ -254,6 +253,13 @@ func (p *wafPlugin) OnRequestBody(body shared.BodyBuffer, endOfStream bool) shar
 		return shared.BodyStatusStopNoBuffer
 	}
 
+	// Check if writeRequestBody triggered internally ProcessRequestBody due to body limit reached under ProcessPartial.
+	if p.requestBodyProcessed {
+		// Body limit was reached and it has been inspected without an interruption.
+		// Stop buffering and let the rest of the body stream through.
+		return shared.BodyStatusContinue
+	}
+
 	// If endOfStream is true, process the body now.
 	if endOfStream {
 		if !p.handleRequestBody() {
@@ -262,18 +268,12 @@ func (p *wafPlugin) OnRequestBody(body shared.BodyBuffer, endOfStream bool) shar
 		return shared.BodyStatusContinue
 	}
 
-	if p.isUpgrade {
-		// In case of upgrade, we cannot buffer the body anyway.
-		return shared.BodyStatusContinue
-	}
-
 	// In other cases, buffer the body until end of stream.
 	return shared.BodyStatusStopAndBuffer
 }
 
 func (p *wafPlugin) OnRequestTrailers(_ shared.HeaderMap) shared.TrailersStatus {
-	if p.txContext.IsRuleEngineOff() || (p.mode == waf.ModeResponseOnly ||
-		p.requestBodyProcessed) {
+	if p.txContext.IsRuleEngineOff() || p.mode == waf.ModeResponseOnly || p.requestBodyProcessed {
 		return shared.TrailersStatusContinue
 	}
 
@@ -329,8 +329,7 @@ func (p *wafPlugin) OnResponseHeaders(headers shared.HeaderMap, endOfStream bool
 }
 
 func (p *wafPlugin) OnResponseBody(body shared.BodyBuffer, endOfStream bool) shared.BodyStatus {
-	if p.txContext.IsRuleEngineOff() || (p.mode == waf.ModeRequestOnly) ||
-		p.responseBodyProcessed {
+	if p.txContext.IsRuleEngineOff() || p.mode == waf.ModeRequestOnly || p.responseBodyProcessed {
 		return shared.BodyStatusContinue
 	}
 
@@ -346,6 +345,13 @@ func (p *wafPlugin) OnResponseBody(body shared.BodyBuffer, endOfStream bool) sha
 		return shared.BodyStatusStopNoBuffer
 	}
 
+	// Check if writeResponseBody triggered internally ProcessResponseBody due to body limit reached under ProcessPartial.
+	if p.responseBodyProcessed {
+		// Body limit was reached and it has been inspected without an interruption.
+		// Stop buffering and let the rest of the body stream through.
+		return shared.BodyStatusContinue
+	}
+
 	// If endOfStream is true, process the body now.
 	if endOfStream {
 		if !p.handleResponseBody() {
@@ -354,18 +360,12 @@ func (p *wafPlugin) OnResponseBody(body shared.BodyBuffer, endOfStream bool) sha
 		return shared.BodyStatusContinue
 	}
 
-	if p.isUpgrade || p.isSSE {
-		// In case of upgrade or SSE, we cannot buffer the body anyway.
-		return shared.BodyStatusContinue
-	}
-
 	// In other cases, buffer the body until end of stream.
 	return shared.BodyStatusStopAndBuffer
 }
 
 func (p *wafPlugin) OnResponseTrailers(_ shared.HeaderMap) shared.TrailersStatus {
-	if p.txContext.IsRuleEngineOff() || (p.mode == waf.ModeRequestOnly) ||
-		p.responseBodyProcessed {
+	if p.txContext.IsRuleEngineOff() || p.mode == waf.ModeRequestOnly || p.responseBodyProcessed {
 		return shared.TrailersStatusContinue
 	}
 
@@ -396,17 +396,34 @@ func (p *wafPlugin) writeRequestBody(body shared.BodyBuffer) bool {
 		return true
 	}
 	for _, chunk := range body.GetChunks() {
-		interruption, _, err := p.txContext.WriteRequestBody(chunk.ToUnsafeBytes())
+		chunkBytes := chunk.ToUnsafeBytes()
+		interruption, writtenBytes, err := p.txContext.WriteRequestBody(chunkBytes)
 		if err != nil {
 			p.handle.Log(shared.LogLevelInfo,
 				"Failed to write partial request body to WAF: %v", err.Error())
 			p.blockRequest(nil, ctypes.PhaseRequestBody, "waf_internal_error")
 			return false
 		}
-		// Write*Body triggers Process*Body if the bodylimit (Sec*BodyLimit) is reached.
+		// Write*Body triggers Process*Body when the bodylimit (Sec*BodyLimit) is reached.
 		if interruption != nil {
-			p.blockRequest(interruption, ctypes.PhaseRequestBody, "waf_request_body_overflow")
+			switch interruption.Status {
+			case 413:
+				// If SecRequestBodyLimitAction is Reject, Coraza will return an interruption with status 413 Payload Too Large
+				// when the request body limit is exceeded.
+				p.blockRequest(interruption, ctypes.PhaseRequestBody, "waf_request_body_overflow")
+			default:
+				// If SecRequestBodyLimitAction is ProcessPartial, Coraza will process the body and
+				// eventually return an interruption.
+				p.blockRequest(interruption, ctypes.PhaseRequestBody, "waf_request_body_blocked")
+			}
 			return false
+		}
+		if writtenBytes < len(chunkBytes) {
+			// writtenBytes < chunk length without an interruption means Coraza hit the body limit under ProcessPartial
+			// and ran Process*Body internally with no rule match. Mark the body as processed so
+			// the remaining data streams through without further buffering.
+			p.requestBodyProcessed = true
+			return true
 		}
 	}
 	return true
@@ -433,16 +450,33 @@ func (p *wafPlugin) writeResponseBody(body shared.BodyBuffer) bool {
 		return true
 	}
 	for _, chunk := range body.GetChunks() {
-		interruption, _, err := p.txContext.WriteResponseBody(chunk.ToUnsafeBytes())
+		chunkBytes := chunk.ToUnsafeBytes()
+		interruption, writtenBytes, err := p.txContext.WriteResponseBody(chunkBytes)
 		if err != nil {
 			p.handle.Log(shared.LogLevelInfo, "Failed to write partial response body to WAF: %v", err.Error())
 			p.blockRequest(nil, ctypes.PhaseResponseBody, "waf_internal_error")
 			return false
 		}
-		// Write*Body triggers Process*Body if the bodylimit (Sec*BodyLimit) is reached.
+		// Write*Body triggers Process*Body when the bodylimit (Sec*BodyLimit) is reached.
 		if interruption != nil {
-			p.blockRequest(interruption, ctypes.PhaseResponseBody, "waf_response_body_overflow")
+			switch interruption.Status {
+			case 500:
+				// If SecResponseBodyLimitAction is Reject, Coraza will return an interruption with status
+				// 500 Internal Server Error when the response body limit is exceeded.
+				p.blockRequest(interruption, ctypes.PhaseResponseBody, "waf_response_body_overflow")
+			default:
+				// If SecResponseBodyLimitAction is ProcessPartial, Coraza will process the body and
+				// eventually return an interruption.
+				p.blockRequest(interruption, ctypes.PhaseResponseBody, "waf_response_body_blocked")
+			}
 			return false
+		}
+		if writtenBytes < len(chunkBytes) {
+			// writtenBytes < chunk length without an interruption means Coraza hit the body limit under ProcessPartial
+			// and ran Process*Body internally with no rule match. Mark the body as processed so
+			// the remaining data streams through without further buffering.
+			p.responseBodyProcessed = true
+			return true
 		}
 	}
 	return true

--- a/extensions/composer/waf/waf_test.go
+++ b/extensions/composer/waf/waf_test.go
@@ -1627,6 +1627,224 @@ func Test_PerRouteConfigOverride(t *testing.T) {
 	})
 }
 
+// When SecRequestBodyLimitAction ProcessPartial is set, the body has to be inspected up
+// to the configured limit and then streamed without keeping buffering the entire body.
+func Test_ProcessPartialBodyLimit(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	// Same directives are shared between request body subtests.
+	// Same rule 100020 is expected to:
+	// - match and block in the first subtest where "hello" is within the 5-byte inspection window.
+	// - not match in the second subtest where "hello" is outside the inspection window, and the body is streamed after the limit is hit.
+	reqPartialDirs := []string{
+		"SecRuleEngine On",
+		"SecRequestBodyAccess On",
+		"SecRequestBodyLimit 5",
+		"SecRequestBodyLimitAction ProcessPartial",
+		`SecRule REQUEST_BODY "@contains hello" "id:100020,phase:2,deny,status:403,msg:'Matched in inspection window'"`,
+	}
+	reqHeaders := map[string][]string{
+		":authority":   {"example.com:8080"},
+		":method":      {"POST"},
+		":path":        {"/submit"},
+		"content-type": {"application/x-www-form-urlencoded"},
+	}
+
+	t.Run("request body: rule matching within inspection window blocks", func(t *testing.T) {
+		wafPluginFactory := newWAFFactory(t, ctrl, reqPartialDirs, "FULL")
+
+		pluginHandle := newPluginHandleWithoutPerRouteConfig(ctrl)
+		pluginHandle.EXPECT().IncrementCounterValue(shared.MetricID(1), uint64(1)).Return(shared.MetricsSuccess)
+		pluginHandle.EXPECT().GetAttributeString(shared.AttributeIDRequestProtocol).Return(pkg.UnsafeBufferFromString("HTTP/1.1"), true)
+		pluginHandle.EXPECT().GetAttributeString(shared.AttributeIDSourceAddress).Return(pkg.UnsafeBufferFromString("127.0.0.1:8080"), true)
+		pluginHandle.EXPECT().IncrementCounterValue(
+			shared.MetricID(2), uint64(1), "example.com", strconv.Itoa(int(ctypes.PhaseRequestBody)), "100020",
+		).Return(shared.MetricsSuccess)
+		pluginHandle.EXPECT().SetMetadata("io.builtonenvoy.waf", metadataKeyBlockRule, 100020)
+		pluginHandle.EXPECT().SetMetadata("io.builtonenvoy.waf", metadataKeyBlockPhase, int(ctypes.PhaseRequestBody))
+		pluginHandle.EXPECT().SendLocalResponse(uint32(403), nil, gomock.Any(), "waf_request_body_blocked")
+
+		wafPlugin, ok := wafPluginFactory.Create(pluginHandle).(*wafPlugin)
+		require.True(t, ok)
+
+		require.Equal(t, shared.HeadersStatusStop, wafPlugin.OnRequestHeaders(fake.NewFakeHeaderMap(reqHeaders), false))
+
+		// "hello" is in bytes 1-5, within the inspection window: 100020 matches and blocks the request.
+		bodyStatus := wafPlugin.OnRequestBody(fake.NewFakeBodyBuffer([]byte("hello world")), false)
+		assert.Equal(t, shared.BodyStatusStopNoBuffer, bodyStatus, "expected rule matching within the 5-byte inspection window to block")
+		wafPlugin.OnStreamComplete()
+	})
+
+	t.Run("request body: ProcessPartial streams after limit, rule outside window does not fire", func(t *testing.T) {
+		wafPluginFactory := newWAFFactory(t, ctrl, reqPartialDirs, "FULL")
+
+		pluginHandle := newPluginHandleWithoutPerRouteConfig(ctrl)
+		pluginHandle.EXPECT().IncrementCounterValue(shared.MetricID(1), uint64(1)).Return(shared.MetricsSuccess)
+		pluginHandle.EXPECT().GetAttributeString(shared.AttributeIDRequestProtocol).Return(pkg.UnsafeBufferFromString("HTTP/1.1"), true)
+		pluginHandle.EXPECT().GetAttributeString(shared.AttributeIDSourceAddress).Return(pkg.UnsafeBufferFromString("127.0.0.1:8080"), true)
+
+		wafPlugin, ok := wafPluginFactory.Create(pluginHandle).(*wafPlugin)
+		require.True(t, ok)
+
+		require.Equal(t, shared.HeadersStatusStop, wafPlugin.OnRequestHeaders(fake.NewFakeHeaderMap(reqHeaders), false))
+
+		// "hello" is outside the inspection window: 100020 does not match
+		bodyStatus := wafPlugin.OnRequestBody(fake.NewFakeBodyBuffer([]byte("this is a longer body. matching hello world outside of checked body limits")), false)
+		assert.Equal(t, shared.BodyStatusContinue, bodyStatus, "expected BodyStatusContinue: rule outside window does not fire, body is not kept buffering nor scanned")
+		assert.True(t, wafPlugin.requestBodyProcessed, "expected requestBodyProcessed to be true after limit hit")
+
+		// Subsequent chunks stream through because the body is already marked as processed.
+		bodyStatus = wafPlugin.OnRequestBody(fake.NewFakeBodyBuffer([]byte("more data")), false)
+		assert.Equal(t, shared.BodyStatusContinue, bodyStatus, "expected BodyStatusContinue for subsequent body after ProcessPartial")
+
+		// Trailers also short-circuit.
+		trailerStatus := wafPlugin.OnRequestTrailers(fake.NewFakeHeaderMap(map[string][]string{"grpc-status": {"0"}}))
+		assert.Equal(t, shared.TrailersStatusContinue, trailerStatus, "expected TrailersStatusContinue after ProcessPartial")
+
+		wafPlugin.OnStreamComplete()
+	})
+
+	t.Run("request body: Reject triggers 413", func(t *testing.T) {
+		wafPluginFactory := newWAFFactory(t, ctrl, []string{
+			"SecRuleEngine On",
+			"SecRequestBodyAccess On",
+			"SecRequestBodyLimit 5",
+			"SecRequestBodyLimitAction Reject",
+		}, "FULL")
+
+		pluginHandle := newPluginHandleWithoutPerRouteConfig(ctrl)
+		pluginHandle.EXPECT().IncrementCounterValue(shared.MetricID(1), uint64(1)).Return(shared.MetricsSuccess)
+		pluginHandle.EXPECT().GetAttributeString(shared.AttributeIDRequestProtocol).Return(pkg.UnsafeBufferFromString("HTTP/1.1"), true)
+		pluginHandle.EXPECT().GetAttributeString(shared.AttributeIDSourceAddress).Return(pkg.UnsafeBufferFromString("127.0.0.1:8080"), true)
+		pluginHandle.EXPECT().IncrementCounterValue(
+			shared.MetricID(2), uint64(1), "example.com", strconv.Itoa(int(ctypes.PhaseRequestBody)), gomock.Any(),
+		).Return(shared.MetricsSuccess)
+		pluginHandle.EXPECT().SetMetadata("io.builtonenvoy.waf", metadataKeyBlockRule, gomock.Any())
+		pluginHandle.EXPECT().SetMetadata("io.builtonenvoy.waf", metadataKeyBlockPhase, int(ctypes.PhaseRequestBody))
+		pluginHandle.EXPECT().SendLocalResponse(uint32(413), nil, gomock.Any(), "waf_request_body_overflow")
+
+		wafPlugin, ok := wafPluginFactory.Create(pluginHandle).(*wafPlugin)
+		require.True(t, ok)
+
+		require.Equal(t, shared.HeadersStatusStop, wafPlugin.OnRequestHeaders(fake.NewFakeHeaderMap(reqHeaders), false))
+
+		bodyStatus := wafPlugin.OnRequestBody(fake.NewFakeBodyBuffer([]byte("hello world")), false)
+		assert.Equal(t, shared.BodyStatusStopNoBuffer, bodyStatus, "expected BodyStatusStopNoBuffer when SecRequestBodyLimitAction is Reject")
+
+		wafPlugin.OnStreamComplete()
+	})
+
+	respPartialDirs := []string{
+		"SecRuleEngine On",
+		"SecResponseBodyAccess On",
+		"SecResponseBodyMimeType text/plain",
+		"SecResponseBodyLimit 5",
+		"SecResponseBodyLimitAction ProcessPartial",
+		`SecRule RESPONSE_BODY "@contains hello" "id:100030,phase:4,deny,status:403,msg:'Matched in inspection window'"`,
+	}
+	respRequestHeaders := fake.NewFakeHeaderMap(map[string][]string{
+		":authority": {"example.com:8080"},
+		":method":    {"GET"},
+		":path":      {"/"},
+	})
+	respHeaders := map[string][]string{
+		":status":      {"200"},
+		"content-type": {"text/plain"},
+	}
+
+	t.Run("response body: rule matching within inspection window blocks", func(t *testing.T) {
+		wafPluginFactory := newWAFFactory(t, ctrl, respPartialDirs, "FULL")
+
+		pluginHandle := newPluginHandleWithoutPerRouteConfig(ctrl)
+		pluginHandle.EXPECT().IncrementCounterValue(shared.MetricID(1), uint64(1)).Return(shared.MetricsSuccess)
+		pluginHandle.EXPECT().GetAttributeString(shared.AttributeIDRequestProtocol).Return(pkg.UnsafeBufferFromString("HTTP/1.1"), true)
+		pluginHandle.EXPECT().GetAttributeString(shared.AttributeIDSourceAddress).Return(pkg.UnsafeBufferFromString("127.0.0.1:8080"), true)
+		pluginHandle.EXPECT().IncrementCounterValue(
+			shared.MetricID(2), uint64(1), "example.com", strconv.Itoa(int(ctypes.PhaseResponseBody)), "100030",
+		).Return(shared.MetricsSuccess)
+		pluginHandle.EXPECT().SetMetadata("io.builtonenvoy.waf", metadataKeyBlockRule, 100030)
+		pluginHandle.EXPECT().SetMetadata("io.builtonenvoy.waf", metadataKeyBlockPhase, int(ctypes.PhaseResponseBody))
+		pluginHandle.EXPECT().SendLocalResponse(uint32(403), gomock.Any(), gomock.Any(), "waf_response_body_blocked")
+
+		wafPlugin, ok := wafPluginFactory.Create(pluginHandle).(*wafPlugin)
+		require.True(t, ok)
+
+		require.Equal(t, shared.HeadersStatusContinue, wafPlugin.OnRequestHeaders(respRequestHeaders, true))
+		pluginHandle.EXPECT().RequestHeaders().Return(respRequestHeaders)
+		require.Equal(t, shared.HeadersStatusStop, wafPlugin.OnResponseHeaders(fake.NewFakeHeaderMap(respHeaders), false))
+
+		// "hello" is in bytes 1-5, within the inspection window: 100030 matches and blocks.
+		bodyStatus := wafPlugin.OnResponseBody(fake.NewFakeBodyBuffer([]byte("hello world")), false)
+		assert.Equal(t, shared.BodyStatusStopNoBuffer, bodyStatus, "expected rule matching within the 5-byte inspection window to block")
+
+		wafPlugin.OnStreamComplete()
+	})
+
+	t.Run("response body: ProcessPartial streams after limit, rule outside window does not fire", func(t *testing.T) {
+		wafPluginFactory := newWAFFactory(t, ctrl, respPartialDirs, "FULL")
+
+		pluginHandle := newPluginHandleWithoutPerRouteConfig(ctrl)
+		pluginHandle.EXPECT().IncrementCounterValue(shared.MetricID(1), uint64(1)).Return(shared.MetricsSuccess)
+		pluginHandle.EXPECT().GetAttributeString(shared.AttributeIDRequestProtocol).Return(pkg.UnsafeBufferFromString("HTTP/1.1"), true)
+		pluginHandle.EXPECT().GetAttributeString(shared.AttributeIDSourceAddress).Return(pkg.UnsafeBufferFromString("127.0.0.1:8080"), true)
+
+		wafPlugin, ok := wafPluginFactory.Create(pluginHandle).(*wafPlugin)
+		require.True(t, ok)
+
+		require.Equal(t, shared.HeadersStatusContinue, wafPlugin.OnRequestHeaders(respRequestHeaders, true))
+		pluginHandle.EXPECT().RequestHeaders().Return(respRequestHeaders)
+		require.Equal(t, shared.HeadersStatusStop, wafPlugin.OnResponseHeaders(fake.NewFakeHeaderMap(respHeaders), false))
+
+		// "hello" is outside the inspection window: 100030 does not match.
+		bodyStatus := wafPlugin.OnResponseBody(fake.NewFakeBodyBuffer([]byte("worldhello")), false)
+		assert.Equal(t, shared.BodyStatusContinue, bodyStatus, "expected BodyStatusContinue: rule outside window does not fire, body is not kept buffering")
+		assert.True(t, wafPlugin.responseBodyProcessed, "expected responseBodyProcessed to be true after limit hit")
+
+		// Subsequent chunks stream through because the body is already marked as processed.
+		bodyStatus = wafPlugin.OnResponseBody(fake.NewFakeBodyBuffer([]byte("more data")), false)
+		assert.Equal(t, shared.BodyStatusContinue, bodyStatus, "expected BodyStatusContinue for subsequent response body after ProcessPartial")
+
+		// Trailers also short-circuit.
+		trailerStatus := wafPlugin.OnResponseTrailers(fake.NewFakeHeaderMap(map[string][]string{"grpc-status": {"0"}}))
+		assert.Equal(t, shared.TrailersStatusContinue, trailerStatus, "expected TrailersStatusContinue after ProcessPartial")
+
+		wafPlugin.OnStreamComplete()
+	})
+
+	t.Run("response body: Reject triggers 500", func(t *testing.T) {
+		wafPluginFactory := newWAFFactory(t, ctrl, []string{
+			"SecRuleEngine On",
+			"SecResponseBodyAccess On",
+			"SecResponseBodyMimeType text/plain",
+			"SecResponseBodyLimit 5",
+			"SecResponseBodyLimitAction Reject",
+		}, "FULL")
+
+		pluginHandle := newPluginHandleWithoutPerRouteConfig(ctrl)
+		pluginHandle.EXPECT().IncrementCounterValue(shared.MetricID(1), uint64(1)).Return(shared.MetricsSuccess)
+		pluginHandle.EXPECT().GetAttributeString(shared.AttributeIDRequestProtocol).Return(pkg.UnsafeBufferFromString("HTTP/1.1"), true)
+		pluginHandle.EXPECT().GetAttributeString(shared.AttributeIDSourceAddress).Return(pkg.UnsafeBufferFromString("127.0.0.1:8080"), true)
+		pluginHandle.EXPECT().IncrementCounterValue(
+			shared.MetricID(2), uint64(1), "example.com", strconv.Itoa(int(ctypes.PhaseResponseBody)), gomock.Any(),
+		).Return(shared.MetricsSuccess)
+		pluginHandle.EXPECT().SetMetadata("io.builtonenvoy.waf", metadataKeyBlockRule, gomock.Any())
+		pluginHandle.EXPECT().SetMetadata("io.builtonenvoy.waf", metadataKeyBlockPhase, int(ctypes.PhaseResponseBody))
+		pluginHandle.EXPECT().SendLocalResponse(uint32(500), gomock.Any(), gomock.Any(), "waf_response_body_overflow")
+
+		wafPlugin, ok := wafPluginFactory.Create(pluginHandle).(*wafPlugin)
+		require.True(t, ok)
+
+		require.Equal(t, shared.HeadersStatusContinue, wafPlugin.OnRequestHeaders(respRequestHeaders, true))
+		pluginHandle.EXPECT().RequestHeaders().Return(respRequestHeaders)
+		require.Equal(t, shared.HeadersStatusStop, wafPlugin.OnResponseHeaders(fake.NewFakeHeaderMap(respHeaders), false))
+
+		bodyStatus := wafPlugin.OnResponseBody(fake.NewFakeBodyBuffer([]byte("hello world")), false)
+		assert.Equal(t, shared.BodyStatusStopNoBuffer, bodyStatus, "expected BodyStatusStopNoBuffer when SecResponseBodyLimitAction is Reject")
+
+		wafPlugin.OnStreamComplete()
+	})
+}
+
 func Test_PerRouteConfigBlocksRequest(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()


### PR DESCRIPTION
When `SecRequestBodyLimitAction ProcessPartial` is configured, the WAF was still buffering the entire body instead of streaming it after the inspection limit was reached. With this PR, the connector detects when Coraza has internally processed the partial body and streams the remaining data through, without further buffering. It also improves some related metrics generation.

Mimics coraza-proxy-wasm logic: https://github.com/corazawaf/coraza-proxy-wasm/blob/main/wasmplugin/plugin.go#L395-L410