### PR TITLE
config: set default node identity in generated bootstrap

### DIFF
--- a/cli/cmd/testdata/output_full_config.yaml
+++ b/cli/cmd/testdata/output_full_config.yaml
@@ -3,6 +3,9 @@
 # The full text of the Apache license is available in the LICENSE file at
 # the root of the repo.
 
+node:
+  cluster: boe
+  id: boe
 admin:
   address:
     socket_address:

--- a/cli/cmd/testdata/output_full_config_with_cluster.yaml
+++ b/cli/cmd/testdata/output_full_config_with_cluster.yaml
@@ -3,6 +3,9 @@
 # The full text of the Apache license is available in the LICENSE file at
 # the root of the repo.
 
+node:
+  cluster: boe
+  id: boe
 admin:
   address:
     socket_address:

--- a/cli/cmd/testdata/output_full_config_with_native.yaml
+++ b/cli/cmd/testdata/output_full_config_with_native.yaml
@@ -3,6 +3,9 @@
 # The full text of the Apache license is available in the LICENSE file at
 # the root of the repo.
 
+node:
+  cluster: boe
+  id: boe
 admin:
   address:
     socket_address:

--- a/cli/cmd/testdata/output_full_config_with_native_after.yaml
+++ b/cli/cmd/testdata/output_full_config_with_native_after.yaml
@@ -3,6 +3,9 @@
 # The full text of the Apache license is available in the LICENSE file at
 # the root of the repo.
 
+node:
+  cluster: boe
+  id: boe
 admin:
   address:
     socket_address:

--- a/cli/cmd/testdata/output_full_config_with_shorthand_cluster.yaml
+++ b/cli/cmd/testdata/output_full_config_with_shorthand_cluster.yaml
@@ -3,6 +3,9 @@
 # The full text of the Apache license is available in the LICENSE file at
 # the root of the repo.
 
+node:
+  cluster: boe
+  id: boe
 admin:
   address:
     socket_address:

--- a/cli/cmd/testdata/output_full_config_with_shorthand_cluster_and_insecure_cluster.yaml
+++ b/cli/cmd/testdata/output_full_config_with_shorthand_cluster_and_insecure_cluster.yaml
@@ -3,6 +3,9 @@
 # The full text of the Apache license is available in the LICENSE file at
 # the root of the repo.
 
+node:
+  cluster: boe
+  id: boe
 admin:
   address:
     socket_address:

--- a/cli/cmd/testdata/output_full_config_with_shorthand_insecure_cluster.yaml
+++ b/cli/cmd/testdata/output_full_config_with_shorthand_insecure_cluster.yaml
@@ -3,6 +3,9 @@
 # The full text of the Apache license is available in the LICENSE file at
 # the root of the repo.
 
+node:
+  cluster: boe
+  id: boe
 admin:
   address:
     socket_address:

--- a/cli/cmd/testdata/output_full_config_with_test_upstream_cluster.yaml
+++ b/cli/cmd/testdata/output_full_config_with_test_upstream_cluster.yaml
@@ -3,6 +3,9 @@
 # The full text of the Apache license is available in the LICENSE file at
 # the root of the repo.
 
+node:
+  cluster: boe
+  id: boe
 admin:
   address:
     socket_address:

--- a/cli/internal/envoy/config.go
+++ b/cli/internal/envoy/config.go
@@ -489,6 +489,10 @@ func buildFullConfig(adminAddress string, listenerPort uint32, testUpstreamClust
 	}
 
 	return &bootstrapv3.Bootstrap{
+		Node: &corev3.Node{
+			Id:      "boe",
+			Cluster: "boe",
+		},
 		Admin: admin,
 		StaticResources: &bootstrapv3.Bootstrap_StaticResources{
 			Listeners: []*listenerv3.Listener{listener},

--- a/cli/internal/envoy/testdata/output_config.yaml
+++ b/cli/internal/envoy/testdata/output_config.yaml
@@ -3,6 +3,9 @@
 # The full text of the Apache license is available in the LICENSE file at
 # the root of the repo.
 
+node:
+  cluster: boe
+  id: boe
 admin:
   address:
     socket_address:

--- a/cli/internal/envoy/testdata/output_config_admin_all_interfaces.yaml
+++ b/cli/internal/envoy/testdata/output_config_admin_all_interfaces.yaml
@@ -3,6 +3,9 @@
 # The full text of the Apache license is available in the LICENSE file at
 # the root of the repo.
 
+node:
+  cluster: boe
+  id: boe
 admin:
   address:
     socket_address:

--- a/cli/internal/envoy/testdata/output_config_with_extensions.yaml
+++ b/cli/internal/envoy/testdata/output_config_with_extensions.yaml
@@ -3,6 +3,9 @@
 # The full text of the Apache license is available in the LICENSE file at
 # the root of the repo.
 
+node:
+  cluster: boe
+  id: boe
 admin:
   address:
     socket_address:

--- a/cli/internal/envoy/testdata/output_config_with_test_upstream_cluster.yaml
+++ b/cli/internal/envoy/testdata/output_config_with_test_upstream_cluster.yaml
@@ -3,6 +3,9 @@
 # The full text of the Apache license is available in the LICENSE file at
 # the root of the repo.
 
+node:
+  cluster: boe
+  id: boe
 admin:
   address:
     socket_address:


### PR DESCRIPTION
Istio [uses ECDS to hot-reload Wasm filters][istio-ecds] on running sidecars without restarting Envoy. In BOE, using [`nativeHttpFilters.after`][native-after], a dynamic module can do the same thing locally: generate [Extension Configuration Discovery Service][ecds] (ECDS) config at init and write it to disk for a native filter to consume (via [`path_config_source`][path-config]). After that point, the module stays out of the request path entirely.

In short, dynamic modules could be used to augment, share code with, or replace control plane ([xDS][xds]) code. This is regardless of if that is about ECDS, [Secret Discovery Service][sds] (SDS) for TLS certs, or any other dynamic config.

If you try this with BOE now, envoy crashes on startup. Envoy requires `node.id` and `node.cluster` for any
xDS config subscription. This simple change to enable this is set `node: {id: "boe", cluster: "boe"}` in `buildFullConfig`. Static configs that don't create subscriptions ignore node entirely, so there's no risk I'm aware of.

[xds]: https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol
[path-config]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/config_source.proto#config-core-v3-pathconfigsource
[ecds]: https://www.envoyproxy.io/docs/envoy/latest/configuration/overview/extension#discovery-service
[sds]: https://www.envoyproxy.io/docs/envoy/latest/configuration/security/secret
[istio-ecds]: https://github.com/envoyproxy/envoy/pull/16795
[native-after]: https://github.com/tetratelabs/built-on-envoy/blob/main/extensions/manifest.schema.json
