### PR TITLE
composer: fix manifest packaging in composer extensions

### DIFF
--- a/extensions/composer/Dockerfile.plugin
+++ b/extensions/composer/Dockerfile.plugin
@@ -24,5 +24,6 @@ RUN CGO_ENABLED=1 go build -trimpath -buildmode=plugin ${BUILD_TAG} -o plugin.so
 
 FROM scratch AS final
 
+ARG EXTENSION_PATH
 COPY --from=builder /workspace/plugin.so /
 COPY --from=builder /workspace/${EXTENSION_PATH}/manifest.yaml /


### PR DESCRIPTION
The `EXTENSION_PATH` variable was not defined in the context of the `final` stage, and it was resolved to empty. This caused the COPY path to be `/workspace//manifest.yaml`, which just copied the parent `composer` manifest instead of the concrete extension one.

After this is merged, all composer `0.6.0` packages need to be regenerated.