### PR TITLE
cli: allow BOE to run custom Envoy binaries

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -57,7 +57,14 @@ COPY --chown=boe:boe ./out/boe-${TARGETOS}-${TARGETARCH} /boe
 COPY --chown=boe:boe ./entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
-# The healthcheck subcommand discovers Envoy's admin server and checks readiness.
+# Set BOE_RUN_ID=0 for predictable file paths in containers.
+# This creates the following directory structure:
+#   ~/.config/boe/                     - XDG config (e.g., envoy-version preference)
+#   ~/.local/share/boe/                - XDG data (downloaded Envoy binaries)
+#   ~/.local/state/boe/runs/0/         - XDG state (boe.log, envoy config)
+#   ~/.local/state/boe/envoy-runs/0/   - XDG state (Envoy stdout.log, stderr.log)
+#   /tmp/boe-0/                        - XDG runtime (uds.sock, admin-address.txt)
+ENV BOE_RUN_ID=0
 HEALTHCHECK --interval=10s --timeout=5s --start-period=5s --retries=3 \
     CMD ["/boe", "healthcheck"]
 

--- a/cli/cmd/healthcheck.go
+++ b/cli/cmd/healthcheck.go
@@ -7,11 +7,11 @@ package cmd
 
 import (
 	"context"
-	"io"
 	"log/slog"
 	"os"
 	"time"
 
+	"github.com/tetratelabs/func-e/api"
 	"github.com/tetratelabs/func-e/experimental/admin"
 )
 
@@ -20,23 +20,18 @@ type Healthcheck struct{}
 
 // Run executes the healthcheck command.
 func (h *Healthcheck) Run(ctx context.Context) error {
-	return healthcheck(ctx, io.Discard, os.Stderr)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{}))
+	// In docker, pid 1 is the boe process
+	return healthcheck(ctx, 1, logger)
 }
 
-// healthcheck performs looks up the Envoy subprocess, gets its admin port,
+// healthcheck looks up the Envoy subprocess, gets its admin port,
 // and returns no error when ready.
-func healthcheck(ctx context.Context, _, stderr io.Writer) error {
+func healthcheck(ctx context.Context, boePid int, logger *slog.Logger, opts ...api.RunOption) error {
 	// Give up to 1 second for the health check
 	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
 	defer cancel()
-
-	logger := slog.New(slog.NewTextHandler(stderr, &slog.HandlerOptions{}))
-	// In docker, pid 1 is the boe process
-	return doHealthcheck(ctx, 1, logger)
-}
-
-func doHealthcheck(ctx context.Context, boePid int, logger *slog.Logger) error {
-	if adminClient, err := admin.NewAdminClient(ctx, boePid); err != nil {
+	if adminClient, err := admin.NewAdminClient(ctx, boePid, opts...); err != nil {
 		logger.Error("Failed to find Envoy admin server", "error", err)
 		return err
 	} else if err = adminClient.IsReady(ctx); err != nil {

--- a/cli/cmd/healthcheck_test.go
+++ b/cli/cmd/healthcheck_test.go
@@ -20,6 +20,12 @@ import (
 	"github.com/tetratelabs/func-e/experimental/admin"
 )
 
+func TestHealthcheck_Run(t *testing.T) {
+	// In test, pid 1 is not boe, so there's no child with --run-id.
+	err := (&Healthcheck{}).Run(t.Context())
+	require.EqualError(t, err, "timeout waiting for Envoy process: no child with --run-id")
+}
+
 func Test_healthcheck(t *testing.T) {
 	pid := os.Getpid()
 
@@ -28,7 +34,7 @@ func Test_healthcheck(t *testing.T) {
 		logger := slog.New(slog.NewTextHandler(&buf, nil))
 		ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
 		defer cancel()
-		err := doHealthcheck(ctx, pid, logger)
+		err := healthcheck(ctx, pid, logger)
 		require.EqualError(t, err, "timeout waiting for Envoy process: no Envoy process found")
 		// Contains not Equal because there's a timestamp
 		require.Contains(t, buf.String(), "Failed to find Envoy admin server")
@@ -45,46 +51,23 @@ func Test_healthcheck(t *testing.T) {
 		// Docker. This intentionally ignores the parameter.
 		startupHook := func(ctx context.Context, _ admin.AdminClient, _ string) error {
 			logger := slog.New(slog.NewTextHandler(&log, nil))
-			healthCheckErr = doHealthcheck(ctx, pid, logger)
+			healthCheckErr = healthcheck(ctx, pid, logger)
 			// Cancel immediately to stop Envoy and complete test quickly
 			cancel()
-			return nil
+			return nil // func-e returns nil on context cancellation (clean shutdown).
 		}
 
 		// Run with minimal Envoy config
 		err := func_e.Run(ctx, []string{
 			"--config-yaml",
 			"admin: {address: {socket_address: {address: '127.0.0.1', port_value: 0}}}",
-		}, api.Out(io.Discard), api.EnvoyOut(io.Discard), api.EnvoyErr(io.Discard), admin.WithStartupHook(startupHook))
+		}, api.Out(io.Discard), api.EnvoyOut(io.Discard), api.EnvoyErr(io.Discard),
+			admin.WithStartupHook(startupHook))
 
 		// Expect nil error since Run returns nil on context cancellation (documented behavior)
 		require.NoError(t, err)
 
 		require.NoError(t, healthCheckErr)
-		require.Empty(t, log)
+		require.Empty(t, log.String())
 	})
-}
-
-func TestHealthcheck_Run(t *testing.T) {
-	tests := []struct {
-		name string
-		ctx  func(*testing.T) context.Context
-	}{
-		{
-			name: "returns error when context is canceled",
-			ctx: func(t *testing.T) context.Context {
-				t.Helper()
-				ctx, cancel := context.WithCancel(t.Context())
-				cancel()
-				return ctx
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := (&Healthcheck{}).Run(tt.ctx(t))
-			require.Error(t, err)
-		})
-	}
 }

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -17,7 +17,6 @@ import (
 	"runtime"
 	"slices"
 	"strings"
-	"time"
 
 	"github.com/tetratelabs/built-on-envoy/cli/internal"
 	"github.com/tetratelabs/built-on-envoy/cli/internal/envoy"
@@ -31,8 +30,9 @@ const defaultLogLevel = "error"
 // Run is a command to run Envoy with extensions.
 type Run struct {
 	EnvoyVersion string   `help:"Envoy version to use (e.g., 1.31.0)" env:"ENVOY_VERSION"`
+	EnvoyPath    string   `name:"envoy-path" help:"Path to a custom Envoy binary. Skips Envoy download and version selection." env:"ENVOY_PATH" type:"existingfile"`
 	LogLevel     string   `help:"Envoy component log level." default:"all:error" env:"ENVOY_LOG_LEVEL"`
-	RunID        string   `name:"run-id" env:"BOE_RUN_ID" help:"Run identifier for this invocation. Defaults to timestamp-based ID or $BOE_RUN_ID. Use '0' for Docker/Kubernetes."`
+	RunID        string   `name:"run-id" env:"BOE_RUN_ID" help:"Run identifier for this invocation. Overrides the default timestamp-based ID."`
 	ListenPort   uint32   `help:"Port for Envoy listener to accept incoming traffic." default:"10000"`
 	AdminPort    uint32   `help:"Port for Envoy admin interface." default:"9901"`
 	Extensions   []string `name:"extension" help:"Extensions to enable (in the format: \"name\" or \"name:version\")."`
@@ -51,7 +51,7 @@ type Run struct {
 	OCI                     OCIFlags     `embed:""`
 
 	extensionPositions extensionPositions `kong:"-"` // Internal field: tracks the original position of extensions specified via both --extension and --local flags
-	defaultLogLevel    string             `kong:"-"` // Internal field: parsed defaut log level
+	defaultLogLevel    string             `kong:"-"` // Internal field: parsed default log level
 	componentLogLevel  string             `kong:"-"` // Internal field: parsed component log levels
 }
 
@@ -84,15 +84,6 @@ func (r *Run) BeforeResolve() error {
 	return err
 }
 
-// BeforeApply is called by Kong before applying defaults to set computed default values.
-func (r *Run) BeforeApply() error {
-	// Set RunID default if not provided
-	if r.RunID == "" {
-		r.RunID = generateRunID(time.Now())
-	}
-	return nil
-}
-
 // Validate is called by Kong after parsing to validate the command arguments.
 func (r *Run) Validate() error {
 	var err error
@@ -102,6 +93,12 @@ func (r *Run) Validate() error {
 	}
 	if r.TestUpstreamHost != "" && r.TestUpstreamCluster != "" {
 		return fmt.Errorf("--test-upstream-host and --test-upstream-cluster are mutually exclusive")
+	}
+	if r.EnvoyPath != "" && r.EnvoyVersion != "" {
+		return fmt.Errorf("--envoy-path and --envoy-version are mutually exclusive")
+	}
+	if r.EnvoyPath != "" && r.Docker {
+		return fmt.Errorf("--envoy-path is not supported with --docker")
 	}
 	return nil
 }
@@ -116,6 +113,7 @@ func (r *Run) Run(ctx context.Context, dirs *xdg.Directories, logger *slog.Logge
 			ListenPort:      r.ListenPort,
 			AdminPort:       r.AdminPort,
 			Dirs:            dirs,
+			RunID:           r.RunID,
 			Arch:            runtime.GOARCH,
 			LocalExtensions: r.Local,
 			Pull:            r.Pull,
@@ -149,18 +147,22 @@ func (r *Run) Run(ctx context.Context, dirs *xdg.Directories, logger *slog.Logge
 		return err
 	}
 
-	// If no Envoy version is specified, check if the extensions have Envoy version constraints defined
-	// and if so, use them to determine a compatible Envoy version to run.
-	if r.EnvoyVersion == "" {
-		r.EnvoyVersion, err = extensions.ResolveMinimumCompatibleEnvoyVersion(extensionsToRun)
-		if err != nil {
-			return err
-		}
-		logger.Debug("resolved Envoy version from manifests", "envoy_version", r.EnvoyVersion)
+	if r.EnvoyPath != "" {
+		logger.Debug("using custom Envoy binary; skipping Envoy version resolution", "envoy_path", r.EnvoyPath)
 	} else {
-		logger.Debug("validating Envoy version compatibility for extensions", "envoy_version", r.EnvoyVersion)
-		if err = validateEnvoyCompat(r.EnvoyVersion, extensionsToRun); err != nil {
-			return err
+		// If no Envoy version is specified, check if the extensions have Envoy version constraints defined
+		// and if so, use them to determine a compatible Envoy version to run.
+		if r.EnvoyVersion == "" {
+			r.EnvoyVersion, err = extensions.ResolveMinimumCompatibleEnvoyVersion(extensionsToRun)
+			if err != nil {
+				return err
+			}
+			logger.Debug("resolved Envoy version from manifests", "envoy_version", r.EnvoyVersion)
+		} else {
+			logger.Debug("validating Envoy version compatibility for extensions", "envoy_version", r.EnvoyVersion)
+			if err = validateEnvoyCompat(r.EnvoyVersion, extensionsToRun); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -185,6 +187,7 @@ func (r *Run) Run(ctx context.Context, dirs *xdg.Directories, logger *slog.Logge
 	runner := &envoy.RunnerFuncE{
 		Logger:                  logger,
 		EnvoyVersion:            r.EnvoyVersion,
+		EnvoyPath:               r.EnvoyPath,
 		DefaultLogLevel:         r.defaultLogLevel,
 		ComponentLogLevel:       r.componentLogLevel,
 		Dirs:                    dirs,
@@ -282,14 +285,6 @@ func downloadExtensions(ctx context.Context, downloader *extensions.Downloader, 
 	}
 
 	return downloaded, nil
-}
-
-// generateRunID generates a unique run identifier based on the current time.
-// Defaults to the same convention as func-e: "YYYYMMDD_HHMMSS_UUU" format.
-// Last 3 digits of microseconds to allow concurrent runs.
-func generateRunID(now time.Time) string {
-	micro := now.Nanosecond() / 1000 % 1000
-	return fmt.Sprintf("%s_%03d", now.Format("20060102_150405"), micro)
 }
 
 // parseLogLevels parses a log level string in the format "component:level,component2:level".

--- a/cli/cmd/run_help.md
+++ b/cli/cmd/run_help.md
@@ -39,6 +39,15 @@ and all the files needed to execute the extension locally.
     boe run --local ~/src/built-on-envoy/extensions/composer/example
     ```
 
+Run with a custom Envoy binary. BOE uses this binary directly; it must match the local OS/arch.
+
+    ```shell
+    boe run --envoy-path ~/src/envoy/bazel-bin/source/exe/envoy-static --local ~/src/built-on-envoy/extensions/composer/example
+    ```
+
+For `boe run --docker`, the container defaults to run ID `0` (set via `ENV BOE_RUN_ID=0` in the
+Dockerfile). Override with `--run-id` or the `BOE_RUN_ID` environment variable.
+
 Run extensions with custom JSON configuration strings. Configs are applied in order to the
 combined list of `--extension` and `--local` flags. Use an empty string `''` to skip an extension:
 

--- a/cli/cmd/run_test.go
+++ b/cli/cmd/run_test.go
@@ -52,10 +52,11 @@ Flags:
 
       --envoy-version=STRING       Envoy version to use (e.g., 1.31.0)
                                    ($ENVOY_VERSION)
+      --envoy-path=STRING          Path to a custom Envoy binary. Skips Envoy
+                                   download and version selection ($ENVOY_PATH).
       --log-level="all:error"      Envoy component log level ($ENVOY_LOG_LEVEL).
-      --run-id=STRING              Run identifier for this invocation. Defaults
-                                   to timestamp-based ID or $BOE_RUN_ID. Use '0'
-                                   for Docker/Kubernetes ($BOE_RUN_ID).
+      --run-id=STRING              Run identifier for this invocation. Overrides
+                                   the default timestamp-based ID ($BOE_RUN_ID).
       --listen-port=10000          Port for Envoy listener to accept incoming
                                    traffic.
       --admin-port=9901            Port for Envoy admin interface.
@@ -114,6 +115,8 @@ Flags:
 
 func TestParseCmdRunDefaults(t *testing.T) {
 	t.Setenv("ENVOY_LOG_LEVEL", "all:error")
+	t.Setenv("BOE_RUN_DOCKER", "false")
+	t.Setenv("BOE_RUN_ID", "")
 
 	var cli struct {
 		Run Run `cmd:"" help:"Run Envoy with extensions"`
@@ -136,13 +139,61 @@ func TestParseCmdRunDefaults(t *testing.T) {
 	require.Equal(t, uint32(10000), cli.Run.ListenPort)
 	require.Equal(t, uint32(9901), cli.Run.AdminPort)
 	require.Empty(t, cli.Run.EnvoyVersion)
+	require.Empty(t, cli.Run.EnvoyPath)
 	require.Empty(t, cli.Run.Extensions)
 	require.Equal(t, extensions.DefaultOCIRegistry, cli.Run.OCI.Registry)
 	require.False(t, cli.Run.OCI.Insecure)
 
-	// Verify RunID is generated with expected format: YYYYMMDD_HHMMSS_UUU
-	require.NotEmpty(t, cli.Run.RunID)
-	require.Regexp(t, `^\d{8}_\d{6}_\d{3}$`, cli.Run.RunID)
+	require.Empty(t, cli.Run.RunID)
+}
+
+func TestParseCmdRunDockerRunID(t *testing.T) {
+	tests := []struct {
+		name          string
+		args          []string
+		envRunID      string
+		expectedRunID string
+	}{
+		{
+			name:          "empty by default",
+			args:          []string{"run", "--docker"},
+			expectedRunID: "",
+		},
+		{
+			name:          "explicit run id",
+			args:          []string{"run", "--docker", "--run-id=custom-run-id"},
+			expectedRunID: "custom-run-id",
+		},
+		{
+			name:          "environment run id",
+			args:          []string{"run", "--docker"},
+			envRunID:      "env-run-id",
+			expectedRunID: "env-run-id",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("BOE_RUN_ID", tt.envRunID)
+
+			var cli struct {
+				Run Run `cmd:"" help:"Run Envoy with extensions"`
+			}
+
+			parser, err := kong.New(&cli,
+				kong.Name("boe"),
+				kong.Exit(func(int) {}),
+				kong.BindTo(t.Context(), (*context.Context)(nil)),
+				kong.Bind(&xdg.Directories{}),
+				Vars,
+			)
+			require.NoError(t, err)
+
+			_, err = parser.Parse(tt.args)
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedRunID, cli.Run.RunID)
+		})
+	}
 }
 
 func TestParseCmdRunLogLevelEnv(t *testing.T) {
@@ -207,19 +258,52 @@ func TestParseCmdRunCustomValues(t *testing.T) {
 }
 
 func TestRunValidateMutualExclusion(t *testing.T) {
-	r := &Run{
-		LogLevel:            "all:error",
-		TestUpstreamHost:    "example.com",
-		TestUpstreamCluster: "example.com:443",
+	tests := []struct {
+		name        string
+		run         Run
+		expectedErr string
+	}{
+		{
+			name: "test upstream host and cluster",
+			run: Run{
+				LogLevel:            "all:error",
+				TestUpstreamHost:    "example.com",
+				TestUpstreamCluster: "example.com:443",
+			},
+			expectedErr: "--test-upstream-host and --test-upstream-cluster are mutually exclusive",
+		},
+		{
+			name: "envoy path and version",
+			run: Run{
+				LogLevel:     "all:error",
+				EnvoyPath:    "/usr/local/bin/envoy",
+				EnvoyVersion: "1.38.0",
+			},
+			expectedErr: "--envoy-path and --envoy-version are mutually exclusive",
+		},
+		{
+			name: "envoy path and docker",
+			run: Run{
+				LogLevel:  "all:error",
+				EnvoyPath: "/usr/local/bin/envoy",
+				Docker:    true,
+			},
+			expectedErr: "--envoy-path is not supported with --docker",
+		},
 	}
-	require.ErrorContains(t, r.Validate(), "--test-upstream-host and --test-upstream-cluster are mutually exclusive")
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.EqualError(t, tt.run.Validate(), tt.expectedErr)
+		})
+	}
 }
 
 func TestValidateLogLevel(t *testing.T) {
 	tests := []struct {
-		name      string
-		logLevel  string
-		wantError string
+		name        string
+		logLevel    string
+		expectedErr string
 	}{
 		{
 			name:     "empty log level is valid",
@@ -238,39 +322,39 @@ func TestValidateLogLevel(t *testing.T) {
 			logLevel: " all:error , upstream:trace ",
 		},
 		{
-			name:      "empty entry",
-			logLevel:  " all:error,,upstream:trace ",
-			wantError: `invalid log level format "": expected component:level`,
+			name:        "empty entry",
+			logLevel:    " all:error,,upstream:trace ",
+			expectedErr: `invalid log level format "": expected component:level`,
 		},
 		{
-			name:      "missing colon separator",
-			logLevel:  "allerror",
-			wantError: `invalid log level format "allerror": expected component:level`,
+			name:        "missing colon separator",
+			logLevel:    "allerror",
+			expectedErr: `invalid log level format "allerror": expected component:level`,
 		},
 		{
-			name:      "empty component",
-			logLevel:  ":error",
-			wantError: `invalid log level format ":error": component cannot be empty`,
+			name:        "empty component",
+			logLevel:    ":error",
+			expectedErr: `invalid log level format ":error": component cannot be empty`,
 		},
 		{
-			name:      "empty level",
-			logLevel:  "all:",
-			wantError: `invalid log level format "all:": level cannot be empty`,
+			name:        "empty level",
+			logLevel:    "all:",
+			expectedErr: `invalid log level format "all:": level cannot be empty`,
 		},
 		{
-			name:      "whitespace-only component",
-			logLevel:  " :error",
-			wantError: `invalid log level format " :error": component cannot be empty`,
+			name:        "whitespace-only component",
+			logLevel:    " :error",
+			expectedErr: `invalid log level format " :error": component cannot be empty`,
 		},
 		{
-			name:      "whitespace-only level",
-			logLevel:  "all: ",
-			wantError: `invalid log level format "all: ": level cannot be empty`,
+			name:        "whitespace-only level",
+			logLevel:    "all: ",
+			expectedErr: `invalid log level format "all: ": level cannot be empty`,
 		},
 		{
-			name:      "missing colon in multi-component string",
-			logLevel:  "all:error,badformat",
-			wantError: `invalid log level format "badformat": expected component:level`,
+			name:        "missing colon in multi-component string",
+			logLevel:    "all:error,badformat",
+			expectedErr: `invalid log level format "badformat": expected component:level`,
 		},
 	}
 
@@ -278,10 +362,10 @@ func TestValidateLogLevel(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cmd := Run{LogLevel: tt.logLevel}
 			err := cmd.Validate()
-			if tt.wantError == "" {
+			if tt.expectedErr == "" {
 				require.NoError(t, err)
 			} else {
-				require.EqualError(t, err, tt.wantError)
+				require.EqualError(t, err, tt.expectedErr)
 			}
 		})
 	}

--- a/cli/internal/envoy/config.go
+++ b/cli/internal/envoy/config.go
@@ -86,7 +86,7 @@ type GeneratedConfigResources struct {
 type ConfigRenderer func(*ConfigGenerationParams, *GeneratedConfigResources) (string, error)
 
 // RenderConfig renders the Envoy configuration with the given parameters.
-// The ouyput is a YAML string that is passed to func-e to run Envoy.
+// The output is a YAML string that is passed to func-e to run Envoy.
 func RenderConfig(params *ConfigGenerationParams, renderer ConfigRenderer) (string, error) {
 	gen, err := generateConfig(params)
 	if err != nil {

--- a/cli/internal/envoy/runner.go
+++ b/cli/internal/envoy/runner.go
@@ -39,6 +39,8 @@ type RunnerFuncE struct {
 	Logger *slog.Logger
 	// EnvoyVersion specifies the Envoy version to run. If empty, the default version is used.
 	EnvoyVersion string
+	// EnvoyPath specifies a custom Envoy binary path. If set, download and version selection are skipped.
+	EnvoyPath string
 	// DefaultLogLevel specifies the base Envoy log level.
 	DefaultLogLevel string
 	// ComponentLogLevel specifies the Envoy component log level.
@@ -96,7 +98,7 @@ func (r *RunnerFuncE) Run(ctx context.Context) error {
 		return err
 	}
 
-	// Create a temporary directory with hard links to all dynamic module libraries
+	// Create a temporary directory with symlinks to all dynamic module libraries.
 	// TODO(wbpcode): once Envoy support to specify lib path directly, we can remove this hack.
 	searchPath, cleanup, err := setupDynamicModuleSearchPath(params)
 	if err != nil {
@@ -120,20 +122,22 @@ func (r *RunnerFuncE) Run(ctx context.Context) error {
 	_, _ = fmt.Fprintf(os.Stderr, "%s✓ Starting Envoy with extensions: %v...%s\n",
 		internal.ANSIBold, names, internal.ANSIReset)
 
-	r.Logger.Info("running Envoy with func-e", "envoy_version", r.EnvoyVersion, "extensions", names)
+	if r.EnvoyPath != "" {
+		r.Logger.Info("running Envoy", "envoy_path", r.EnvoyPath, "extensions", names)
+	} else {
+		r.Logger.Info("running Envoy", "envoy_version", r.EnvoyVersion, "extensions", names)
+	}
 
-	// ext-proc servers will be started once Envoy starts. func-e assumes that the first child process
-	// is the envoy process, and starting the ext_proc servers before may cause issues.
-	var extProcCmds []*exec.Cmd
+	// ext_proc servers start before Envoy so they are ready to handle requests immediately.
+	extProcCmds, err := startExtProcServers(ctx, r.Logger, params.Extensions, r.ExtProcBinaries)
+	if err != nil {
+		return fmt.Errorf("failed to start ext_proc servers: %w", err)
+	}
 	defer stopExtProcServers(r.Logger, extProcCmds)
 
 	// Define startup hook that will be called when Envoy admin is ready
 	start := time.Now()
 	startupHook := func(_ context.Context, adminClient admin.AdminClient, _ string) error {
-		extProcCmds, err = startExtProcServers(ctx, r.Logger, params.Extensions, r.ExtProcBinaries)
-		if err != nil {
-			return fmt.Errorf("failed to start ext_proc servers: %w", err)
-		}
 		startDuration := time.Since(start).Round(100 * time.Millisecond)
 
 		_, _ = fmt.Fprintf(os.Stderr, `
@@ -158,11 +162,16 @@ Press Ctrl+C to stop
 		api.DataHome(r.Dirs.DataHome),
 		api.StateHome(r.Dirs.StateHome),
 		api.RuntimeDir(r.Dirs.RuntimeDir),
-		api.RunID(r.RunID),
 		admin.WithStartupHook(startupHook),
+	}
+	if r.RunID != "" {
+		opts = append(opts, api.RunID(r.RunID))
 	}
 	if r.EnvoyVersion != "" {
 		opts = append(opts, api.EnvoyVersion(r.EnvoyVersion))
+	}
+	if r.EnvoyPath != "" {
+		opts = append(opts, api.EnvoyPath(r.EnvoyPath))
 	}
 
 	// Run Envoy with embedded config
@@ -174,7 +183,7 @@ Press Ctrl+C to stop
 	return funce.Run(ctx, args, opts...)
 }
 
-// setupDynamicModuleSearchPath creates a temporary directory and populates it with hard links
+// setupDynamicModuleSearchPath creates a temporary directory and populates it with symlinks
 // to all dynamic module libraries (both composer and Rust dynamic modules).
 // Returns the path to the temporary directory and a cleanup function.
 func setupDynamicModuleSearchPath(params *ConfigGenerationParams) (string, func(), error) {
@@ -208,7 +217,7 @@ func setupDynamicModuleSearchPath(params *ConfigGenerationParams) (string, func(
 				return "", nil, fmt.Errorf("library not found at %s for extension %s", libPath, ext.Name)
 			}
 
-			// Create hard link in the temporary directory
+			// Create symlink in the temporary directory.
 			linkPath := filepath.Join(tempDir, filepath.Base(libPath))
 			// If the target file exists, skip linking to avoid "file exists" error.
 			if _, err := os.Stat(linkPath); err == nil {
@@ -217,7 +226,7 @@ func setupDynamicModuleSearchPath(params *ConfigGenerationParams) (string, func(
 
 			if err := os.Symlink(libPath, linkPath); err != nil {
 				cleanup()
-				return "", nil, fmt.Errorf("failed to create hard link for %s: %w", ext.Name, err)
+				return "", nil, fmt.Errorf("failed to create symlink for %s: %w", ext.Name, err)
 			}
 		}
 	}
@@ -232,14 +241,14 @@ func setupDynamicModuleSearchPath(params *ConfigGenerationParams) (string, func(
 
 			if err := os.Symlink(composerPath, linkPath); err != nil {
 				cleanup()
-				return "", nil, fmt.Errorf("failed to create hard link for libcomposer: %w", err)
+				return "", nil, fmt.Errorf("failed to create symlink for libcomposer: %w", err)
 			}
 		}
 	}
 
 	params.Logger.Debug("setting up dynamic module search path", "path", tempDir)
 
-	return tempDir, func() {}, nil
+	return tempDir, cleanup, nil
 }
 
 // extProcServerReadyTimeout is how long to wait for an ext_proc server to accept connections.
@@ -344,7 +353,7 @@ const (
 	// containerStateHome is the XDG state home inside the container.
 	containerStateHome = containerVolumeDir + "/state"
 	// containerRuntimeDir is the XDG runtime dir inside the container.
-	// This much match the one in the CLI Dockerfile
+	// This must match the one in the CLI Dockerfile.
 	containerRuntimeDir = containerVolumeDir + "/run"
 	// containerLocalExtensionsDir is the directory inside the container where local extensions are mounted.
 	containerLocalExtensionsDir = containerRuntimeDir + "/extensions"
@@ -357,6 +366,7 @@ type RunnerDocker struct {
 	ListenPort      uint32
 	AdminPort       uint32
 	Dirs            *xdg.Directories
+	RunID           string
 	Arch            string
 	LocalExtensions []string
 	Pull            string
@@ -381,23 +391,7 @@ func (r *RunnerDocker) Run(ctx context.Context) error {
 		return fmt.Errorf("failed to create Docker volume for cache: %w\nOutput: %s", err, string(output))
 	}
 
-	args := []string{
-		"run", "--rm",
-		"--pull", r.Pull,
-		"--platform", "linux/" + r.Arch,
-		"-p", fmt.Sprintf("%d:%d", r.ListenPort, r.ListenPort),
-		"-p", fmt.Sprintf("%d:%d", r.AdminPort, r.AdminPort),
-		"-v", ContainerCacheVolumeName + ":" + containerVolumeDir,
-		"-e", "BOE_CONFIG_HOME=" + containerConfigHome,
-		"-e", "BOE_DATA_HOME=" + containerDataHome,
-		"-e", "BOE_STATE_HOME=" + containerStateHome,
-		"-e", "BOE_RUNTIME_DIR=" + containerRuntimeDir,
-	}
-
-	args = append(args, localExtArgs...)                  // local extension volumes
-	args = append(args, passthroughEnvVars()...)          // passthrough BOE_ env vars
-	args = append(args, image, "/boe")                    // container image and command
-	args = append(args, r.processCommandArgs(os.Args)...) // command-line args
+	args := r.dockerRunArgs(image, localExtArgs)
 
 	fmt.Printf("→ %sRunning Envoy in Docker (%v)...%s\n", internal.ANSIBold, image, internal.ANSIReset)
 
@@ -410,6 +404,31 @@ func (r *RunnerDocker) Run(ctx context.Context) error {
 	}
 
 	return cmd.Run()
+}
+
+func (r *RunnerDocker) dockerRunArgs(image string, localExtArgs []string) []string {
+	args := []string{
+		"run", "--rm",
+		"--pull", r.Pull,
+		"--platform", "linux/" + r.Arch,
+		"-p", fmt.Sprintf("%d:%d", r.ListenPort, r.ListenPort),
+		"-p", fmt.Sprintf("%d:%d", r.AdminPort, r.AdminPort),
+		"-v", ContainerCacheVolumeName + ":" + containerVolumeDir,
+		"-e", "BOE_CONFIG_HOME=" + containerConfigHome,
+		"-e", "BOE_DATA_HOME=" + containerDataHome,
+		"-e", "BOE_STATE_HOME=" + containerStateHome,
+		"-e", "BOE_RUNTIME_DIR=" + containerRuntimeDir,
+	}
+	if r.RunID != "" {
+		args = append(args, "-e", "BOE_RUN_ID="+r.RunID)
+	}
+
+	args = append(args, localExtArgs...)                  // local extension volumes
+	args = append(args, passthroughEnvVars()...)          // passthrough BOE_ env vars
+	args = append(args, image, "/boe")                    // container image and command
+	args = append(args, r.processCommandArgs(os.Args)...) // command-line args
+
+	return args
 }
 
 // imageVersion returns the image version to use for the Docker runner. For dev versions, it returns "latest"
@@ -426,12 +445,13 @@ func passthroughEnvVars() []string {
 	var args []string
 	// Pass through BOE_ environment variables to the Docker container,
 	// so that users can set registry credentials or other configs via env vars instead of CLI flags.
-	// We don't passthrough the XDG variables as we'll mount hte host directories on a fixed location in the container.
+	// We don't passthrough the XDG variables as we'll mount the host directories on a fixed location in the container.
 	passthroughEnv := slices.DeleteFunc(os.Environ(), func(arg string) bool {
 		return strings.HasPrefix(arg, "BOE_CONFIG_HOME=") ||
 			strings.HasPrefix(arg, "BOE_DATA_HOME=") ||
 			strings.HasPrefix(arg, "BOE_STATE_HOME=") ||
-			strings.HasPrefix(arg, "BOE_RUNTIME_DIR=")
+			strings.HasPrefix(arg, "BOE_RUNTIME_DIR=") ||
+			strings.HasPrefix(arg, "BOE_RUN_ID=")
 	})
 
 	for _, e := range passthroughEnv {
@@ -445,10 +465,7 @@ func passthroughEnvVars() []string {
 
 // processLocalExtensions processes local extensions and returns Docker volume arguments and container paths.
 func (r *RunnerDocker) processLocalExtensions(localExts []string) ([]string, error) {
-	var (
-		args     []string
-		mappings = make(map[string]string)
-	)
+	var args []string
 	for _, ext := range localExts {
 		absPath, containerPath, err := localExtensionContainerPath(ext)
 		if err != nil {
@@ -458,7 +475,7 @@ func (r *RunnerDocker) processLocalExtensions(localExts []string) ([]string, err
 		args = append(args, "-v", absPath+":"+containerPath)
 	}
 
-	r.Logger.Debug("processed local extensions for Docker", "volumes", args, "mappings", mappings)
+	r.Logger.Debug("processed local extensions for Docker", "volumes", args)
 
 	return args, nil
 }

--- a/cli/internal/envoy/runner_test.go
+++ b/cli/internal/envoy/runner_test.go
@@ -41,7 +41,7 @@ func TestRunner_Run_ConfigError(t *testing.T) {
 	require.ErrorIs(t, err, ErrUnsupportedExtensionType)
 }
 
-func TestRunner_Run_ContextCanceled(t *testing.T) {
+func TestRunnerFuncE_RunID(t *testing.T) {
 	ext := &extensions.Manifest{
 		Name: "test-lua",
 		Type: extensions.TypeLua,
@@ -49,24 +49,34 @@ func TestRunner_Run_ContextCanceled(t *testing.T) {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	cancel() // Cancel immediately
+	cancel()
 
-	tmpdir := t.TempDir()
-	r := &RunnerFuncE{
-		Logger:     internaltesting.NewTLogger(t),
-		Dirs:       &xdg.Directories{DataHome: tmpdir, RuntimeDir: tmpdir},
-		Extensions: []*extensions.Manifest{ext},
-		ListenPort: 10000,
-		AdminPort:  9901,
-		RunID:      "test-run",
+	tests := []struct {
+		name  string
+		runID string
+	}{
+		{
+			name: "empty RunID lets func-e choose",
+		},
+		{
+			name:  "explicit RunID",
+			runID: "0",
+		},
 	}
 
-	err := r.Run(ctx)
-	// Expect error because context is canceled, but we care that code was executed.
-	// funce.Run typically returns error when context is canceled.
-	// We mainly want to ensure no panic and that it reached funce.Run.
-	if err != nil {
-		assert.Contains(t, err.Error(), "context canceled")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpdir := t.TempDir()
+			r := &RunnerFuncE{
+				Logger:     internaltesting.NewTLogger(t),
+				Dirs:       &xdg.Directories{DataHome: tmpdir, RuntimeDir: tmpdir, StateHome: tmpdir},
+				Extensions: []*extensions.Manifest{ext},
+				ListenPort: 10000,
+				AdminPort:  9901,
+				RunID:      tt.runID,
+			}
+			require.ErrorIs(t, r.Run(ctx), context.Canceled)
+		})
 	}
 }
 
@@ -176,6 +186,69 @@ func TestProcessCommandArgs(t *testing.T) {
 	assert.Equal(t, want, result)
 }
 
+func TestDockerRunArgs_RunID(t *testing.T) {
+	originalArgs := os.Args
+	os.Args = []string{"boe", "run", "--docker"}
+	t.Cleanup(func() { os.Args = originalArgs })
+
+	tests := []struct {
+		name     string
+		runID    string
+		expected []string
+	}{
+		{
+			name: "empty RunID leaves Dockerfile ENV intact",
+			expected: []string{
+				"run", "--rm",
+				"--pull", "missing",
+				"--platform", "linux/arm64",
+				"-p", "10000:10000",
+				"-p", "9901:9901",
+				"-v", "boe-cache:" + containerVolumeDir,
+				"-e", "BOE_CONFIG_HOME=" + containerConfigHome,
+				"-e", "BOE_DATA_HOME=" + containerDataHome,
+				"-e", "BOE_STATE_HOME=" + containerStateHome,
+				"-e", "BOE_RUNTIME_DIR=" + containerRuntimeDir,
+				"ghcr.io/test/boe:latest", "/boe",
+				"run",
+			},
+		},
+		{
+			name:  "explicit RunID overrides Dockerfile ENV",
+			runID: "custom",
+			expected: []string{
+				"run", "--rm",
+				"--pull", "missing",
+				"--platform", "linux/arm64",
+				"-p", "10000:10000",
+				"-p", "9901:9901",
+				"-v", "boe-cache:" + containerVolumeDir,
+				"-e", "BOE_CONFIG_HOME=" + containerConfigHome,
+				"-e", "BOE_DATA_HOME=" + containerDataHome,
+				"-e", "BOE_STATE_HOME=" + containerStateHome,
+				"-e", "BOE_RUNTIME_DIR=" + containerRuntimeDir,
+				"-e", "BOE_RUN_ID=custom",
+				"ghcr.io/test/boe:latest", "/boe",
+				"run",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &RunnerDocker{
+				Logger:     internaltesting.NewTLogger(t),
+				ListenPort: 10000,
+				AdminPort:  9901,
+				Arch:       "arm64",
+				Pull:       "missing",
+				RunID:      tt.runID,
+			}
+			require.Equal(t, tt.expected, r.dockerRunArgs("ghcr.io/test/boe:latest", nil))
+		})
+	}
+}
+
 func TestPassthroughEnvVars(t *testing.T) {
 	// Save and restore the original environment.
 	originalEnv := os.Environ()
@@ -205,6 +278,7 @@ func TestPassthroughEnvVars(t *testing.T) {
 				"BOE_DATA_HOME":   "/custom/data",
 				"BOE_STATE_HOME":  "/custom/state",
 				"BOE_RUNTIME_DIR": "/custom/runtime",
+				"BOE_RUN_ID":      "host-run-id",
 				"BOE_TOKEN":       "secret",
 				"HOME":            "/home/user",
 			},

--- a/cli/internal/testing/run.go
+++ b/cli/internal/testing/run.go
@@ -41,7 +41,7 @@ func RunEnvoy(t *testing.T, cliBin string, args ...string) (listenPort int, admi
 	proxyPort := defaultListenPort
 	hasLogLevel := false
 	for i, arg := range args {
-		if arg == "--listen-port" && i+1 < len(arg) {
+		if arg == "--listen-port" && i+1 < len(args) {
 			var err error
 			proxyPort, err = strconv.Atoi(args[i+1])
 			require.NoError(t, err)
@@ -83,7 +83,7 @@ func RunEnvoy(t *testing.T, cliBin string, args ...string) (listenPort int, admi
 			t.Logf("Failed to send interrupt to boe process: %v", err)
 		}
 		// Wait for the process to exit gracefully, in worst case this is
-		// killed in 3 seconds by WaitDelay conigured int he command.
+		// killed in 3 seconds by WaitDelay configured in the command.
 		// In that case, you may have a zombie Envoy process left behind!
 		if _, err := process.Wait(); err != nil {
 			t.Logf("Failed to wait for boe process to exit: %v", err)

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -89,7 +89,7 @@ require (
 	github.com/davidmz/go-pageant v1.0.2 // indirect
 	github.com/denis-tingaikin/go-header v0.5.0 // indirect
 	github.com/dlclark/regexp2 v1.11.5 // indirect
-	github.com/ebitengine/purego v0.9.1 // indirect
+	github.com/ebitengine/purego v0.10.0 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/ettle/strcase v0.2.0 // indirect
 	github.com/fatih/color v1.18.0 // indirect
@@ -240,7 +240,7 @@ require (
 	github.com/sashamelentyev/usestdlibvars v1.29.0 // indirect
 	github.com/securego/gosec/v2 v2.22.11 // indirect
 	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect
-	github.com/shirou/gopsutil/v4 v4.25.12 // indirect
+	github.com/shirou/gopsutil/v4 v4.26.3 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/sivchari/containedctx v1.0.3 // indirect
@@ -259,7 +259,7 @@ require (
 	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/subosito/gotenv v1.4.1 // indirect
 	github.com/tetafro/godot v1.5.4 // indirect
-	github.com/tetratelabs/func-e v1.4.0 // indirect
+	github.com/tetratelabs/func-e v1.5.0 // indirect
 	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect
@@ -269,7 +269,9 @@ require (
 	github.com/tklauser/numcpus v0.11.0 // indirect
 	github.com/tomarrell/wrapcheck/v2 v2.12.0 // indirect
 	github.com/tommy-muehle/go-mnd/v2 v2.5.1 // indirect
+	github.com/ulikunitz/lz v0.6.11 // indirect
 	github.com/ulikunitz/xz v0.5.15 // indirect
+	github.com/ulikunitz/xz/v2 v2.0.0-dev.4 // indirect
 	github.com/ultraware/funlen v0.2.0 // indirect
 	github.com/ultraware/whitespace v0.2.0 // indirect
 	github.com/uudashr/gocognit v1.2.0 // indirect

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -220,8 +220,8 @@ github.com/denis-tingaikin/go-header v0.5.0 h1:SRdnP5ZKvcO9KKRP1KJrhFR3RrlGuD+42
 github.com/denis-tingaikin/go-header v0.5.0/go.mod h1:mMenU5bWrok6Wl2UsZjy+1okegmwQ3UgWl4V1D8gjlY=
 github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZQ=
 github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
-github.com/ebitengine/purego v0.9.1 h1:a/k2f2HQU3Pi399RPW1MOaZyhKJL9w/xFpKAg4q1s0A=
-github.com/ebitengine/purego v0.9.1/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
+github.com/ebitengine/purego v0.10.0 h1:QIw4xfpWT6GWTzaW5XEKy3HXoqrJGx1ijYHzTF0/ISU=
+github.com/ebitengine/purego v0.10.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/elazarl/goproxy v1.7.2 h1:Y2o6urb7Eule09PjlhQRGNsqRfPmYI3KKQLFpCAV3+o=
 github.com/elazarl/goproxy v1.7.2/go.mod h1:82vkLNir0ALaW14Rc399OTTjyNREgmdL2cVoIbS6XaE=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
@@ -710,8 +710,8 @@ github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/shabbyrobe/gocovmerge v0.0.0-20190829150210-3e036491d500 h1:WnNuhiq+FOY3jNj6JXFT+eLN3CQ/oPIsDPRanvwsmbI=
 github.com/shabbyrobe/gocovmerge v0.0.0-20190829150210-3e036491d500/go.mod h1:+njLrG5wSeoG4Ds61rFgEzKvenR2UHbjMoDHsczxly0=
-github.com/shirou/gopsutil/v4 v4.25.12 h1:e7PvW/0RmJ8p8vPGJH4jvNkOyLmbkXgXW4m6ZPic6CY=
-github.com/shirou/gopsutil/v4 v4.25.12/go.mod h1:EivAfP5x2EhLp2ovdpKSozecVXn1TmuG7SMzs/Wh4PU=
+github.com/shirou/gopsutil/v4 v4.26.3 h1:2ESdQt90yU3oXF/CdOlRCJxrP+Am1aBYubTMTfxJ1qc=
+github.com/shirou/gopsutil/v4 v4.26.3/go.mod h1:LZ6ewCSkBqUpvSOf+LsTGnRinC6iaNUNMGBtDkJBaLQ=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=
@@ -766,8 +766,8 @@ github.com/tenntenn/text/transform v0.0.0-20200319021203-7eef512accb3 h1:f+jULpR
 github.com/tenntenn/text/transform v0.0.0-20200319021203-7eef512accb3/go.mod h1:ON8b8w4BN/kE1EOhwT0o+d62W65a6aPw1nouo9LMgyY=
 github.com/tetafro/godot v1.5.4 h1:u1ww+gqpRLiIA16yF2PV1CV1n/X3zhyezbNXC3E14Sg=
 github.com/tetafro/godot v1.5.4/go.mod h1:eOkMrVQurDui411nBY2FA05EYH01r14LuWY/NrVDVcU=
-github.com/tetratelabs/func-e v1.4.0 h1:eBu8RoGQIogjCNuX1lmbO8crRopvfcu7tQO82NVL+gA=
-github.com/tetratelabs/func-e v1.4.0/go.mod h1:q8/N//P0lY3hTuMKwWrfq4IXIUN5pCc2J+AsE74odxo=
+github.com/tetratelabs/func-e v1.5.0 h1:usqnwqIlLereQdua/BYLwFNfnNX7qGOFUGPihp8KMo0=
+github.com/tetratelabs/func-e v1.5.0/go.mod h1:9d/4Wne/HSg8pM+6fNhUePCsbQLeDrajn+wwbiN5WS4=
 github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
 github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
@@ -789,8 +789,12 @@ github.com/tommy-muehle/go-mnd/v2 v2.5.1 h1:NowYhSdyE/1zwK9QCLeRb6USWdoif80Ie+v+
 github.com/tommy-muehle/go-mnd/v2 v2.5.1/go.mod h1:WsUAkMJMYww6l/ufffCD3m+P7LEvr8TnZn9lwVDlgzw=
 github.com/tonglil/buflogr v1.1.1 h1:CKAjOHBSMmgbRFxpn/RhQHPj5oANc7ekhlsoUDvcZIg=
 github.com/tonglil/buflogr v1.1.1/go.mod h1:WLLtPRLqcFYWQLbA+ytXy5WrFTYnfA+beg1MpvJCxm4=
+github.com/ulikunitz/lz v0.6.11 h1:KX3Wk0shhb9X7xo0gjmjGYgqOJ22ykxVmnvt6rBaG6E=
+github.com/ulikunitz/lz v0.6.11/go.mod h1:7LLNMF+PbobzOrHHNTrUu7Tq8jKDgahkRO5lyj3gNz0=
 github.com/ulikunitz/xz v0.5.15 h1:9DNdB5s+SgV3bQ2ApL10xRc35ck0DuIX/isZvIk+ubY=
 github.com/ulikunitz/xz v0.5.15/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
+github.com/ulikunitz/xz/v2 v2.0.0-dev.4 h1:RivfGjDWpWOZj2anqNhPJ34gV1oknryMhKYfHKWIiNo=
+github.com/ulikunitz/xz/v2 v2.0.0-dev.4/go.mod h1:Yx+GXjZb1l94JZzLIuGMG8+QP9BPW3GMJUEX95iQNDM=
 github.com/ultraware/funlen v0.2.0 h1:gCHmCn+d2/1SemTdYMiKLAHFYxTYz7z9VIDRaTGyLkI=
 github.com/ultraware/funlen v0.2.0/go.mod h1:ZE0q4TsJ8T1SQcjmkhN/w+MceuatI6pBFSxxyteHIJA=
 github.com/ultraware/whitespace v0.2.0 h1:TYowo2m9Nfj1baEQBjuHzvMRbp19i+RCcRYrSWoFa+g=

--- a/website/src/pages/docs/cli/run.mdx
+++ b/website/src/pages/docs/cli/run.mdx
@@ -49,6 +49,15 @@ and all the files needed to execute the extension locally.
     boe run --local ~/src/built-on-envoy/extensions/composer/example
     ```
 
+Run with a custom Envoy binary. BOE uses this binary directly; it must match the local OS/arch.
+
+    ```shell
+    boe run --envoy-path ~/src/envoy/bazel-bin/source/exe/envoy-static --local ~/src/built-on-envoy/extensions/composer/example
+    ```
+
+For `boe run --docker`, the container defaults to run ID `0` (set via `ENV BOE_RUN_ID=0` in the
+Dockerfile). Override with `--run-id` or the `BOE_RUN_ID` environment variable.
+
 Run extensions with custom JSON configuration strings. Configs are applied in order to the
 combined list of `--extension` and `--local` flags. Use an empty string `''` to skip an extension:
 
@@ -88,8 +97,9 @@ boe run --help
 | Name | Description | Type | Default | Env Var | Required |
 |------|-------------|------|---------|-----|----------|
 | `--envoy-version` | Envoy version to use (e.g., 1.31.0) | `string` | - | `ENVOY_VERSION` | No |
+| `--envoy-path` | Path to a custom Envoy binary. Skips Envoy download and version selection. | `string` | - | `ENVOY_PATH` | No |
 | `--log-level` | Envoy component log level. | `string` | `all:error` | `ENVOY_LOG_LEVEL` | No |
-| `--run-id` | Run identifier for this invocation. Defaults to timestamp-based ID or $BOE_RUN_ID. Use '0' for Docker/Kubernetes. | `string` | - | `BOE_RUN_ID` | No |
+| `--run-id` | Run identifier for this invocation. Overrides the default timestamp-based ID. | `string` | - | `BOE_RUN_ID` | No |
 | `--listen-port` | Port for Envoy listener to accept incoming traffic. | `uint32` | `10000` | - | No |
 | `--admin-port` | Port for Envoy admin interface. | `uint32` | `9901` | - | No |
 | `--extension` | Extensions to enable (in the format: "name" or "name:version"). | `[]string` | - | - | No |

--- a/website/src/pages/docs/reference/environment-variables.mdx
+++ b/website/src/pages/docs/reference/environment-variables.mdx
@@ -19,7 +19,8 @@ List of environment variables that can be used to configure the CLI behavior.
 | `BOE_REGISTRY_USERNAME` | Username for the OCI registry. | - |
 | `BOE_RUNTIME_DIR` | Ephemeral runtime files directory. Defaults to /tmp/boe-$UID | - |
 | `BOE_RUN_DOCKER` | Run Envoy as a Docker container instead of using func-e. | `false` |
-| `BOE_RUN_ID` | Run identifier for this invocation. Defaults to timestamp-based ID or $BOE_RUN_ID. Use '0' for Docker/Kubernetes. | - |
+| `BOE_RUN_ID` | Run identifier for this invocation. Overrides the default timestamp-based ID. | - |
 | `BOE_STATE_HOME` | Persistent state and logs directory. Defaults to ~/.local/state/boe | `~/.local/state/boe` |
 | `ENVOY_LOG_LEVEL` | Envoy component log level. | `all:error` |
+| `ENVOY_PATH` | Path to a custom Envoy binary. Skips Envoy download and version selection. | - |
 | `ENVOY_VERSION` | Envoy version to use (e.g., 1.31.0) | - |


### PR DESCRIPTION
`--envoy-path` runs any local Envoy binary directly, skipping download and version selection. Useful for testing pre-release or custom-built Envoy.

ext_proc servers now start before Envoy instead of waiting for the admin hook, and `setupDynamicModuleSearchPath` returns the real cleanup function instead of a no-op.

Docker containers default to `BOE_RUN_ID=0` for predictable file paths.

Related: tetratelabs/func-e#493, tetratelabs/func-e#505.