### PR TITLE
extensions: package parent composer manifest in the extension packages

### DIFF
--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -248,7 +248,7 @@ func downloadExtensions(ctx context.Context, downloader *extensions.Downloader, 
 			// If the downloaded artifact is the composer bundle, we need to find the path to the extension
 			// inside the composer source tree.
 			if artifact.Manifest.Type == extensions.TypeComposer {
-				var manifest *extensions.Manifest
+				var manifest, composerManifest *extensions.Manifest
 				extensionSrc := extensions.LocalCacheComposerExtensionSourceDir(downloader.Dirs, artifact.Manifest, name)
 				if extensionSrc == "" {
 					return nil, fmt.Errorf("invalid source artifact for Go extension %s: missing expected source directory: %s", name, artifact.Path)
@@ -260,11 +260,15 @@ func downloadExtensions(ctx context.Context, downloader *extensions.Downloader, 
 					return nil, fmt.Errorf("failed to load manifest for composer extension %s from source artifact %q: %w",
 						name, extensionSrc, err)
 				}
+				composerManifestPath := filepath.Join(extensions.LocalCacheComposerSourceArtifactDir(downloader.Dirs, artifact.Manifest), "manifest.yaml")
+				composerManifest, err = extensions.LoadLocalManifest(composerManifestPath)
+				if err != nil {
+					return nil, fmt.Errorf("failed to load composer parent manifest for composer extension %s from source artifact %q: %w",
+						name, extensionSrc, err)
+				}
+
+				extensions.ResolveVersionsWithParent(manifest, composerManifest)
 				manifest.Remote = true // Mark the manifest as remote since it is from a downloaded artifact
-				// Composer source artifacts contains manifests without version information (just the parent reference).
-				// We need to set the versions here.
-				manifest.Version = artifact.Manifest.Version
-				manifest.ComposerVersion = artifact.Manifest.ComposerVersion
 
 				if build {
 					fmt.Printf("→ %sBuilding %s...%s\n", internal.ANSIBold, name, internal.ANSIReset)

--- a/cli/cmd/run_test.go
+++ b/cli/cmd/run_test.go
@@ -846,6 +846,42 @@ func TestDownloadExtensions(t *testing.T) {
 		require.Contains(t, err.Error(), "unknown artifact type")
 	})
 
+	t.Run("source Go extension", func(t *testing.T) {
+		composerVersion := "0.1.0"
+		composer := &extensions.Manifest{Name: "composer", Version: composerVersion, Type: extensions.TypeComposer}
+		dirs := &xdg.Directories{DataHome: t.TempDir()}
+
+		// Precreate the manifests to simulate a successful download
+		composerDir := extensions.LocalCacheComposerSourceArtifactDir(dirs, composer)
+		childDir := filepath.Join(composerDir, "composer-child")
+		require.NoError(t, os.MkdirAll(childDir, 0o750))
+
+		composerManifest, err := os.ReadFile("testdata/composer_test.yaml")
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Join(composerDir, "manifest.yaml"), composerManifest, 0o600))
+
+		childManifest, err := os.ReadFile("testdata/composer_child.yaml")
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Join(childDir, "manifest.yaml"), childManifest, 0o600))
+
+		mock := &mockOCIClient{
+			annotations: map[string]string{
+				ocispec.AnnotationTitle:                 "composer",
+				extensions.OCIAnnotationExtensionType:   string(extensions.TypeComposer),
+				extensions.OCIAnnotationArtifact:        extensions.ArtifactSource,
+				extensions.OCIAnnotationComposerVersion: composerVersion,
+			},
+		}
+		d := newTestDownloader(t, dirs.DataHome, mock)
+
+		exts, err := downloadExtensions(t.Context(), d, []string{"composer-child:" + composerVersion}, false)
+		require.NoError(t, err)
+		require.Len(t, exts, 1)
+		require.Equal(t, "Test Author", exts[0].Author)
+		require.Equal(t, "1.38.0", exts[0].MinEnvoyVersion)
+		require.Equal(t, "1.39.0", exts[0].MaxEnvoyVersion) // This is computed when loading based on the min version
+	})
+
 	t.Run("source Go extension with missing source dir", func(t *testing.T) {
 		mock := &mockOCIClient{
 			annotations: map[string]string{

--- a/cli/cmd/testdata/composer_child.yaml
+++ b/cli/cmd/testdata/composer_child.yaml
@@ -1,0 +1,18 @@
+# Copyright Built On Envoy
+# SPDX-License-Identifier: Apache-2.0
+# The full text of the Apache license is available in the LICENSE file at
+# the root of the repo.
+
+name: composer-child
+parent: composer
+categories:
+  - Security
+author: Test Author
+description: A child extension that inherits parent version
+longDescription: |
+  This is a child extension.
+type: go
+tags:
+  - test
+license: Apache-2.0
+examples: []

--- a/cli/cmd/testdata/composer_test.yaml
+++ b/cli/cmd/testdata/composer_test.yaml
@@ -1,0 +1,21 @@
+# Copyright Built On Envoy
+# SPDX-License-Identifier: Apache-2.0
+# The full text of the Apache license is available in the LICENSE file at
+# the root of the repo.
+
+name: composer
+version: 1.0.0
+composerVersion: 1.0.0
+minEnvoyVersion: 1.38.0
+categories:
+  - Misc
+author: Tetrate
+description: Composer parent test extension
+longDescription: |
+  This is a longer description of the test extension.
+type: composer
+tags:
+  - test
+license: Apache-2.0
+examples: []
+extensionSet: true

--- a/cli/internal/extensions/downloader.go
+++ b/cli/internal/extensions/downloader.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"strings"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -97,6 +98,19 @@ func (d *Downloader) DownloadExtension(ctx context.Context, name, version string
 				return DownloadedExtension{},
 					fmt.Errorf("failed to load manifest from downloaded extension at %q: %w", manifestPath, err)
 			}
+
+			// Composer plugin extension packages contain the extension manifest and the parent composer manifest as well.
+			// If it exists, load it and resolve the versions
+			composerParent := filepath.Join(LocalCacheExtensionDir(d.Dirs, artifact.Manifest), "manifest-composer.yaml")
+			if _, err = os.Stat(composerParent); err == nil {
+				p, err := LoadLocalManifest(composerParent)
+				if err != nil {
+					return DownloadedExtension{},
+						fmt.Errorf("failed to load parent manifest from downloaded extension at %q: %w", composerParent, err)
+				}
+				ResolveVersionsWithParent(m, p)
+			}
+
 			mergeManifestFromOCI(m, fromOCI)
 			artifact.Manifest = m
 		}

--- a/cli/internal/extensions/downloader_test.go
+++ b/cli/internal/extensions/downloader_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"testing"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -338,6 +339,68 @@ func TestCheckOrDownloadLibComposerCacheHit(t *testing.T) {
 	}
 
 	require.NoError(t, CheckOrDownloadLibComposer(t.Context(), d, version, ComposerArtifactLite))
+}
+
+func TestDownloadComposerExtensionLoadsParentManifest(t *testing.T) {
+	dirs := &xdg.Directories{DataHome: t.TempDir()}
+	m := &Manifest{Name: "parent-valid", Version: "1.0.0", Type: TypeGo}
+
+	cacheDir := LocalCacheExtensionDir(dirs, m)
+	cachedManifestPath := filepath.Join(cacheDir, "manifest.yaml")
+	cachedManifest, err := os.ReadFile("testdata/parent_valid.yaml")
+	require.NoError(t, err)
+
+	// Create the files as if they were downloaded:
+	// - mock extension binary
+	// - manifest.yaml file as packaged by the old composer individual extensions
+	require.NoError(t, os.MkdirAll(cacheDir, 0o750))
+	require.NoError(t, os.WriteFile(cachedManifestPath, cachedManifest, 0o600))
+	require.NoError(t, os.WriteFile(LocalCacheExtension(dirs, m), []byte("cached"), 0o600))
+
+	d := &Downloader{
+		Logger:                internaltesting.NewTLogger(t),
+		Registry:              "ghcr.io/test",
+		Dirs:                  dirs,
+		OS:                    "linux",
+		Arch:                  "arm64",
+		DisableSourceFallback: true,
+		newClient: func(_ *slog.Logger, _, _, _ string, _ bool) (oci.RepositoryClient, error) {
+			return &mockRepositoryClient{
+				manifestAnnotations: map[string]string{
+					ocispec.AnnotationTitle:      "parent-valid",
+					ocispec.AnnotationVersion:    "1.0.0",
+					OCIAnnotationExtensionType:   string(TypeGo),
+					OCIAnnotationComposerVersion: "1.0.0",
+				},
+			}, nil
+		},
+	}
+
+	// backward-compatible behaviour for old individual composer extension packages.
+	// the information of the manifest should be loaded without loading any further
+	// information from any parent
+	t.Run("no parent manifest", func(t *testing.T) {
+		ext, err := d.DownloadExtension(t.Context(), "parent-valid", "1.0.0")
+		require.NoError(t, err)
+		require.Equal(t, "Test Author", ext.Manifest.Author)
+		require.Empty(t, ext.Manifest.MinEnvoyVersion)
+		require.Empty(t, ext.Manifest.MaxEnvoyVersion)
+	})
+
+	// The information from the parent manifest should be loaded
+	t.Run("with parent manifest", func(t *testing.T) {
+		// Create the parent manifest in the download location
+		parentManifest, err := os.ReadFile("testdata/composer_test.yaml")
+		require.NoError(t, err)
+		parentManifestPath := filepath.Join(cacheDir, "manifest-composer.yaml")
+		require.NoError(t, os.WriteFile(parentManifestPath, parentManifest, 0o600))
+
+		ext, err := d.DownloadExtension(t.Context(), "parent-valid", "1.0.0")
+		require.NoError(t, err)
+		require.Equal(t, "Test Author", ext.Manifest.Author)
+		require.Equal(t, "1.38.0", ext.Manifest.MinEnvoyVersion)
+		require.Equal(t, "1.39.0", ext.Manifest.MaxEnvoyVersion) // This is computed when loading based on the min version
+	})
 }
 
 func TestCheckOrDownloadLibComposerCacheMiss(t *testing.T) {

--- a/cli/internal/extensions/manifest.go
+++ b/cli/internal/extensions/manifest.go
@@ -331,23 +331,28 @@ func resolveVersions(m *Manifest, all map[string]*Manifest) error {
 		if !ok {
 			return fmt.Errorf("%w: %s", ErrParentManifestNotFound, m.Parent)
 		}
-		if m.Version == "" {
-			m.Version = parent.Version
-		}
-		if m.ComposerVersion == "" {
-			m.ComposerVersion = parent.Version
-		}
-		if m.MinEnvoyVersion == "" {
-			m.MinEnvoyVersion = parent.MinEnvoyVersion
-		}
-		if m.MaxEnvoyVersion == "" {
-			m.MaxEnvoyVersion = parent.MaxEnvoyVersion
-		}
-		if m.MinEnvoyVersion != "" && m.MaxEnvoyVersion == "" {
-			m.MaxEnvoyVersion = ImplicitMaxEnvoyVersion(m.MinEnvoyVersion)
-		}
+		ResolveVersionsWithParent(m, parent)
 	}
 	return nil
+}
+
+// ResolveVersionsWithParent resolves the version fields for a manifest using its parent manifest.
+func ResolveVersionsWithParent(m *Manifest, parent *Manifest) {
+	if m.Version == "" {
+		m.Version = parent.Version
+	}
+	if m.ComposerVersion == "" {
+		m.ComposerVersion = parent.Version
+	}
+	if m.MinEnvoyVersion == "" {
+		m.MinEnvoyVersion = parent.MinEnvoyVersion
+	}
+	if m.MaxEnvoyVersion == "" {
+		m.MaxEnvoyVersion = parent.MaxEnvoyVersion
+	}
+	if m.MinEnvoyVersion != "" && m.MaxEnvoyVersion == "" {
+		m.MaxEnvoyVersion = ImplicitMaxEnvoyVersion(m.MinEnvoyVersion)
+	}
 }
 
 // ManifestsIndex returns a list of manifests that should be included in the catalog.
@@ -390,7 +395,8 @@ func ResolveLocalVersions(m *Manifest) error {
 	// Try to find the parent manifest on the local filesystem.
 	parent, err := findLocalParentManifest(m)
 	if err == nil {
-		return resolveVersions(m, map[string]*Manifest{parent.Name: parent})
+		ResolveVersionsWithParent(m, parent)
+		return nil
 	}
 
 	// Fall back to the embedded manifests.

--- a/cli/internal/extensions/manifest_test.go
+++ b/cli/internal/extensions/manifest_test.go
@@ -638,6 +638,7 @@ examples: []
 		assert.Equal(t, "9.9.9", m.Version)
 		assert.Equal(t, "9.9.9", m.ComposerVersion)
 		assert.Equal(t, "1.99.0", m.MinEnvoyVersion)
+		assert.Equal(t, "1.100.0", m.MaxEnvoyVersion) // Automatically computed when loading the manifest
 	})
 
 	t.Run("no-local-parent-falls-back-to-embedded", func(t *testing.T) {

--- a/cli/internal/extensions/testdata/composer_test.yaml
+++ b/cli/internal/extensions/testdata/composer_test.yaml
@@ -1,0 +1,21 @@
+# Copyright Built On Envoy
+# SPDX-License-Identifier: Apache-2.0
+# The full text of the Apache license is available in the LICENSE file at
+# the root of the repo.
+
+name: composer
+version: 1.0.0
+composerVersion: 1.0.0
+minEnvoyVersion: 1.38.0
+categories:
+  - Misc
+author: Tetrate
+description: Composer parent test extension
+longDescription: |
+  This is a longer description of the test extension.
+type: composer
+tags:
+  - test
+license: Apache-2.0
+examples: []
+extensionSet: true

--- a/extensions/composer/Dockerfile.plugin
+++ b/extensions/composer/Dockerfile.plugin
@@ -26,4 +26,5 @@ FROM scratch AS final
 
 ARG EXTENSION_PATH
 COPY --from=builder /workspace/plugin.so /
-COPY --from=builder /workspace/${EXTENSION_PATH}/manifest.yaml /
+COPY --from=builder /workspace/$EXTENSION_PATH/manifest.yaml /
+COPY --from=builder /workspace/manifest.yaml /manifest-composer.yaml


### PR DESCRIPTION
Packages for individual composer extensions were bundling only the individual extension manifest, but that did not contain the complete version information provided by the parent. When downloading a precompiled Go extension, the Envoy constraints were not present, and running defaulted to the locally configured Envoy version.

With this change, the packages for Go extensions will include the parent composer manifest as well, so that all the information can be resolved when downloading the extensions, including the supported Envoy versions, for a more accurate choice of the Envoy version when using `boe run`.