### PR TITLE
build: support Darwin extension builds

### DIFF
--- a/cli/cmd/templates/create/go/Makefile.tmpl
+++ b/cli/cmd/templates/create/go/Makefile.tmpl
@@ -98,9 +98,19 @@ build_image:
 		-t $(IMAGE)-linux-$(ARCH) \
 		-f ./Dockerfile .
 
-# For default push operation, we will also prefer to build a multi-platform image to support
-# both amd64 and arm64 architectures, and push it to the registry.
-PLATFORMS ?= linux/arm64,linux/amd64
+host_os := $(shell uname -s | tr '[:upper:]' '[:lower:]')
+# Darwin: QEMU amd64 emulation crashes on go mod download; use native only.
+ifeq ($(host_os),darwin)
+  PLATFORMS ?= linux/$(ARCH)
+else
+  PLATFORMS ?= linux/arm64,linux/amd64
+endif
+# index,manifest: annotations are only valid for multi-platform (OCI index) exports.
+ifneq (,$(findstring $(comma),$(PLATFORMS)))
+  PUSH_ANNOTATIONS := $(MULTI_OCI_ANNOTATIONS)
+else
+  PUSH_ANNOTATIONS := $(BASE_OCI_ANNOTATIONS) $(BINARY_ARTIFACT)
+endif
 .PHONY: push_image
 push_image: create_builder  ## Build and push docker image for the plugin for cross-platform support
 	@echo "Building and pushing image..."
@@ -108,7 +118,7 @@ push_image: create_builder  ## Build and push docker image for the plugin for cr
 		--builder $(BUILDER_NAME) \
 		--output type=registry,oci-mediatypes=true$(registry_output) \
 		--provenance=false \
-		$(MULTI_OCI_ANNOTATIONS) \
+		$(PUSH_ANNOTATIONS) \
 		--tag $(IMAGE) \
 		-f ./Dockerfile .
 

--- a/extensions/composer/Makefile
+++ b/extensions/composer/Makefile
@@ -64,6 +64,14 @@ else ifeq ($(ARCH),aarch64)
   ARCH := arm64
 endif
 
+# Use the host OS for normal local builds; targets may override this when the
+# output must run somewhere else.
+host_uname_s := $(shell uname -s)
+host_os := $(if $(findstring Linux,$(host_uname_s)),linux,\
+           $(if $(findstring Darwin,$(host_uname_s)),darwin,\
+           $(host_uname_s)))
+force_target_os ?= $(host_os)
+
 # Some IDEs like Goland place `.go` files in the `.idea` directory when using code templates. Using a
 # git command to find the files ensures that only relevant files are formatted and that git-ignored
 # files do not get in the way
@@ -125,9 +133,13 @@ create_builder:
 			--driver docker-container --driver-opt network=host \
 			--buildkitd-flags '--allow-insecure-entitlement network.host' --use
 
+# Cross-build through Docker only when a target overrides force_target_os.
+build_cmd_native = CGO_ENABLED=1 go build -trimpath -buildmode=c-shared $(COMPOSER_BUILD_TAG) -o lib$(NAME).so ./main
+build_cmd_cross  = docker buildx build --platform=$(force_target_os)/$(ARCH) --output type=local,dest=. --build-arg BUILD_TAG="$(COMPOSER_BUILD_TAG)" -f ./Dockerfile .
+
 .PHONY: build
 build:
-	CGO_ENABLED=1 go build -trimpath -buildmode=c-shared $(COMPOSER_BUILD_TAG) -o lib$(NAME).so ./main
+	$(if $(filter $(force_target_os),$(host_os)),$(build_cmd_native),$(build_cmd_cross))
 
 .PHONY: install
 install: build
@@ -199,6 +211,8 @@ install_plugins: ## Install all plugins locally
 		$(MAKE) -f Makefile.plugin install EXTENSION_PATH=$$dir; \
 	done
 	
+# Envoy runs in a Linux container, so the integration library must be Linux.
 .PHONY: test-integration
+test-integration: force_target_os := $(OS)
 test-integration: build
 	$(MAKE) -C integration test

--- a/extensions/composer/integration/envoy.yaml
+++ b/extensions/composer/integration/envoy.yaml
@@ -127,7 +127,7 @@ static_resources:
               - endpoint:
                   address:
                     socket_address:
-                      address: 127.0.0.1
+                      address: host.docker.internal
                       port_value: 1234
     - name: albedo
       connect_timeout: 5s
@@ -140,5 +140,5 @@ static_resources:
               - endpoint:
                   address:
                     socket_address:
-                      address: 127.0.0.1
+                      address: host.docker.internal
                       port_value: 1235

--- a/extensions/composer/integration/main_test.go
+++ b/extensions/composer/integration/main_test.go
@@ -237,6 +237,7 @@ func requireRunEnvoy(t *testing.T, integrationDir, composerLibPath string) {
 		dockerArgs := []string{
 			"run",
 			"--network", "host",
+			"--add-host", "host.docker.internal:host-gateway",
 			"-v", integrationDir + ":/integration",
 			"-v", composerDir + ":/composer:ro",
 			"-w", "/integration",


### PR DESCRIPTION
Default generated Go extension pushes to the host Linux architecture on Darwin because amd64 emulation can fail, like during `go mod download`. Single-platform pushes now use the annotation form valid for single-platform exports.

Composer integration tests now build a Linux shared object on non-Linux hosts before mounting it into the Envoy container, and use host.docker.internal for host services.

If we get Darwin working normally but I think this makes sense because envoy doesn't publish a Darwin image anyway.