### PR TITLE
cli: support dev Envoy version natively via func-e v1.6.0

### DIFF
--- a/cli/cmd/genconfig.go
+++ b/cli/cmd/genconfig.go
@@ -247,10 +247,13 @@ func copyFile(srcPath, dstPath string, logger *slog.Logger) error {
 // printExportSummary prints information about how to use the exported configuration.
 func printExportSummary(stdout io.Writer, outputPath string, files []string, listenPort, adminPort uint32, envoyVersion string) {
 	adminPortStr := strconv.FormatUint(uint64(adminPort), 10)
-	if envoyVersion == "" {
-		envoyVersion = "dev"
-	} else if !strings.HasPrefix(envoyVersion, "v") {
-		envoyVersion = "v" + envoyVersion
+	funcEEnvoyVersion := envoyVersion
+	if funcEEnvoyVersion == "" {
+		funcEEnvoyVersion = "dev"
+	}
+	dockerEnvoyTag := funcEEnvoyVersion
+	if dockerEnvoyTag != "dev" && !strings.HasPrefix(dockerEnvoyTag, "v") {
+		dockerEnvoyTag = "v" + dockerEnvoyTag
 	}
 
 	_, _ = fmt.Fprintf(stdout, "\n%v✓ Config exported to:%v %s\n",
@@ -262,7 +265,7 @@ func printExportSummary(stdout io.Writer, outputPath string, files []string, lis
 %[1]s→ Run locally with with func-e:%[2]s (https://func-e.io/)
     cd %[3]s
     export GODEBUG=cgocheck=0
-    func-e run -c envoy.yaml --log-level info --component-log-level dynamic_modules:debug
+    ENVOY_VERSION=%[6]s func-e run -c envoy.yaml --log-level info --component-log-level dynamic_modules:debug
 
 %[1]s→ Run locally in Docker:%[2]s (not supported in Darwin hosts yet)
     docker run --rm \
@@ -272,6 +275,6 @@ func printExportSummary(stdout io.Writer, outputPath string, files []string, lis
         -e GODEBUG=cgocheck=0 \
         -v /tmp/boe-export:/boe \
         -w /boe \
-        envoyproxy/envoy:%[6]s -c /boe/envoy.yaml --log-level info --component-log-level dynamic_modules:debug
-`, internal.ANSIBold, internal.ANSIReset, outputPath, listenPort, adminPortStr, envoyVersion)
+        envoyproxy/envoy:%[7]s -c /boe/envoy.yaml --log-level info --component-log-level dynamic_modules:debug
+`, internal.ANSIBold, internal.ANSIReset, outputPath, listenPort, adminPortStr, funcEEnvoyVersion, dockerEnvoyTag)
 }

--- a/cli/cmd/genconfig_test.go
+++ b/cli/cmd/genconfig_test.go
@@ -371,7 +371,7 @@ func TestPrintExportSummary(t *testing.T) {
 %[1]s→ Run locally with with func-e:%[2]s (https://func-e.io/)
     cd /tmp/boe-export
     export GODEBUG=cgocheck=0
-    func-e run -c envoy.yaml --log-level info --component-log-level dynamic_modules:debug
+    ENVOY_VERSION=%[3]s func-e run -c envoy.yaml --log-level info --component-log-level dynamic_modules:debug
 
 %[1]s→ Run locally in Docker:%[2]s (not supported in Darwin hosts yet)
     docker run --rm \
@@ -381,18 +381,18 @@ func TestPrintExportSummary(t *testing.T) {
         -e GODEBUG=cgocheck=0 \
         -v /tmp/boe-export:/boe \
         -w /boe \
-        envoyproxy/envoy:%[3]s -c /boe/envoy.yaml --log-level info --component-log-level dynamic_modules:debug
+        envoyproxy/envoy:%[4]s -c /boe/envoy.yaml --log-level info --component-log-level dynamic_modules:debug
 `
 
 	t.Run("with Envoy version", func(t *testing.T) {
 		var buf bytes.Buffer
 		printExportSummary(&buf, "/tmp/boe-export", []string{"envoy.yaml", "libcomposer.so"}, 10000, 9901, "1.38.0")
-		require.Equal(t, fmt.Sprintf(wantTemplate, internal.ANSIBold, internal.ANSIReset, "v1.38.0"), buf.String())
+		require.Equal(t, fmt.Sprintf(wantTemplate, internal.ANSIBold, internal.ANSIReset, "1.38.0", "v1.38.0"), buf.String())
 	})
 
-	t.Run("without Envoy version defaults to 'dev' for Docker", func(t *testing.T) {
+	t.Run("without Envoy version defaults to 'dev'", func(t *testing.T) {
 		var buf bytes.Buffer
 		printExportSummary(&buf, "/tmp/boe-export", []string{"envoy.yaml", "libcomposer.so"}, 10000, 9901, "")
-		require.Equal(t, fmt.Sprintf(wantTemplate, internal.ANSIBold, internal.ANSIReset, "dev"), buf.String())
+		require.Equal(t, fmt.Sprintf(wantTemplate, internal.ANSIBold, internal.ANSIReset, "dev", "dev"), buf.String())
 	})
 }

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -31,15 +31,16 @@ const defaultLogLevel = "error"
 
 // Run is a command to run Envoy with extensions.
 type Run struct {
-	EnvoyVersion string   `help:"Envoy version to use (e.g., 1.31.0)" env:"ENVOY_VERSION"`
-	EnvoyPath    string   `name:"envoy-path" help:"Path to a custom Envoy binary. Skips Envoy download and version selection." env:"ENVOY_PATH" type:"existingfile"`
-	LogLevel     string   `help:"Envoy component log level." default:"all:error" env:"ENVOY_LOG_LEVEL"`
-	RunID        string   `name:"run-id" env:"BOE_RUN_ID" help:"Run identifier for this invocation. Overrides the default timestamp-based ID."`
-	ListenPort   uint32   `help:"Port for Envoy listener to accept incoming traffic." default:"10000"`
-	AdminPort    uint32   `name:"admin-port" help:"Port for Envoy admin interface." default:"9901" env:"BOE_ADMIN_PORT"`
-	Extensions   []string `name:"extension" help:"Extensions to enable (in the format: \"name\" or \"name:version\")."`
-	Local        []string `name:"local" sep:"none" help:"Path to a directory containing a local Extension to enable." type:"existingdir"`
-	Dev          bool     `help:"Whether to allow downloading dev versions of extensions (with -dev suffix). By default, only stable versions are allowed." default:"false"`
+	EnvoyVersion     string   `help:"Envoy version to use (e.g., 1.31.0, dev, dev-latest)" env:"ENVOY_VERSION"`
+	EnvoyVersionsURL string   `name:"envoy-versions-url" help:"URL of the Envoy versions JSON. Override to use debug builds (see archive-envoy)." env:"ENVOY_VERSIONS_URL" hidden:""`
+	EnvoyPath        string   `name:"envoy-path" help:"Path to a custom Envoy binary. Skips Envoy download and version selection." env:"ENVOY_PATH" type:"existingfile"`
+	LogLevel         string   `help:"Envoy component log level." default:"all:error" env:"ENVOY_LOG_LEVEL"`
+	RunID            string   `name:"run-id" env:"BOE_RUN_ID" help:"Run identifier for this invocation. Overrides the default timestamp-based ID."`
+	ListenPort       uint32   `help:"Port for Envoy listener to accept incoming traffic." default:"10000"`
+	AdminPort        uint32   `name:"admin-port" help:"Port for Envoy admin interface." default:"9901" env:"BOE_ADMIN_PORT"`
+	Extensions       []string `name:"extension" help:"Extensions to enable (in the format: \"name\" or \"name:version\")."`
+	Local            []string `name:"local" sep:"none" help:"Path to a directory containing a local Extension to enable." type:"existingdir"`
+	Dev              bool     `help:"Whether to allow downloading dev versions of extensions (with -dev suffix). By default, only stable versions are allowed." default:"false"`
 	// sep:"none" disables Kong's default comma-separated splitting for []string flags.
 	// JSON config values contain commas (e.g. {"a":"1","b":"2"}) which would otherwise
 	// be split into separate invalid fragments, causing protobuf unmarshal failures.
@@ -190,6 +191,7 @@ func (r *Run) Run(ctx context.Context, dirs *xdg.Directories, logger *slog.Logge
 	runner := &envoy.RunnerFuncE{
 		Logger:                  logger,
 		EnvoyVersion:            r.EnvoyVersion,
+		EnvoyVersionsURL:        r.EnvoyVersionsURL,
 		EnvoyPath:               r.EnvoyPath,
 		DefaultLogLevel:         r.defaultLogLevel,
 		ComponentLogLevel:       r.componentLogLevel,

--- a/cli/cmd/run_test.go
+++ b/cli/cmd/run_test.go
@@ -50,8 +50,8 @@ Run Envoy with extensions
 Flags:
   -h, --help                       Show context-sensitive help.
 
-      --envoy-version=STRING       Envoy version to use (e.g., 1.31.0)
-                                   ($ENVOY_VERSION)
+      --envoy-version=STRING       Envoy version to use (e.g., 1.31.0, dev,
+                                   dev-latest) ($ENVOY_VERSION)
       --envoy-path=STRING          Path to a custom Envoy binary. Skips Envoy
                                    download and version selection ($ENVOY_PATH).
       --log-level="all:error"      Envoy component log level ($ENVOY_LOG_LEVEL).
@@ -594,6 +594,20 @@ func TestValidateEnvoyCompat(t *testing.T) {
 				`incompatible Envoy version 1.31.0: extension ext-1 (1.0.0) requires Envoy ">= 1.32.0"`,
 				`incompatible Envoy version 1.31.0: extension ext-2 (2.0.0) requires Envoy "<= 1.30.0"`,
 				`incompatible Envoy version 1.31.0: extension ext-3 (2.0.0) requires Envoy ">= 1.31.1 && <= 1.32.0"`,
+			},
+		},
+		{
+			name:         "dev aliases are compatible with constrained extensions",
+			envoyVersion: "dev",
+			extensions: []*extensions.Manifest{
+				{Name: "ext-1", Version: "1.0.0", MinEnvoyVersion: "1.38.0", MaxEnvoyVersion: "1.39.0"},
+			},
+		},
+		{
+			name:         "dev-latest alias is compatible with constrained extensions",
+			envoyVersion: "dev-latest",
+			extensions: []*extensions.Manifest{
+				{Name: "ext-1", Version: "1.0.0", MinEnvoyVersion: "1.38.0", MaxEnvoyVersion: "1.39.0"},
 			},
 		},
 	}

--- a/cli/e2e/run_test.go
+++ b/cli/e2e/run_test.go
@@ -66,6 +66,17 @@ func TestLuaRemoteExecution(t *testing.T) {
 	require.NoError(t, internaltesting.CheckGet(ctx, url, checkHeader))
 }
 
+func TestDevEnvoyVersion(t *testing.T) {
+	ports := internaltesting.FreePorts(t, 2)
+	proxyPort, adminPort := ports[0], ports[1]
+	internaltesting.RunEnvoy(t, cliBin, proxyPort, adminPort, "--envoy-version", "dev-latest")
+
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+	t.Cleanup(cancel)
+
+	require.NoError(t, internaltesting.CheckGet(ctx, fmt.Sprintf("http://localhost:%d/status/200", proxyPort), internaltesting.EqualStatus(200)))
+}
+
 func TestLuaLocalExtension(t *testing.T) {
 	ports := internaltesting.FreePorts(t, 2)
 	proxyPort := ports[0]

--- a/cli/internal/envoy/runner.go
+++ b/cli/internal/envoy/runner.go
@@ -40,6 +40,8 @@ type RunnerFuncE struct {
 	Logger *slog.Logger
 	// EnvoyVersion specifies the Envoy version to run. If empty, the default version is used.
 	EnvoyVersion string
+	// EnvoyVersionsURL overrides the Envoy versions JSON URL (e.g. for debug builds).
+	EnvoyVersionsURL string
 	// EnvoyPath specifies a custom Envoy binary path. If set, download and version selection are skipped.
 	EnvoyPath string
 	// DefaultLogLevel specifies the base Envoy log level.
@@ -175,6 +177,9 @@ Press Ctrl+C to stop
 	}
 	if r.EnvoyVersion != "" {
 		opts = append(opts, api.EnvoyVersion(r.EnvoyVersion))
+	}
+	if r.EnvoyVersionsURL != "" {
+		opts = append(opts, api.EnvoyVersionsURL(r.EnvoyVersionsURL))
 	}
 	if r.EnvoyPath != "" {
 		opts = append(opts, api.EnvoyPath(r.EnvoyPath))

--- a/cli/internal/extensions/manifest.go
+++ b/cli/internal/extensions/manifest.go
@@ -132,6 +132,9 @@ type (
 
 // SupportsEnvoyVersion checks if the extension supports the given Envoy version.
 func (m *Manifest) SupportsEnvoyVersion(version string) bool {
+	if version == "dev" || version == "dev-latest" {
+		return true
+	}
 	envoySemver := "v" + version
 	if m.MinEnvoyVersion != "" && semver.Compare(envoySemver, "v"+m.MinEnvoyVersion) < 0 {
 		return false

--- a/cli/internal/extensions/manifest_test.go
+++ b/cli/internal/extensions/manifest_test.go
@@ -250,6 +250,37 @@ func TestSupportsEnvoyVersion(t *testing.T) {
 			version:         "1.30.2",
 			want:            true,
 		},
+		{
+			name:    "dev - no constraints",
+			version: "dev",
+			want:    true,
+		},
+		{
+			name:            "dev - with min",
+			minEnvoyVersion: "1.38.0",
+			version:         "dev",
+			want:            true,
+		},
+		{
+			name:            "dev - with max",
+			maxEnvoyVersion: "1.39.0",
+			version:         "dev",
+			want:            true,
+		},
+		{
+			name:            "dev - with min and max",
+			minEnvoyVersion: "1.38.0",
+			maxEnvoyVersion: "1.39.0",
+			version:         "dev",
+			want:            true,
+		},
+		{
+			name:            "dev-latest - with min and max",
+			minEnvoyVersion: "1.38.0",
+			maxEnvoyVersion: "1.39.0",
+			version:         "dev-latest",
+			want:            true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/cli/tools/gen-cli-docs/go.mod
+++ b/cli/tools/gen-cli-docs/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/shirou/gopsutil/v4 v4.26.3 // indirect
-	github.com/tetratelabs/func-e v1.5.0 // indirect
+	github.com/tetratelabs/func-e v1.6.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.16 // indirect
 	github.com/tklauser/numcpus v0.11.0 // indirect
 	github.com/ulikunitz/lz v0.6.11 // indirect

--- a/cli/tools/gen-cli-docs/go.sum
+++ b/cli/tools/gen-cli-docs/go.sum
@@ -110,8 +110,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/testcontainers/testcontainers-go v0.42.0 h1:He3IhTzTZOygSXLJPMX7n44XtK+qhjat1nI9cneBbUY=
 github.com/testcontainers/testcontainers-go v0.42.0/go.mod h1:vZjdY1YmUA1qEForxOIOazfsrdyORJAbhi0bp8plN30=
-github.com/tetratelabs/func-e v1.5.0 h1:usqnwqIlLereQdua/BYLwFNfnNX7qGOFUGPihp8KMo0=
-github.com/tetratelabs/func-e v1.5.0/go.mod h1:9d/4Wne/HSg8pM+6fNhUePCsbQLeDrajn+wwbiN5WS4=
+github.com/tetratelabs/func-e v1.6.0 h1:TlTVVCSX/I+SBg6NWtU8On7EjrGz2/kxHQUtOo5tl1U=
+github.com/tetratelabs/func-e v1.6.0/go.mod h1:9d/4Wne/HSg8pM+6fNhUePCsbQLeDrajn+wwbiN5WS4=
 github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYICU0nA=
 github.com/tklauser/go-sysconf v0.3.16/go.mod h1:/qNL9xxDhc7tx3HSRsLWNnuzbVfh3e7gh/BmM179nYI=
 github.com/tklauser/numcpus v0.11.0 h1:nSTwhKH5e1dMNsCdVBukSZrURJRoHbSEQjdEbY+9RXw=

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.42.0
-	github.com/tetratelabs/func-e v1.5.0
+	github.com/tetratelabs/func-e v1.6.0
 	golang.org/x/mod v0.36.0
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -116,8 +116,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/testcontainers/testcontainers-go v0.42.0 h1:He3IhTzTZOygSXLJPMX7n44XtK+qhjat1nI9cneBbUY=
 github.com/testcontainers/testcontainers-go v0.42.0/go.mod h1:vZjdY1YmUA1qEForxOIOazfsrdyORJAbhi0bp8plN30=
-github.com/tetratelabs/func-e v1.5.0 h1:usqnwqIlLereQdua/BYLwFNfnNX7qGOFUGPihp8KMo0=
-github.com/tetratelabs/func-e v1.5.0/go.mod h1:9d/4Wne/HSg8pM+6fNhUePCsbQLeDrajn+wwbiN5WS4=
+github.com/tetratelabs/func-e v1.6.0 h1:TlTVVCSX/I+SBg6NWtU8On7EjrGz2/kxHQUtOo5tl1U=
+github.com/tetratelabs/func-e v1.6.0/go.mod h1:9d/4Wne/HSg8pM+6fNhUePCsbQLeDrajn+wwbiN5WS4=
 github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYICU0nA=
 github.com/tklauser/go-sysconf v0.3.16/go.mod h1:/qNL9xxDhc7tx3HSRsLWNnuzbVfh3e7gh/BmM179nYI=
 github.com/tklauser/numcpus v0.11.0 h1:nSTwhKH5e1dMNsCdVBukSZrURJRoHbSEQjdEbY+9RXw=

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -266,7 +266,7 @@ require (
 	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/subosito/gotenv v1.4.1 // indirect
 	github.com/tetafro/godot v1.5.4 // indirect
-	github.com/tetratelabs/func-e v1.5.0 // indirect
+	github.com/tetratelabs/func-e v1.6.0 // indirect
 	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -774,8 +774,8 @@ github.com/tenntenn/text/transform v0.0.0-20200319021203-7eef512accb3 h1:f+jULpR
 github.com/tenntenn/text/transform v0.0.0-20200319021203-7eef512accb3/go.mod h1:ON8b8w4BN/kE1EOhwT0o+d62W65a6aPw1nouo9LMgyY=
 github.com/tetafro/godot v1.5.4 h1:u1ww+gqpRLiIA16yF2PV1CV1n/X3zhyezbNXC3E14Sg=
 github.com/tetafro/godot v1.5.4/go.mod h1:eOkMrVQurDui411nBY2FA05EYH01r14LuWY/NrVDVcU=
-github.com/tetratelabs/func-e v1.5.0 h1:usqnwqIlLereQdua/BYLwFNfnNX7qGOFUGPihp8KMo0=
-github.com/tetratelabs/func-e v1.5.0/go.mod h1:9d/4Wne/HSg8pM+6fNhUePCsbQLeDrajn+wwbiN5WS4=
+github.com/tetratelabs/func-e v1.6.0 h1:TlTVVCSX/I+SBg6NWtU8On7EjrGz2/kxHQUtOo5tl1U=
+github.com/tetratelabs/func-e v1.6.0/go.mod h1:9d/4Wne/HSg8pM+6fNhUePCsbQLeDrajn+wwbiN5WS4=
 github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
 github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=

--- a/website/src/pages/docs/cli/run.mdx
+++ b/website/src/pages/docs/cli/run.mdx
@@ -96,7 +96,7 @@ boe run --help
 
 | Name | Description | Type | Default | Env Var | Required |
 |------|-------------|------|---------|-----|----------|
-| `--envoy-version` | Envoy version to use (e.g., 1.31.0) | `string` | - | `ENVOY_VERSION` | No |
+| `--envoy-version` | Envoy version to use (e.g., 1.31.0, dev, dev-latest) | `string` | - | `ENVOY_VERSION` | No |
 | `--envoy-path` | Path to a custom Envoy binary. Skips Envoy download and version selection. | `string` | - | `ENVOY_PATH` | No |
 | `--log-level` | Envoy component log level. | `string` | `all:error` | `ENVOY_LOG_LEVEL` | No |
 | `--run-id` | Run identifier for this invocation. Overrides the default timestamp-based ID. | `string` | - | `BOE_RUN_ID` | No |

--- a/website/src/pages/docs/reference/environment-variables.mdx
+++ b/website/src/pages/docs/reference/environment-variables.mdx
@@ -24,4 +24,4 @@ List of environment variables that can be used to configure the CLI behavior.
 | `BOE_STATE_HOME` | Persistent state and logs directory. Defaults to ~/.local/state/boe | `~/.local/state/boe` |
 | `ENVOY_LOG_LEVEL` | Envoy component log level. | `all:error` |
 | `ENVOY_PATH` | Path to a custom Envoy binary. Skips Envoy download and version selection. | - |
-| `ENVOY_VERSION` | Envoy version to use (e.g., 1.31.0) | - |
+| `ENVOY_VERSION` | Envoy version to use (e.g., 1.31.0, dev, dev-latest) | - |


### PR DESCRIPTION
Testing unreleased Envoy features with BOE previously meant using
Docker and the distroless-dev image tag, which only works on Linux and
bypasses func-e entirely.

func-e v1.6.0 added native dev builds backed by the same daily
archive-envoy pipeline that publishes released versions. The dev key in
envoy-versions.json carries a commitSha that traces back to the exact
envoyproxy/envoy Docker image it was extracted from.

`--envoy-versions-url` (or `ENVOY_VERSIONS_URL`) passes a custom
versions JSON URL through to func-e. `dev` and `dev-latest` are
accepted as Envoy version strings and bypass the semver compatibility
check against extension manifests.

```console
$ boe run --envoy-version dev-latest --local extensions/example-lua     --envoy-versions-url https://archive.tetratelabs.io/envoy/envoy-versions_debug.json
```