### PR TITLE
download: fix message when platform is not explicitly set

### DIFF
--- a/cli/cmd/download.go
+++ b/cli/cmd/download.go
@@ -66,8 +66,8 @@ func (d *Download) Run(ctx context.Context, logger *slog.Logger) error {
 	logger.Debug("handling download command", "cmd", internal.RedactSensitive(d))
 
 	name, tag := splitRef(d.Extension)
-	_, _ = fmt.Fprintf(os.Stderr, "→ %sDownloading %s for %s...%s\n",
-		internal.ANSIBold, d.Extension, d.Platform, internal.ANSIReset)
+	_, _ = fmt.Fprintf(os.Stderr, "→ %sDownloading %s for %s/%s...%s\n",
+		internal.ANSIBold, d.Extension, d.downloader.OS, d.downloader.Arch, internal.ANSIReset)
 
 	var (
 		downloaded extensions.DownloadedExtension


### PR DESCRIPTION
When the platform was not explicitly set in the command line, the message was not properly formed.