### PR TITLE
test: fix flaky requireEqualError when proto errors contain U+00A0

### DIFF
--- a/cli/internal/envoy/config_test.go
+++ b/cli/internal/envoy/config_test.go
@@ -788,7 +788,11 @@ func TestRenderConfigWithNativeHTTPFiltersBeforeOverride(t *testing.T) {
 func requireEqualError(t *testing.T, err error, expected string) {
 	t.Helper()
 	require.Error(t, err)
-	require.Equal(t, expected, strings.ReplaceAll(err.Error(), "\u00a0", " "))
+	// google.golang.org/protobuf randomizes spaces in error messages between regular space and U+00A0
+	// (see internal/detrand) to discourage exact-string matching. Normalize both sides so tests that
+	// embed proto errors in their expected string aren't flaky depending on which space the runtime drew.
+	normalize := func(s string) string { return strings.ReplaceAll(s, "\u00a0", " ") }
+	require.Equal(t, normalize(expected), normalize(err.Error()))
 }
 
 func requireProtoJSON(t *testing.T, expect string, result []*hcmv3.HttpFilter) {


### PR DESCRIPTION
## Summary
- `requireEqualError` stripped U+00A0 only from the actual error, leaving NBSP in the expected string when it was built via `fmt.Sprintf("...: %v", err)` around a proto error.
- protobuf-go intentionally randomizes spaces in error messages (see `internal/detrand`) to discourage exact matching, so the helper failed intermittently in CI depending on which space the runtime drew.
- Normalize both sides.

This was observed as an intermittent failure in `TestRejectTerminalDynamicModule/dynamic_modules_with_wrong_typed_config_errors` and `TestRenderConfigWithNativeHTTPFiltersBeforeErrors/manifest_parse_error_is_wrapped` (both introduced in #397).

## Test plan
- [x] `go test ./internal/envoy/ -run 'TestRejectTerminalDynamicModule|TestRenderConfigWithNativeHTTPFiltersBeforeErrors' -count=10`
- [x] `go test ./internal/envoy/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)