### PR TITLE
ci: use zig as the C compiler for all composer platforms

### DIFF
--- a/extensions/Dockerfile.rust
+++ b/extensions/Dockerfile.rust
@@ -3,45 +3,66 @@
 # The full text of the Apache license is available in the LICENSE file at
 # the root of the repo.
 
-# Multi-stage build for Rust dynamic modules
+# Pin the builder to the CI runner platform so cross-OS compilation
+# (e.g. darwin from a Linux runner) works without OS-level emulation.
+FROM --platform=$BUILDPLATFORM rust:1.84-bookworm AS builder
 
-# Build stage
-FROM rust:1.84-bookworm AS builder
+ARG TARGETOS
+ARG TARGETARCH
+ARG ZIG_VERSION=0.16.0
 
-# Install build dependencies
 RUN apt-get update && \
-    apt-get install -y clang libclang-dev && \
+    apt-get install -y --no-install-recommends clang libclang-dev xz-utils && \
     rm -rf /var/lib/apt/lists/*
 
-WORKDIR /workspace
+RUN wget -qO zig.tar.xz "https://ziglang.org/download/${ZIG_VERSION}/zig-$(uname -m)-linux-${ZIG_VERSION}.tar.xz" && \
+    tar xf zig.tar.xz && mv zig-*/zig /usr/local/bin/ && mv zig-*/lib /usr/local/lib/zig && \
+    rm -rf zig.tar.xz zig-*
 
-# The extension source will be mounted at build time
+# zig cc cannot resolve macOS SDK flags without a full SDK install.
+COPY <<'ZIGCC' /usr/local/bin/zigcc
+#!/bin/sh
+skip=false; f=
+for a in "$@"; do
+  if $skip; then skip=false; continue; fi
+  case "$a" in
+    -Wl,-flat_namespace|-Wl,-bind_at_load|-Wl,--unresolved-symbols*|-lresolv) ;;
+    -framework|-arch) skip=true ;;
+    *) f="$f $a" ;;
+  esac
+done
+exec zig cc $f
+ZIGCC
+RUN chmod +x /usr/local/bin/zigcc
+
+WORKDIR /workspace
 COPY . .
 
-# Build the Rust extension
-RUN cargo build --release --target-dir ./target
+RUN RUST_ARCH=$(echo $TARGETARCH | sed 's/amd64/x86_64/;s/arm64/aarch64/') && \
+    case "$TARGETOS" in \
+      darwin) \
+        RUST_TARGET="${RUST_ARCH}-apple-darwin"; \
+        ZIG_TARGET="${RUST_ARCH}-macos"; \
+        EXT=dylib; \
+        export BINDGEN_EXTRA_CLANG_ARGS="--target=${RUST_TARGET} -isystem /usr/local/lib/zig/libc/include/any-darwin-any"; \
+        ;; \
+      *) \
+        RUST_TARGET="${RUST_ARCH}-unknown-linux-gnu"; \
+        ZIG_TARGET="${RUST_ARCH}-linux-gnu"; \
+        EXT=so; \
+        ;; \
+    esac && \
+    rustup target add $RUST_TARGET && \
+    printf '#!/bin/sh\nexec zigcc -target %s "$@"\n' "$ZIG_TARGET" > /usr/local/bin/zigcc-target && \
+    chmod +x /usr/local/bin/zigcc-target && \
+    eval "export CARGO_TARGET_$(echo $RUST_TARGET | tr 'a-z-' 'A-Z_')_LINKER=zigcc-target" && \
+    cargo build --release --target $RUST_TARGET --target-dir ./target && \
+    ORIGINAL_NAME=$(grep "^name:" manifest.yaml | sed 's/[^:]*:[[:space:]]*//g' | tr -d '"') && \
+    RUST_LIB_NAME=$(echo "$ORIGINAL_NAME" | tr '-' '_') && \
+    mkdir -p /output && \
+    cp ./target/$RUST_TARGET/release/lib${RUST_LIB_NAME}.$EXT /output/lib${ORIGINAL_NAME}.$EXT
 
-# Copy the library from Rust output (with underscores) to original name (with dashes)
-RUN mkdir -p /output
-RUN ORIGINAL_NAME=$(grep "^name:" manifest.yaml | sed 's/[^:]*:[[:space:]]*//g' | tr -d '"'); \
-    RUST_LIB_NAME=$(echo "$ORIGINAL_NAME" | tr '-' '_'); \
-    cp ./target/release/lib${RUST_LIB_NAME}.so /output/lib${ORIGINAL_NAME}.so
-
-# Final stage - minimal image with just the compiled library
 FROM scratch AS final
 
-# Copy the compiled library from builder
-COPY --from=builder /output/*.so /
+COPY --from=builder /output/lib*.* /
 COPY --from=builder /workspace/manifest.yaml /
-
-
-
-
-
-
-
-
-
-
-
-

--- a/extensions/Makefile
+++ b/extensions/Makefile
@@ -151,7 +151,7 @@ push_lua: create_builder
 		--tag $(IMAGE) $(DEV_TAG) \
 		--file Dockerfile.code ./$(EXTENSION_PATH)
 
-PLATFORMS ?= linux/arm64,linux/amd64
+PLATFORMS ?= linux/arm64,linux/amd64,darwin/arm64
 .PHONY: push_rust
 push_rust: create_builder
 	@echo "Building and pushing Rust extension image for multiple architectures: $(IMAGE)"

--- a/extensions/composer/Dockerfile
+++ b/extensions/composer/Dockerfile
@@ -3,21 +3,49 @@
 # The full text of the Apache license is available in the LICENSE file at
 # the root of the repo.
 
-# Build the manager binary
-FROM golang:1.26.3 AS builder
+# Pin the builder to the CI runner platform so cross-OS compilation
+# (e.g. darwin from a Linux runner) works without OS-level emulation.
+FROM --platform=$BUILDPLATFORM golang:1.26.3 AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
+ARG ZIG_VERSION=0.16.0
 
 WORKDIR /workspace
 COPY . .
 
-# Install necessary tools for cgo
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
-    ca-certificates wget git ssh netcat-openbsd gcc build-essential binutils binutils-gold
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    ca-certificates wget git ssh netcat-openbsd xz-utils
+
+RUN wget -qO zig.tar.xz "https://ziglang.org/download/${ZIG_VERSION}/zig-$(uname -m)-linux-${ZIG_VERSION}.tar.xz" && \
+    tar xf zig.tar.xz && mv zig-*/zig /usr/local/bin/ && mv zig-*/lib /usr/local/lib/zig && \
+    rm -rf zig.tar.xz zig-*
+
+# zig cc cannot resolve macOS SDK flags without a full SDK install.
+COPY <<'ZIGCC' /usr/local/bin/zigcc
+#!/bin/sh
+skip=false; f=
+for a in "$@"; do
+  if $skip; then skip=false; continue; fi
+  case "$a" in
+    -Wl,-flat_namespace|-Wl,-bind_at_load|-Wl,--unresolved-symbols*|-lresolv) ;;
+    -framework|-arch) skip=true ;;
+    *) f="$f $a" ;;
+  esac
+done
+exec zig cc $f
+ZIGCC
+RUN chmod +x /usr/local/bin/zigcc
 
 RUN go mod download all
 ARG BUILD_TAG=""
-# Build go shared library
-RUN CGO_ENABLED=1 go build -buildmode=c-shared ${BUILD_TAG} -o libcomposer.so ./main
+
+RUN ZIG_TARGET=$(echo $TARGETARCH | sed 's/arm64/aarch64/;s/amd64/x86_64/') && \
+    case "$TARGETOS" in darwin) ZIG_TARGET="$ZIG_TARGET-macos" ;; *) ZIG_TARGET="$ZIG_TARGET-linux-gnu" ;; esac && \
+    CC="zigcc -target $ZIG_TARGET" \
+    CGO_ENABLED=1 GOOS=$TARGETOS GOARCH=$TARGETARCH \
+    go build -trimpath -buildmode=c-shared ${BUILD_TAG} -o libcomposer.so ./main
 
 FROM scratch AS final
 

--- a/extensions/composer/Dockerfile.plugin
+++ b/extensions/composer/Dockerfile.plugin
@@ -51,7 +51,7 @@ RUN ZIG_TARGET=$(echo $TARGETARCH | sed 's/arm64/aarch64/;s/amd64/x86_64/') && \
     case "$TARGETOS" in darwin) ZIG_TARGET="$ZIG_TARGET-macos" ;; *) ZIG_TARGET="$ZIG_TARGET-linux-gnu" ;; esac && \
     CC="zigcc -target $ZIG_TARGET" \
     CGO_ENABLED=1 GOOS=$TARGETOS GOARCH=$TARGETARCH \
-    go build -trimpath -ldflags="-s" -buildmode=plugin ${BUILD_TAG} -o plugin.so ./$EXTENSION_PATH/standalone
+    go build -trimpath -ldflags="-s -w" -buildmode=plugin ${BUILD_TAG} -o plugin.so ./$EXTENSION_PATH/standalone
 
 FROM scratch AS final
 

--- a/extensions/composer/Dockerfile.plugin
+++ b/extensions/composer/Dockerfile.plugin
@@ -7,20 +7,51 @@
 # If you need to customize the build process, consider creating a separate
 # Dockerfile (e.g., Dockerfile.custom) instead of editing this file.
 
-# Build the manager binary
-FROM golang:1.26.3 AS builder
+# Pin the builder to the CI runner platform so cross-OS compilation
+# (e.g. darwin from a Linux runner) works without OS-level emulation.
+FROM --platform=$BUILDPLATFORM golang:1.26.3 AS builder
 
+ARG TARGETOS
+ARG TARGETARCH
 ARG EXTENSION_PATH
+ARG ZIG_VERSION=0.16.0
 
 WORKDIR /workspace
 COPY . .
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends xz-utils && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN wget -qO zig.tar.xz "https://ziglang.org/download/${ZIG_VERSION}/zig-$(uname -m)-linux-${ZIG_VERSION}.tar.xz" && \
+    tar xf zig.tar.xz && mv zig-*/zig /usr/local/bin/ && mv zig-*/lib /usr/local/lib/zig && \
+    rm -rf zig.tar.xz zig-*
+
+# zig cc cannot resolve macOS SDK flags without a full SDK install.
+COPY <<'ZIGCC' /usr/local/bin/zigcc
+#!/bin/sh
+skip=false; f=
+for a in "$@"; do
+  if $skip; then skip=false; continue; fi
+  case "$a" in
+    -Wl,-flat_namespace|-Wl,-bind_at_load|-Wl,--unresolved-symbols*|-lresolv) ;;
+    -framework|-arch) skip=true ;;
+    *) f="$f $a" ;;
+  esac
+done
+exec zig cc $f
+ZIGCC
+RUN chmod +x /usr/local/bin/zigcc
 
 RUN go mod download all
 
 # BUILD_TAG is used to to include coraza waf build tags, populated by Makefile.plugin via --build-arg
 ARG BUILD_TAG=""
-# Build go plugin
-RUN CGO_ENABLED=1 go build -trimpath -buildmode=plugin ${BUILD_TAG} -o plugin.so ./$EXTENSION_PATH/standalone
+RUN ZIG_TARGET=$(echo $TARGETARCH | sed 's/arm64/aarch64/;s/amd64/x86_64/') && \
+    case "$TARGETOS" in darwin) ZIG_TARGET="$ZIG_TARGET-macos" ;; *) ZIG_TARGET="$ZIG_TARGET-linux-gnu" ;; esac && \
+    CC="zigcc -target $ZIG_TARGET" \
+    CGO_ENABLED=1 GOOS=$TARGETOS GOARCH=$TARGETARCH \
+    go build -trimpath -ldflags="-s" -buildmode=plugin ${BUILD_TAG} -o plugin.so ./$EXTENSION_PATH/standalone
 
 FROM scratch AS final
 

--- a/extensions/composer/Makefile
+++ b/extensions/composer/Makefile
@@ -163,7 +163,7 @@ build_image:
 
 # For default push operation, we will also prefer to build a multi-platform image to support
 # both amd64 and arm64 architectures, and push it to the registry.
-PLATFORMS ?= linux/arm64,linux/amd64
+PLATFORMS ?= linux/arm64,linux/amd64,darwin/arm64
 .PHONY: push_image
 push_image: create_builder  ## Build and push docker image for the plugin for cross-platform support
 	@echo "Building and pushing image..."

--- a/extensions/composer/Makefile.plugin
+++ b/extensions/composer/Makefile.plugin
@@ -122,7 +122,7 @@ build_image:
 
 # For default push operation, we will also prefer to build a multi-platform image to support
 # both amd64 and arm64 architectures, and push it to the registry.
-PLATFORMS ?= linux/arm64,linux/amd64
+PLATFORMS ?= linux/arm64,linux/amd64,darwin/arm64
 .PHONY: push_image
 push_image: create_builder ## Build and push docker image for the plugin for cross-platform support
 	@echo "Building and pushing image..."


### PR DESCRIPTION
composer-lite only published linux/arm64 and linux/amd64. On macOS,
`boe run` downloads composer-src and builds from source because there is
no darwin/arm64 binary. Docker buildx cannot produce darwin binaries
natively since containers always run Linux.

Replace gcc with zig as the C compiler for all platforms. Zig
cross-compiles to any OS/arch from a single Linux builder, so the same
Dockerfile now produces linux/arm64, linux/amd64, and darwin/arm64
without conditional logic. A `zigcc` wrapper filters linker flags that
zig cannot resolve without a full platform SDK; these resolve at load
time on the target OS.

```console
$ docker buildx build --platform=darwin/arm64     --output type=local,dest=. -f Dockerfile .
$ file libcomposer.so
libcomposer.so: Mach-O 64-bit dynamically linked shared library arm64
```