### PR TITLE
docs: generate reference docs for extension config based on their schemas

### DIFF
--- a/cli/Makefile
+++ b/cli/Makefile
@@ -114,7 +114,7 @@ gen-docs:  ## Generate documentation
 	@go run tools/gen-cli-docs/main.go -docs-dir=../website/src/pages/docs
 	@go run tools/gen-manifest-reference/main.go \
 		-schema=../extensions/manifest.schema.json \
-		-output=../website/src/pages/docs/reference/manifest.mdx \
+		-docs-output=../website/src/pages/docs \
 		-extension-index=../website/public/extensions.json \
 		-extensions=../extensions
 

--- a/cli/internal/extensions/manifest.go
+++ b/cli/internal/extensions/manifest.go
@@ -122,7 +122,7 @@ type (
 		After []map[string]any `yaml:"after,omitempty" json:"after,omitempty"`
 	}
 
-	// ManifestIndexEntry represents manifest entry in the manifext index JSON that is used
+	// ManifestIndexEntry represents manifest entry in the manifest index JSON that is used
 	// as the source of truth of manifests and served in the public site.
 	ManifestIndexEntry struct {
 		*Manifest  `yaml:",inline" json:",inline"`

--- a/cli/tools/gen-cli-docs/templates/sidebar-cli.yaml.tmpl
+++ b/cli/tools/gen-cli-docs/templates/sidebar-cli.yaml.tmpl
@@ -15,3 +15,5 @@ sections:
         href: /docs/reference/environment-variables
       - title: Extension manifest
         href: /docs/reference/manifest
+      - title: Extension configuration
+        href: /docs/reference/extensions

--- a/cli/tools/gen-manifest-reference/main.go
+++ b/cli/tools/gen-manifest-reference/main.go
@@ -10,10 +10,13 @@ package main
 import (
 	"embed"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"text/template"
@@ -29,17 +32,20 @@ var templateFS embed.FS
 
 // JSONSchema represents a JSON Schema document.
 type JSONSchema struct {
-	Title       string               `json:"title"`
-	Description string               `json:"description"`
-	Type        string               `json:"type"`
-	Required    []string             `json:"required"`
-	Properties  map[string]*Property `json:"properties"`
-	AllOf       []*ConditionalSchema `json:"allOf"`
+	Title       string                 `json:"title"`
+	Description string                 `json:"description"`
+	Type        string                 `json:"type"`
+	Required    []string               `json:"required"`
+	Properties  map[string]*Property   `json:"properties"`
+	AllOf       []*ConditionalSchema   `json:"allOf"`
+	OneOf       []*OneOfItem           `json:"oneOf"`
+	Defs        map[string]*JSONSchema `json:"$defs"`
 }
 
 // Property represents a property in the JSON schema.
 type Property struct {
 	Type        any                  `json:"type"`
+	Ref         string               `json:"$ref"`
 	Description string               `json:"description"`
 	MinLength   *int                 `json:"minLength"`
 	MaxLength   *int                 `json:"maxLength"`
@@ -56,6 +62,7 @@ type Property struct {
 // Items represents the items definition for array types.
 type Items struct {
 	Type       string               `json:"type"`
+	Ref        string               `json:"$ref"`
 	Enum       []string             `json:"enum"`
 	MinLength  *int                 `json:"minLength"`
 	Pattern    string               `json:"pattern"`
@@ -108,7 +115,7 @@ type Constraint struct {
 // DocProperty represents a property for documentation.
 type DocProperty struct {
 	Name          string
-	Type          string
+	Type          TypeRef
 	Description   string
 	Required      bool
 	Constraints   []Constraint
@@ -117,74 +124,133 @@ type DocProperty struct {
 	OneOf         []string
 }
 
+// TypeRef represents a reference to another type in the documentation.
+type TypeRef struct {
+	Name string
+	Href string
+}
+
 // TemplateData holds the data for the template.
 type TemplateData struct {
+	Name        string
+	Href        string
 	Title       string
 	Description string
 	Properties  []DocProperty
+	OneOf       []string
+	CustomTypes []TemplateData
 }
 
 func main() {
 	var (
 		schemaPath         string
-		outputPath         string
+		docsOutputPath     string
 		extensionIndexPath string
 		extensionsDir      string
 	)
 
 	flag.StringVar(&schemaPath, "schema", "", "Path to the JSON schema file (required)")
-	flag.StringVar(&outputPath, "output", "", "Output path for the MDX file (required)")
+	flag.StringVar(&docsOutputPath, "docs-output", "", "Output path for the docs (required)")
 	flag.StringVar(&extensionIndexPath, "extension-index", "", "Output path for the extension index file (required)")
 	flag.StringVar(&extensionsDir, "extensions", "", "Path to the extensions directory (required)")
 	flag.Parse()
 
-	if schemaPath == "" || outputPath == "" || extensionIndexPath == "" || extensionsDir == "" {
-		fmt.Fprintln(os.Stderr, "Usage: gen-manifest-reference -schema <path> -output <path> -extension-index <path> -extensions <path>")
+	if schemaPath == "" || docsOutputPath == "" || extensionIndexPath == "" || extensionsDir == "" {
+		fmt.Fprintln(os.Stderr, "Usage: gen-manifest-reference -schema <path> -docs-output <path> -extension-index <path> -extensions <path>")
 		flag.PrintDefaults()
 		os.Exit(1)
 	}
 
-	if err := generateExtensionIndex(extensionIndexPath, extensionsDir); err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to generate extension index: %v\n", err)
+	manifestSchema, err := loadSchema(schemaPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to load manifest schema: %v\n", err)
+		os.Exit(1)
+	}
+	manifestSchemaOutputPath := filepath.Join(docsOutputPath, "reference", "manifest.mdx")
+	if err = generateJSONSchemaReference(map[string]*JSONSchema{"reference": manifestSchema}, manifestSchemaOutputPath); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to generate JSON schema reference: %v\n", err)
 		os.Exit(1)
 	}
 
-	// Read and parse the schema
+	configSchemas, err := generateExtensionIndex(extensionIndexPath, extensionsDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to generate extension index: %v\n", err)
+		os.Exit(1)
+	}
+	if len(configSchemas) > 0 {
+		if err = generateJSONSchemaReference(configSchemas, filepath.Join(docsOutputPath, "reference", "extensions.mdx")); err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to generate extension config reference: %v\n", err)
+			os.Exit(1)
+		}
+	}
+}
+
+func generateExtensionIndex(path string, extensionsDir string) (map[string]*JSONSchema, error) {
+	fs := os.DirFS(extensionsDir)
+	all, err := extensions.LoadManifests(fs, ".", false)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load manifests from %s: %w", extensionsDir, err)
+	}
+	extensionIndex := extensions.ManifestsIndex(all)
+
+	type ManifestWithConfigSchema struct {
+		*extensions.ManifestIndexEntry
+		ConfigReferencePath string `json:"configReferencePath,omitempty"`
+	}
+
+	entries := make([]*ManifestWithConfigSchema, 0, len(extensionIndex))
+	schemas := make(map[string]*JSONSchema)
+	for _, ext := range extensionIndex {
+		entry := &ManifestWithConfigSchema{ManifestIndexEntry: ext}
+		entries = append(entries, entry)
+
+		var configSchema *JSONSchema
+		configSchema, err = loadSchema(filepath.Join(extensionsDir, ext.SourcePath, "config.schema.json"))
+		if err == nil {
+			entry.ConfigReferencePath = "/docs/reference/extensions#" + ext.Name
+			schemas[ext.Name] = configSchema
+			continue
+		}
+
+		if errors.Is(err, os.ErrNotExist) {
+			fmt.Printf("No config.schema.json found for extension %s, skipping\n", ext.Name)
+		} else {
+			return nil, fmt.Errorf("failed to load config schema for extension %s: %w", ext.Name, err)
+		}
+	}
+
+	index, err := json.MarshalIndent(entries, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal extension index: %w", err)
+	}
+	if err := os.WriteFile(path, index, 0o600); err != nil {
+		return nil, fmt.Errorf("failed to write extension index to %s: %w", path, err)
+	}
+	fmt.Printf("Generated: %s\n", path)
+	return schemas, nil
+}
+
+func loadSchema(schemaPath string) (*JSONSchema, error) {
 	schemaData, err := os.ReadFile(filepath.Clean(schemaPath))
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to read schema file: %v\n", err)
-		os.Exit(1)
+		return nil, fmt.Errorf("failed to read schema file: %w", err)
 	}
 
 	var schema JSONSchema
 	if err = json.Unmarshal(schemaData, &schema); err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to parse schema: %v\n", err)
-		os.Exit(1)
+		return nil, fmt.Errorf("failed to parse schema: %w", err)
 	}
+	return &schema, nil
+}
 
-	// Build required fields set
-	requiredSet := make(map[string]bool)
-	for _, r := range schema.Required {
-		requiredSet[r] = true
-	}
+func generateJSONSchemaReference(schemas map[string]*JSONSchema, outputPath string) error {
+	var data []TemplateData
 
-	// Convert schema properties to doc properties
-	var properties []DocProperty
-	for name, prop := range schema.Properties {
-		docProp := convertProperty(name, prop, requiredSet[name], schema.AllOf)
-		properties = append(properties, docProp)
-	}
+	sortedKeys := slices.Collect(maps.Keys(schemas))
+	sort.Strings(sortedKeys)
 
-	// Sort properties alphabetically
-	sort.Slice(properties, func(i, j int) bool {
-		return properties[i].Name < properties[j].Name
-	})
-
-	// Prepare template data
-	data := TemplateData{
-		Title:       schema.Title,
-		Description: schema.Description,
-		Properties:  properties,
+	for _, name := range sortedKeys {
+		data = append(data, convertSchema(name, name, schemas[name]))
 	}
 
 	// Load and execute template
@@ -193,51 +259,76 @@ func main() {
 		"title": titleCase.String,
 	}).ParseFS(templateFS, "templates/*.tmpl")
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to parse templates: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to parse templates: %w", err)
 	}
 
 	// Ensure output directory exists
 	if err = os.MkdirAll(filepath.Dir(outputPath), 0o750); err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to create output directory: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to create output directory: %w", err)
 	}
 
 	// Write output file
 	f, err := os.Create(filepath.Clean(outputPath))
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to create output file: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to create output file: %w", err)
 	}
+	defer func() { _ = f.Close() }()
 
 	if err = tmpl.ExecuteTemplate(f, "manifest.mdx.tmpl", data); err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to execute template: %v\n", err)
-		_ = f.Close()
-		os.Exit(1)
+		return fmt.Errorf("failed to execute template: %w", err)
 	}
-	_ = f.Close()
 
 	fmt.Printf("Generated: %s\n", outputPath)
-}
-
-func generateExtensionIndex(path string, extensionsDir string) error {
-	all, err := extensions.LoadManifests(os.DirFS(extensionsDir), ".", false)
-	if err != nil {
-		return fmt.Errorf("failed to load manifests from %s: %w", extensionsDir, err)
-	}
-	index, err := json.MarshalIndent(extensions.ManifestsIndex(all), "", "  ")
-	if err != nil {
-		return err
-	}
-	if err := os.WriteFile(path, index, 0o600); err != nil {
-		return err
-	}
-	fmt.Printf("Generated: %s\n", path)
 	return nil
 }
 
+// convertSchema converts a JSON schema to template data for documentation.
+func convertSchema(name, href string, schema *JSONSchema) TemplateData {
+	requiredSet := make(map[string]bool)
+	for _, r := range schema.Required {
+		requiredSet[r] = true
+	}
+
+	// Convert schema properties to doc properties
+	var properties []DocProperty
+	for propName, prop := range schema.Properties {
+		docProp := convertProperty(propName, prop, requiredSet[propName], schema.AllOf, name)
+		properties = append(properties, docProp)
+	}
+	// Sort properties alphabetically
+	sort.Slice(properties, func(i, j int) bool {
+		return properties[i].Name < properties[j].Name
+	})
+
+	customTypes := make([]TemplateData, 0, len(schema.Defs))
+	for typeName, def := range schema.Defs {
+		typeHref := fmt.Sprintf("%s-%s", name, typeName)
+		if def.Title == "" {
+			def.Title = typeName
+		}
+		customTypes = append(customTypes, convertSchema(name, typeHref, def))
+	}
+	// Sort custom types alphabetically
+	sort.Slice(customTypes, func(i, j int) bool {
+		return customTypes[i].Title < customTypes[j].Title
+	})
+
+	if schema.Title == "" {
+		schema.Title = name
+	}
+	return TemplateData{
+		Name:        name,
+		Href:        href,
+		Title:       schema.Title,
+		Description: schema.Description,
+		Properties:  properties,
+		OneOf:       collectOneOfOptions(schema.OneOf),
+		CustomTypes: customTypes,
+	}
+}
+
 // convertProperty converts a schema property to a documentation property.
-func convertProperty(name string, prop *Property, required bool, allOf []*ConditionalSchema) DocProperty {
+func convertProperty(name string, prop *Property, required bool, allOf []*ConditionalSchema, baseType string) DocProperty {
 	docProp := DocProperty{
 		Name:        name,
 		Description: prop.Description,
@@ -245,7 +336,7 @@ func convertProperty(name string, prop *Property, required bool, allOf []*Condit
 	}
 
 	// Determine type
-	docProp.Type = getTypeString(prop)
+	docProp.Type = getTypeString(prop, baseType)
 
 	// Build constraints
 	var constraints []Constraint
@@ -285,15 +376,7 @@ func convertProperty(name string, prop *Property, required bool, allOf []*Condit
 	}
 
 	// Handle oneOf constraints
-	if len(prop.OneOf) > 0 {
-		var oneOfOptions []string
-		for _, o := range prop.OneOf {
-			if len(o.Required) > 0 {
-				oneOfOptions = append(oneOfOptions, strings.Join(o.Required, ", "))
-			}
-		}
-		docProp.OneOf = oneOfOptions
-	}
+	docProp.OneOf = collectOneOfOptions(prop.OneOf)
 
 	// Check for conditional requirements in allOf
 	for _, cond := range allOf {
@@ -314,7 +397,7 @@ func convertProperty(name string, prop *Property, required bool, allOf []*Condit
 
 		var subProps []DocProperty
 		for subName, subProp := range prop.Properties {
-			subDocProp := convertProperty(subName, subProp, nestedRequired[subName], nil)
+			subDocProp := convertProperty(subName, subProp, nestedRequired[subName], nil, baseType)
 			subProps = append(subProps, subDocProp)
 		}
 		sort.Slice(subProps, func(i, j int) bool {
@@ -332,7 +415,7 @@ func convertProperty(name string, prop *Property, required bool, allOf []*Condit
 
 		var subProps []DocProperty
 		for subName, subProp := range prop.Items.Properties {
-			subDocProp := convertProperty(subName, subProp, nestedRequired[subName], nil)
+			subDocProp := convertProperty(subName, subProp, nestedRequired[subName], nil, baseType)
 			subProps = append(subProps, subDocProp)
 		}
 		sort.Slice(subProps, func(i, j int) bool {
@@ -342,6 +425,17 @@ func convertProperty(name string, prop *Property, required bool, allOf []*Condit
 	}
 
 	return docProp
+}
+
+// collectOneOfOptions collects the required fields from oneOf constraints for documentation.
+func collectOneOfOptions(oneOf []*OneOfItem) []string {
+	var options []string
+	for _, o := range oneOf {
+		if len(o.Required) > 0 {
+			options = append(options, strings.Join(o.Required, ", "))
+		}
+	}
+	return options
 }
 
 // conditionalConstraints returns constraints for a property based on a conditional allOf rule.
@@ -475,7 +569,7 @@ func describeNegatedCondition(cif *ConditionIf) string {
 }
 
 // getTypeString returns a human-readable type string from a property.
-func getTypeString(prop *Property) string {
+func getTypeString(prop *Property, baseType string) TypeRef {
 	typeStr := "unknown"
 
 	switch t := prop.Type.(type) {
@@ -492,14 +586,33 @@ func getTypeString(prop *Property) string {
 		typeStr = strings.Join(types, " | ")
 	}
 
+	ref := TypeRef{Name: typeStr}
+
 	// Handle arrays
 	if typeStr == "array" && prop.Items != nil {
-		if prop.Items.Type == "object" {
-			typeStr = "[]object"
-		} else if prop.Items.Type != "" {
-			typeStr = "[]" + prop.Items.Type
+		if prop.Items.Type != "" {
+			ref.Name = "[]" + prop.Items.Type
+		} else if prop.Items.Ref != "" {
+			name := referencedTypeName(prop.Items.Ref)
+			ref.Name = "[]" + name
+			ref.Href = fmt.Sprintf("#%s-%s", baseType, name)
 		}
 	}
 
-	return typeStr
+	// Handle custom types
+	if prop.Ref != "" {
+		name := referencedTypeName(prop.Ref)
+		ref.Name = name
+		ref.Href = fmt.Sprintf("#%s-%s", baseType, name)
+	}
+
+	return ref
+}
+
+// referencedTypeName extracts the type name from a $ref string, removing the "#/$defs/" prefix if present.
+func referencedTypeName(ref string) string {
+	if after, ok := strings.CutPrefix(ref, "#/$defs/"); ok {
+		return after
+	}
+	return ref
 }

--- a/cli/tools/gen-manifest-reference/templates/manifest.mdx.tmpl
+++ b/cli/tools/gen-manifest-reference/templates/manifest.mdx.tmpl
@@ -1,26 +1,37 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
-title: {{.Title}}
-description: {{.Description}}
+title: Schema Reference
+description: Schema Reference Documentation
 ---
 
 import ToC from '../../../components/ToC.astro';
 
-# {{.Title}}
-
-{{.Description}}
+# Schema Reference
 
 <ToC maxDepth="4"/>
 
+{{- range .}}
+
+{{ $parentTitle := .Title }}
+{{ $parentHref := .Href }}
+
+<a id="{{.Href}}"></a>
+## {{.Title}}
+
+{{.Description}}
+{{- if .OneOf}}
+**Requires one of:** {{range $i, $v := .OneOf}}{{if $i}}, {{end}}`{{$v}}`{{end}}s
+{{- end}}
+
 {{- range .Properties}}
 
-## {{.Name}}
+### {{.Name}}
 
 {{.Description}}
 
 | | |
 |---|---|
-| **Type** | `{{.Type}}` |
+| **Type** | {{if .Type.Href}}[{{.Type.Name}}]({{.Type.Href}}){{else}}`{{.Type.Name}}`{{end}} |
 | **Required** | {{if .Required}}Yes{{else}}No{{end}} |
 {{- if .EnumValues}}
 | **Allowed values** | {{range $i, $v := .EnumValues}}{{if $i}}, {{end}}`{{$v}}`{{end}} |
@@ -32,25 +43,70 @@ import ToC from '../../../components/ToC.astro';
 | **Requires one of** | {{range $i, $v := .OneOf}}{{if $i}}, {{end}}`{{$v}}`{{end}} |
 {{- end}}
 
+[↑ Top](#) | [↑ {{$parentTitle}}](#{{$parentHref}})
+
 {{- if .SubProperties}}
 {{ $prop := . }}
 {{range .SubProperties}}
 
-### {{$prop.Name}}.{{.Name}}
+#### {{$prop.Name}}.{{.Name}}
 
 {{.Description}}
 
 | | |
 |---|---|
-| **Type** | `{{.Type}}` |
+| **Type** | {{if .Type.Href}}[{{.Type.Name}}]({{.Type.Href}}){{else}}`{{.Type.Name}}`{{end}} |
 | **Required** | {{if .Required}}Yes{{else}}No{{end}} |
 {{- range .Constraints}}
 | **{{.Name}}** | {{.Value}} |
 {{- end}}
 {{- if .OneOf}}
-| **Reqiutes one of** | {{range $i, $v := .OneOf}}{{if $i}}, {{end}}`{{$v}}`{{end}} |
-{{- end}}
-{{end}}
+| **Requires one of** | {{range $i, $v := .OneOf}}{{if $i}}, {{end}}`{{$v}}`{{end}} |
 {{- end}}
 
-{{end}}
+[↑ Top](#) | [↑ {{$parentTitle}}](#{{$parentHref}})
+
+{{end}}   {/* range .SubProperties */}
+{{- end}} {/* if .SubProperties */}
+{{- end}} {/* range .Properties */}
+
+{{- if .CustomTypes}}
+{{ $parentTitle := .Title }}
+{{ $parentHref := .Href }}
+{{- range .CustomTypes}}
+
+<a id="{{.Href}}"></a>
+### Custom type: {{.Title}}
+
+{{.Description}}
+{{- if .OneOf}}
+**Requires one of:** {{range $i, $v := .OneOf}}{{if $i}}, {{end}}`{{$v}}`{{end}}
+{{- end}}
+
+{{- range .Properties}}
+
+#### {{.Name}}
+
+{{.Description}}
+
+| | |
+|---|---|
+| **Type** | {{if .Type.Href}}[{{.Type.Name}}]({{.Type.Href}}){{else}}`{{.Type.Name}}`{{end}} |
+| **Required** | {{if .Required}}Yes{{else}}No{{end}} |
+{{- if .EnumValues}}
+| **Allowed values** | {{range $i, $v := .EnumValues}}{{if $i}}, {{end}}`{{$v}}`{{end}} |
+{{- end}}
+{{- range .Constraints}}
+| **{{.Name}}** | {{.Value}} |
+{{- end}}
+{{- if .OneOf}}
+| **Requires one of** | {{range $i, $v := .OneOf}}{{if $i}}, {{end}}`{{$v}}`{{end}} |
+{{- end}}
+
+[↑ Top](#) | [↑ {{$parentTitle}}](#{{$parentHref}})
+
+{{- end}} {/* range .Properties */}
+{{- end}} {/* range .CustomTypes */}
+{{- end}} {/* if .CustomTypes */}
+
+{{- end}} {/* range . */}

--- a/website/public/extensions.json
+++ b/website/public/extensions.json
@@ -49,7 +49,8 @@
     "minEnvoyVersion": "1.38.0",
     "maxEnvoyVersion": "1.39.0",
     "composerVersion": "0.7.0-dev",
-    "sourcePath": "composer/anthropic-decoder"
+    "sourcePath": "composer/anthropic-decoder",
+    "configReferencePath": "/docs/reference/extensions#anthropic-messages-decoder"
   },
   {
     "name": "azure-content-safety",
@@ -114,7 +115,8 @@
     "minEnvoyVersion": "1.38.0",
     "maxEnvoyVersion": "1.39.0",
     "composerVersion": "0.7.0-dev",
-    "sourcePath": "composer/azure-content-safety"
+    "sourcePath": "composer/azure-content-safety",
+    "configReferencePath": "/docs/reference/extensions#azure-content-safety"
   },
   {
     "name": "bedrock-guardrails",
@@ -162,7 +164,8 @@
     "minEnvoyVersion": "1.38.0",
     "maxEnvoyVersion": "1.39.0",
     "composerVersion": "0.7.0-dev",
-    "sourcePath": "composer/bedrock-guardrails"
+    "sourcePath": "composer/bedrock-guardrails",
+    "configReferencePath": "/docs/reference/extensions#bedrock-guardrails"
   },
   {
     "name": "cedar-auth",
@@ -239,7 +242,8 @@
     "minEnvoyVersion": "1.38.0",
     "maxEnvoyVersion": "1.39.0",
     "composerVersion": "0.7.0-dev",
-    "sourcePath": "composer/cedar"
+    "sourcePath": "composer/cedar",
+    "configReferencePath": "/docs/reference/extensions#cedar-auth"
   },
   {
     "name": "chat-completions-decoder",
@@ -291,7 +295,8 @@
     "minEnvoyVersion": "1.38.0",
     "maxEnvoyVersion": "1.39.0",
     "composerVersion": "0.7.0-dev",
-    "sourcePath": "composer/chat-completions-decoder"
+    "sourcePath": "composer/chat-completions-decoder",
+    "configReferencePath": "/docs/reference/extensions#chat-completions-decoder"
   },
   {
     "name": "coraza-waf",
@@ -332,7 +337,8 @@
     "minEnvoyVersion": "1.38.0",
     "maxEnvoyVersion": "1.39.0",
     "composerVersion": "0.7.0-dev",
-    "sourcePath": "composer/waf"
+    "sourcePath": "composer/waf",
+    "configReferencePath": "/docs/reference/extensions#coraza-waf"
   },
   {
     "name": "example-ext-proc",
@@ -473,7 +479,8 @@
     "minEnvoyVersion": "1.38.0",
     "maxEnvoyVersion": "1.39.0",
     "composerVersion": "0.7.0-dev",
-    "sourcePath": "composer/file-server"
+    "sourcePath": "composer/file-server",
+    "configReferencePath": "/docs/reference/extensions#file-server"
   },
   {
     "name": "ip-restriction",
@@ -520,7 +527,8 @@
     ],
     "minEnvoyVersion": "1.37.1",
     "maxEnvoyVersion": "1.38.0",
-    "sourcePath": "ip-restriction"
+    "sourcePath": "ip-restriction",
+    "configReferencePath": "/docs/reference/extensions#ip-restriction"
   },
   {
     "name": "jwe-decrypt",
@@ -579,7 +587,8 @@
     "minEnvoyVersion": "1.38.0",
     "maxEnvoyVersion": "1.39.0",
     "composerVersion": "0.7.0-dev",
-    "sourcePath": "composer/jwe-decrypt"
+    "sourcePath": "composer/jwe-decrypt",
+    "configReferencePath": "/docs/reference/extensions#jwe-decrypt"
   },
   {
     "name": "llm-proxy",
@@ -630,7 +639,8 @@
     "minEnvoyVersion": "1.38.0",
     "maxEnvoyVersion": "1.39.0",
     "composerVersion": "0.7.0-dev",
-    "sourcePath": "composer/llm-proxy"
+    "sourcePath": "composer/llm-proxy",
+    "configReferencePath": "/docs/reference/extensions#llm-proxy"
   },
   {
     "name": "opa",
@@ -707,7 +717,8 @@
     "minEnvoyVersion": "1.38.0",
     "maxEnvoyVersion": "1.39.0",
     "composerVersion": "0.7.0-dev",
-    "sourcePath": "composer/opa"
+    "sourcePath": "composer/opa",
+    "configReferencePath": "/docs/reference/extensions#opa"
   },
   {
     "name": "openapi-validator",
@@ -757,7 +768,8 @@
     "minEnvoyVersion": "1.38.0",
     "maxEnvoyVersion": "1.39.0",
     "composerVersion": "0.7.0-dev",
-    "sourcePath": "composer/openapi-validator"
+    "sourcePath": "composer/openapi-validator",
+    "configReferencePath": "/docs/reference/extensions#openapi-validator"
   },
   {
     "name": "openfga",
@@ -827,7 +839,8 @@
     "minEnvoyVersion": "1.38.0",
     "maxEnvoyVersion": "1.39.0",
     "composerVersion": "0.7.0-dev",
-    "sourcePath": "composer/openfga"
+    "sourcePath": "composer/openfga",
+    "configReferencePath": "/docs/reference/extensions#openfga"
   },
   {
     "name": "saml",
@@ -883,7 +896,8 @@
     "minEnvoyVersion": "1.38.0",
     "maxEnvoyVersion": "1.39.0",
     "composerVersion": "0.7.0-dev",
-    "sourcePath": "composer/saml"
+    "sourcePath": "composer/saml",
+    "configReferencePath": "/docs/reference/extensions#saml"
   },
   {
     "name": "token-exchange",
@@ -918,6 +932,7 @@
     "minEnvoyVersion": "1.38.0",
     "maxEnvoyVersion": "1.39.0",
     "composerVersion": "0.7.0-dev",
-    "sourcePath": "composer/token-exchange"
+    "sourcePath": "composer/token-exchange",
+    "configReferencePath": "/docs/reference/extensions#token-exchange"
   }
 ]

--- a/website/src/components/Sidebar.astro
+++ b/website/src/components/Sidebar.astro
@@ -27,6 +27,7 @@ for (const yamlPath of yamlPaths) {
 		{allSections.map((section: any) => (
 			<SidebarSection title={section.title} items={section.items} />
 		))}
+		<br/>
 	</nav>
 </aside>
 

--- a/website/src/components/ToC.astro
+++ b/website/src/components/ToC.astro
@@ -55,7 +55,7 @@ const { minDepth = 2, maxDepth = 3 } = Astro.props;
         let text = heading.textContent || '';
         text = text.substring(text.lastIndexOf('.') + 1);
         // Capitalize the text
-        link.textContent = text.charAt(0).toUpperCase() + text.slice(1);
+        link.textContent = text
 
         li.appendChild(link);
         list.appendChild(li);

--- a/website/src/layouts/DocsLayout.astro
+++ b/website/src/layouts/DocsLayout.astro
@@ -33,7 +33,8 @@ const description = frontmatter?.description ?? Astro.props.description;
 		<div class="docs-container">
 			<Sidebar yamlPaths={[
 				"src/pages/docs/sidebar-static.yaml",
-				"src/pages/docs/sidebar-cli.yaml"
+				"src/pages/docs/sidebar-cli.yaml",
+				"src/pages/docs/sidebar-extensions.yaml"
 			]} />
 
 			<main class="docs-main">

--- a/website/src/pages/docs/reference/extensions.mdx
+++ b/website/src/pages/docs/reference/extensions.mdx
@@ -1,0 +1,1986 @@
+---
+layout: ../../../layouts/DocsLayout.astro
+title: Schema Reference
+description: Schema Reference Documentation
+---
+
+import ToC from '../../../components/ToC.astro';
+
+# Schema Reference
+
+<ToC maxDepth="4"/>
+
+
+
+
+<a id="anthropic-messages-decoder"></a>
+## Anthropic Messages Decoder Configuration
+
+Configuration for the Anthropic Messages Decoder extension. Decodes Anthropic Messages API requests and responses, exposing structured metadata for downstream filters.
+
+### metadata_namespace
+
+Filter metadata namespace for decoded fields. Defaults to "io.builtonenvoy.anthropic" if not set.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ Anthropic Messages Decoder Configuration](#anthropic-messages-decoder) {/* if .SubProperties */} {/* range .Properties */} {/* if .CustomTypes */}
+
+
+
+
+<a id="azure-content-safety"></a>
+## Azure Content Safety Configuration
+
+Configuration for the Azure AI Content Safety extension. Integrates with Azure Content Safety to analyze LLM prompts and responses for harmful content.
+
+### api_key
+
+API subscription key for the Azure Content Safety resource.
+
+| | |
+|---|---|
+| **Type** | [DataSource](#azure-content-safety-DataSource) |
+| **Required** | Yes |
+
+[↑ Top](#) | [↑ Azure Content Safety Configuration](#azure-content-safety) {/* if .SubProperties */}
+
+### api_version
+
+Azure API version string. Defaults to "2024-09-01".
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ Azure Content Safety Configuration](#azure-content-safety) {/* if .SubProperties */}
+
+### categories
+
+Content categories to analyze. Defaults to ["Hate", "SelfHarm", "Sexual", "Violence"].
+
+| | |
+|---|---|
+| **Type** | `[]string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ Azure Content Safety Configuration](#azure-content-safety) {/* if .SubProperties */}
+
+### enable_protected_material
+
+Enable protected material detection on responses. Defaults to false.
+
+| | |
+|---|---|
+| **Type** | `boolean` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ Azure Content Safety Configuration](#azure-content-safety) {/* if .SubProperties */}
+
+### enable_task_adherence
+
+Enable task adherence detection on requests. Defaults to false.
+
+| | |
+|---|---|
+| **Type** | `boolean` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ Azure Content Safety Configuration](#azure-content-safety) {/* if .SubProperties */}
+
+### endpoint
+
+Azure Content Safety resource endpoint URL (e.g. "https://my-resource.cognitiveservices.azure.com").
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | Yes |
+
+[↑ Top](#) | [↑ Azure Content Safety Configuration](#azure-content-safety) {/* if .SubProperties */}
+
+### fail_open
+
+If true, allow traffic when the Azure API returns an error. Defaults to false.
+
+| | |
+|---|---|
+| **Type** | `boolean` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ Azure Content Safety Configuration](#azure-content-safety) {/* if .SubProperties */}
+
+### hate_threshold
+
+Severity threshold for hate content (0-6). Content at or above this level is flagged. Defaults to 2.
+
+| | |
+|---|---|
+| **Type** | `integer` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ Azure Content Safety Configuration](#azure-content-safety) {/* if .SubProperties */}
+
+### mode
+
+Operating mode. "block" rejects harmful content, "monitor" logs but allows it. Defaults to "block".
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+| **Allowed values** | `block`, `monitor` |
+
+[↑ Top](#) | [↑ Azure Content Safety Configuration](#azure-content-safety) {/* if .SubProperties */}
+
+### self_harm_threshold
+
+Severity threshold for self-harm content (0-6). Content at or above this level is flagged. Defaults to 2.
+
+| | |
+|---|---|
+| **Type** | `integer` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ Azure Content Safety Configuration](#azure-content-safety) {/* if .SubProperties */}
+
+### sexual_threshold
+
+Severity threshold for sexual content (0-6). Content at or above this level is flagged. Defaults to 2.
+
+| | |
+|---|---|
+| **Type** | `integer` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ Azure Content Safety Configuration](#azure-content-safety) {/* if .SubProperties */}
+
+### task_adherence_api_version
+
+Azure API version for the task adherence endpoint. Defaults to "2025-09-15-preview".
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ Azure Content Safety Configuration](#azure-content-safety) {/* if .SubProperties */}
+
+### violence_threshold
+
+Severity threshold for violence content (0-6). Content at or above this level is flagged. Defaults to 2.
+
+| | |
+|---|---|
+| **Type** | `integer` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ Azure Content Safety Configuration](#azure-content-safety) {/* if .SubProperties */} {/* range .Properties */}
+
+
+
+<a id="azure-content-safety-DataSource"></a>
+### Custom type: DataSource
+
+A data source provided either inline or as a file path. Exactly one must be set.
+**Requires one of:** `inline`, `file`
+
+#### file
+
+Path to a file containing the data.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ Azure Content Safety Configuration](#azure-content-safety)
+
+#### inline
+
+Data provided directly as a string.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ Azure Content Safety Configuration](#azure-content-safety) {/* range .Properties */} {/* range .CustomTypes */} {/* if .CustomTypes */}
+
+
+
+
+<a id="bedrock-guardrails"></a>
+## Bedrock Guardrails Configuration
+
+Configuration for the AWS Bedrock Guardrails extension. Applies Bedrock Guardrails to evaluate LLM prompts for content moderation.
+
+### bedrock_api_key
+
+API key for AWS Bedrock authentication.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | Yes |
+
+[↑ Top](#) | [↑ Bedrock Guardrails Configuration](#bedrock-guardrails) {/* if .SubProperties */}
+
+### bedrock_cluster
+
+Envoy cluster name configured to reach the Bedrock endpoint.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | Yes |
+
+[↑ Top](#) | [↑ Bedrock Guardrails Configuration](#bedrock-guardrails) {/* if .SubProperties */}
+
+### bedrock_endpoint
+
+AWS Bedrock API endpoint URL (e.g. "https://bedrock-runtime.us-east-1.amazonaws.com").
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | Yes |
+
+[↑ Top](#) | [↑ Bedrock Guardrails Configuration](#bedrock-guardrails) {/* if .SubProperties */}
+
+### bedrock_guardrails
+
+List of Bedrock guardrails to apply. Duplicate identifiers are removed automatically.
+
+| | |
+|---|---|
+| **Type** | `[]object` |
+| **Required** | Yes |
+| **Min items** | 1 |
+
+[↑ Top](#) | [↑ Bedrock Guardrails Configuration](#bedrock-guardrails)
+
+
+
+#### bedrock_guardrails.identifier
+
+Unique guardrail identifier.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | Yes |
+
+[↑ Top](#) | [↑ Bedrock Guardrails Configuration](#bedrock-guardrails)
+
+
+
+#### bedrock_guardrails.version
+
+Guardrail version to apply.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | Yes |
+
+[↑ Top](#) | [↑ Bedrock Guardrails Configuration](#bedrock-guardrails)
+
+   {/* range .SubProperties */} {/* if .SubProperties */}
+
+### bedrock_timeoutms
+
+API request timeout in milliseconds. Defaults to 20000 (20 seconds).
+
+| | |
+|---|---|
+| **Type** | `integer` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ Bedrock Guardrails Configuration](#bedrock-guardrails) {/* if .SubProperties */} {/* range .Properties */} {/* if .CustomTypes */}
+
+
+
+
+<a id="cedar-auth"></a>
+## Cedar Authorization Configuration
+
+Configuration for the Cedar authorization extension. Evaluates Cedar policies inline to authorize HTTP requests.
+
+### action_type
+
+Cedar entity type for actions. Defaults to "Action".
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ Cedar Authorization Configuration](#cedar-auth) {/* if .SubProperties */}
+
+### deny_body
+
+Response body returned when a request is denied. Defaults to "Forbidden".
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ Cedar Authorization Configuration](#cedar-auth) {/* if .SubProperties */}
+
+### deny_headers
+
+Additional headers to include in deny responses.
+
+| | |
+|---|---|
+| **Type** | `object` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ Cedar Authorization Configuration](#cedar-auth) {/* if .SubProperties */}
+
+### deny_status
+
+HTTP status code returned when a request is denied. Defaults to 403.
+
+| | |
+|---|---|
+| **Type** | `integer` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ Cedar Authorization Configuration](#cedar-auth) {/* if .SubProperties */}
+
+### dry_run
+
+If true, log authorization decisions without enforcing them. Defaults to false.
+
+| | |
+|---|---|
+| **Type** | `boolean` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ Cedar Authorization Configuration](#cedar-auth) {/* if .SubProperties */}
+
+### entities_file
+
+Path to a JSON file containing Cedar entities for hierarchy support.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ Cedar Authorization Configuration](#cedar-auth) {/* if .SubProperties */}
+
+### fail_open
+
+If true, allow requests when policy evaluation fails. Defaults to false.
+
+| | |
+|---|---|
+| **Type** | `boolean` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ Cedar Authorization Configuration](#cedar-auth) {/* if .SubProperties */}
+
+### metadata_namespaces
+
+List of dynamic metadata namespaces to include in the Cedar context record under the "dynamic_metadata" key.
+
+| | |
+|---|---|
+| **Type** | `[]string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ Cedar Authorization Configuration](#cedar-auth) {/* if .SubProperties */}
+
+### policy
+
+Cedar policy set to evaluate.
+
+| | |
+|---|---|
+| **Type** | [DataSource](#cedar-auth-DataSource) |
+| **Required** | Yes |
+
+[↑ Top](#) | [↑ Cedar Authorization Configuration](#cedar-auth) {/* if .SubProperties */}
+
+### principal_id_header
+
+Request header from which to extract the principal ID.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | Yes |
+
+[↑ Top](#) | [↑ Cedar Authorization Configuration](#cedar-auth) {/* if .SubProperties */}
+
+### principal_type
+
+Cedar entity type for the principal (e.g. "User").
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | Yes |
+
+[↑ Top](#) | [↑ Cedar Authorization Configuration](#cedar-auth) {/* if .SubProperties */}
+
+### resource_type
+
+Cedar entity type for resources. Defaults to "Resource".
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ Cedar Authorization Configuration](#cedar-auth) {/* if .SubProperties */} {/* range .Properties */}
+
+
+
+<a id="cedar-auth-DataSource"></a>
+### Custom type: DataSource
+
+A data source provided either inline or as a file path. Exactly one must be set.
+**Requires one of:** `inline`, `file`
+
+#### file
+
+Path to a file containing the data.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ Cedar Authorization Configuration](#cedar-auth)
+
+#### inline
+
+Data provided directly as a string.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ Cedar Authorization Configuration](#cedar-auth) {/* range .Properties */} {/* range .CustomTypes */} {/* if .CustomTypes */}
+
+
+
+
+<a id="chat-completions-decoder"></a>
+## Chat Completions Decoder Configuration
+
+Configuration for the Chat Completions Decoder extension. Decodes OpenAI Chat Completion requests and responses, exposing structured metadata for downstream filters.
+
+### metadata_namespace
+
+Filter metadata namespace for decoded fields. Defaults to "io.builtonenvoy.openai" if not set.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ Chat Completions Decoder Configuration](#chat-completions-decoder) {/* if .SubProperties */} {/* range .Properties */} {/* if .CustomTypes */}
+
+
+
+
+<a id="coraza-waf"></a>
+## Coraza WAF Configuration
+
+Configuration for the Coraza WAF extension. Provides Web Application Firewall protection using SecLang directives.
+
+### directives
+
+List of Coraza SecLang directives. Each entry is a single directive string. Special includes are supported: "Include @recommended.conf", "Include @crs-setup.conf", "Include @owasp_crs/*.conf".
+
+| | |
+|---|---|
+| **Type** | `[]string` |
+| **Required** | Yes |
+| **Min items** | 1 |
+| **Item min length** | 1 |
+
+[↑ Top](#) | [↑ Coraza WAF Configuration](#coraza-waf) {/* if .SubProperties */}
+
+### mode
+
+WAF inspection mode. Defaults to "REQUEST_ONLY" if not set.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+| **Allowed values** | `REQUEST_ONLY`, `RESPONSE_ONLY`, `FULL` |
+
+[↑ Top](#) | [↑ Coraza WAF Configuration](#coraza-waf) {/* if .SubProperties */} {/* range .Properties */} {/* if .CustomTypes */}
+
+
+
+
+<a id="file-server"></a>
+## File Server Configuration
+
+Configuration for the File Server extension. Serves static files from the local filesystem through Envoy.
+
+### content_types
+
+Custom file extension to content-type mappings. Keys are file suffixes without dots (e.g. "html", "css").
+
+| | |
+|---|---|
+| **Type** | `object` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ File Server Configuration](#file-server) {/* if .SubProperties */}
+
+### default_content_type
+
+Default content-type when the file extension is not found in content_types.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ File Server Configuration](#file-server) {/* if .SubProperties */}
+
+### directory_index_files
+
+Files to serve for directory requests (e.g. ["index.html"]). File names must not contain slashes.
+
+| | |
+|---|---|
+| **Type** | `[]string` |
+| **Required** | No |
+| **Item pattern** | `^[^/]*$` |
+
+[↑ Top](#) | [↑ File Server Configuration](#file-server) {/* if .SubProperties */}
+
+### path_mappings
+
+Mappings from URL path prefixes to filesystem path prefixes. At least one mapping is required. Duplicate request path prefixes are not allowed.
+
+| | |
+|---|---|
+| **Type** | `[]object` |
+| **Required** | Yes |
+| **Min items** | 1 |
+
+[↑ Top](#) | [↑ File Server Configuration](#file-server)
+
+
+
+#### path_mappings.file_path_prefix
+
+Filesystem path prefix to map to (e.g. "/var/www/").
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | Yes |
+| **Min length** | 1 |
+
+[↑ Top](#) | [↑ File Server Configuration](#file-server)
+
+
+
+#### path_mappings.request_path_prefix
+
+URL path prefix to match (e.g. "/static/").
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | Yes |
+| **Min length** | 1 |
+
+[↑ Top](#) | [↑ File Server Configuration](#file-server)
+
+   {/* range .SubProperties */} {/* if .SubProperties */} {/* range .Properties */} {/* if .CustomTypes */}
+
+
+
+
+<a id="ip-restriction"></a>
+## IP Restriction Configuration
+
+Configuration for the IP Restriction extension. Controls access based on IP allowlists or denylists. Exactly one of allow_addresses or deny_addresses must be provided.
+**Requires one of:** `allow_addresses`, `deny_addresses`s
+
+### allow_addresses
+
+IP addresses or CIDR ranges to allow. When set, only requests from these addresses are permitted.
+
+| | |
+|---|---|
+| **Type** | `[]string` |
+| **Required** | No |
+| **Unique items** | Yes |
+
+[↑ Top](#) | [↑ IP Restriction Configuration](#ip-restriction) {/* if .SubProperties */}
+
+### deny_addresses
+
+IP addresses or CIDR ranges to deny. When set, requests from these addresses are blocked with 403 Forbidden.
+
+| | |
+|---|---|
+| **Type** | `[]string` |
+| **Required** | No |
+| **Unique items** | Yes |
+
+[↑ Top](#) | [↑ IP Restriction Configuration](#ip-restriction) {/* if .SubProperties */} {/* range .Properties */} {/* if .CustomTypes */}
+
+
+
+
+<a id="jwe-decrypt"></a>
+## JWE Decrypt Configuration
+
+Configuration for the JWE Decrypt extension. Decrypts JWE tokens and recovers the inner JWT for Envoy to process.
+
+### algorithm
+
+JWE key management algorithm (e.g. "RSA-OAEP", "A256KW", "dir").
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | Yes |
+
+[↑ Top](#) | [↑ JWE Decrypt Configuration](#jwe-decrypt) {/* if .SubProperties */}
+
+### input_header
+
+Request header containing the JWE token. Defaults to "Authorization".
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ JWE Decrypt Configuration](#jwe-decrypt) {/* if .SubProperties */}
+
+### output_header
+
+Request header where the decrypted JWT payload is placed.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ JWE Decrypt Configuration](#jwe-decrypt) {/* if .SubProperties */}
+
+### output_metadata
+
+Envoy dynamic metadata location for the decrypted JWT payload. Namespace defaults to "jwe-decrypt".
+
+| | |
+|---|---|
+| **Type** | [MetadataKey](#jwe-decrypt-MetadataKey) |
+| **Required** | No |
+
+[↑ Top](#) | [↑ JWE Decrypt Configuration](#jwe-decrypt) {/* if .SubProperties */}
+
+### prefix
+
+Prefix to strip from the header value before decryption (e.g. "Bearer ").
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ JWE Decrypt Configuration](#jwe-decrypt) {/* if .SubProperties */}
+
+### private_key
+
+PKCS8 private key used for JWE decryption.
+
+| | |
+|---|---|
+| **Type** | [DataSource](#jwe-decrypt-DataSource) |
+| **Required** | Yes |
+
+[↑ Top](#) | [↑ JWE Decrypt Configuration](#jwe-decrypt) {/* if .SubProperties */} {/* range .Properties */}
+
+
+
+<a id="jwe-decrypt-DataSource"></a>
+### Custom type: DataSource
+
+A data source provided either inline or as a file path. Exactly one must be set.
+**Requires one of:** `inline`, `file`
+
+#### file
+
+Path to a file containing the data.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ JWE Decrypt Configuration](#jwe-decrypt)
+
+#### inline
+
+Data provided directly as a string.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ JWE Decrypt Configuration](#jwe-decrypt) {/* range .Properties */}
+
+<a id="jwe-decrypt-MetadataKey"></a>
+### Custom type: MetadataKey
+
+Identifies a location in Envoy dynamic metadata.
+
+#### key
+
+Key within the namespace.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | Yes |
+
+[↑ Top](#) | [↑ JWE Decrypt Configuration](#jwe-decrypt)
+
+#### namespace
+
+Filter-state namespace for the metadata entry.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ JWE Decrypt Configuration](#jwe-decrypt) {/* range .Properties */} {/* range .CustomTypes */} {/* if .CustomTypes */}
+
+
+
+
+<a id="llm-proxy"></a>
+## LLM Proxy Configuration
+
+Configuration for the LLM Proxy extension. Routes LLM API requests by model name and monitors token usage via Envoy metadata.
+
+### clear_route_cache
+
+Clear Envoy route cache after setting metadata, enabling route re-selection. Defaults to false.
+
+| | |
+|---|---|
+| **Type** | `boolean` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ LLM Proxy Configuration](#llm-proxy) {/* if .SubProperties */}
+
+### llm_configs
+
+Path-matcher rules mapping request paths to LLM API kinds. If empty, default rules for OpenAI and Anthropic are auto-configured.
+
+| | |
+|---|---|
+| **Type** | `[]object` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ LLM Proxy Configuration](#llm-proxy)
+
+
+
+#### llm_configs.kind
+
+LLM API kind for matched requests.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | Yes |
+
+[↑ Top](#) | [↑ LLM Proxy Configuration](#llm-proxy)
+
+
+
+#### llm_configs.matcher
+
+Path matcher for this rule.
+
+| | |
+|---|---|
+| **Type** | [StringMatcher](#llm-proxy-StringMatcher) |
+| **Required** | Yes |
+
+[↑ Top](#) | [↑ LLM Proxy Configuration](#llm-proxy)
+
+   {/* range .SubProperties */} {/* if .SubProperties */}
+
+### llm_model_header
+
+Request header to set with the extracted model name.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ LLM Proxy Configuration](#llm-proxy) {/* if .SubProperties */}
+
+### metadata_namespace
+
+Filter metadata namespace for LLM proxy data. Defaults to "io.builtonenvoy.llm-proxy".
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ LLM Proxy Configuration](#llm-proxy) {/* if .SubProperties */} {/* range .Properties */}
+
+
+
+<a id="llm-proxy-StringMatcher"></a>
+### Custom type: StringMatcher
+
+Matches a string by prefix, suffix, or regex. Exactly one must be set.
+**Requires one of:** `prefix`, `suffix`, `regex`
+
+#### prefix
+
+Match strings starting with this value.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ LLM Proxy Configuration](#llm-proxy)
+
+#### regex
+
+Match strings satisfying this regular expression.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ LLM Proxy Configuration](#llm-proxy)
+
+#### suffix
+
+Match strings ending with this value.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ LLM Proxy Configuration](#llm-proxy) {/* range .Properties */} {/* range .CustomTypes */} {/* if .CustomTypes */}
+
+
+
+
+<a id="opa"></a>
+## OPA Authorization Configuration
+
+Configuration for the OPA authorization extension. Evaluates Open Policy Agent policies inline to authorize HTTP requests.
+
+### decision_path
+
+OPA rule path to query for the authorization decision. Defaults to "envoy.authz.allow".
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ OPA Authorization Configuration](#opa) {/* if .SubProperties */}
+
+### dry_run
+
+If true, log authorization decisions without enforcing them. Defaults to false.
+
+| | |
+|---|---|
+| **Type** | `boolean` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ OPA Authorization Configuration](#opa) {/* if .SubProperties */}
+
+### fail_open
+
+If true, allow requests when policy evaluation fails. Defaults to false.
+
+| | |
+|---|---|
+| **Type** | `boolean` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ OPA Authorization Configuration](#opa) {/* if .SubProperties */}
+
+### metadata_namespaces
+
+List of dynamic metadata namespaces to include in the OPA input document under the "dynamic_metadata" key.
+
+| | |
+|---|---|
+| **Type** | `[]string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ OPA Authorization Configuration](#opa) {/* if .SubProperties */}
+
+### policies
+
+OPA policies to load and evaluate. At least one policy is required.
+
+| | |
+|---|---|
+| **Type** | [[]DataSource](#opa-DataSource) |
+| **Required** | Yes |
+| **Min items** | 1 |
+
+[↑ Top](#) | [↑ OPA Authorization Configuration](#opa) {/* if .SubProperties */}
+
+### with_body
+
+If true, buffer the request body and include it as parsed JSON in the OPA input. Defaults to false.
+
+| | |
+|---|---|
+| **Type** | `boolean` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ OPA Authorization Configuration](#opa) {/* if .SubProperties */} {/* range .Properties */}
+
+
+
+<a id="opa-DataSource"></a>
+### Custom type: DataSource
+
+A data source provided either inline or as a file path. Exactly one must be set.
+**Requires one of:** `inline`, `file`
+
+#### file
+
+Path to a file containing the data.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ OPA Authorization Configuration](#opa)
+
+#### inline
+
+Data provided directly as a string.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ OPA Authorization Configuration](#opa) {/* range .Properties */} {/* range .CustomTypes */} {/* if .CustomTypes */}
+
+
+
+
+<a id="openapi-validator"></a>
+## OpenAPI Validator Configuration
+
+Configuration for the OpenAPI Validator extension. Validates HTTP requests against an OpenAPI specification.
+
+### allow_unmatched_paths
+
+If true, allow requests to paths not defined in the spec. Defaults to false.
+
+| | |
+|---|---|
+| **Type** | `boolean` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ OpenAPI Validator Configuration](#openapi-validator) {/* if .SubProperties */}
+
+### deny_response
+
+Custom response returned when validation fails.
+
+| | |
+|---|---|
+| **Type** | [LocalResponse](#openapi-validator-LocalResponse) |
+| **Required** | No |
+
+[↑ Top](#) | [↑ OpenAPI Validator Configuration](#openapi-validator) {/* if .SubProperties */}
+
+### dry_run
+
+If true, log validation failures without rejecting requests. Defaults to false.
+
+| | |
+|---|---|
+| **Type** | `boolean` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ OpenAPI Validator Configuration](#openapi-validator) {/* if .SubProperties */}
+
+### max_body_bytes
+
+Maximum request body size in bytes for validation. 0 means no limit. Defaults to 0.
+
+| | |
+|---|---|
+| **Type** | `integer` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ OpenAPI Validator Configuration](#openapi-validator) {/* if .SubProperties */}
+
+### spec
+
+OpenAPI specification in YAML or JSON format.
+
+| | |
+|---|---|
+| **Type** | [DataSource](#openapi-validator-DataSource) |
+| **Required** | Yes |
+
+[↑ Top](#) | [↑ OpenAPI Validator Configuration](#openapi-validator) {/* if .SubProperties */} {/* range .Properties */}
+
+
+
+<a id="openapi-validator-DataSource"></a>
+### Custom type: DataSource
+
+A data source provided either inline or as a file path. Exactly one must be set.
+**Requires one of:** `inline`, `file`
+
+#### file
+
+Path to a file containing the data.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ OpenAPI Validator Configuration](#openapi-validator)
+
+#### inline
+
+Data provided directly as a string.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ OpenAPI Validator Configuration](#openapi-validator) {/* range .Properties */}
+
+<a id="openapi-validator-LocalResponse"></a>
+### Custom type: LocalResponse
+
+Custom local HTTP response to send to the client.
+
+#### body
+
+Response body.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ OpenAPI Validator Configuration](#openapi-validator)
+
+#### headers
+
+Additional response headers.
+
+| | |
+|---|---|
+| **Type** | `object` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ OpenAPI Validator Configuration](#openapi-validator)
+
+#### status
+
+HTTP status code.
+
+| | |
+|---|---|
+| **Type** | `integer` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ OpenAPI Validator Configuration](#openapi-validator) {/* range .Properties */} {/* range .CustomTypes */} {/* if .CustomTypes */}
+
+
+
+
+<a id="openfga"></a>
+## OpenFGA Authorization Configuration
+
+Configuration for the OpenFGA authorization extension. Checks authorization via the OpenFGA Check API through Envoy's async HTTP callout mechanism.
+
+### authorization_model_id
+
+OpenFGA authorization model ID. Uses the store's latest model if omitted.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ OpenFGA Authorization Configuration](#openfga) {/* if .SubProperties */}
+
+### callout_headers
+
+Additional headers to include in callouts to OpenFGA (e.g. Authorization).
+
+| | |
+|---|---|
+| **Type** | `object` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ OpenFGA Authorization Configuration](#openfga) {/* if .SubProperties */}
+
+### cluster
+
+Envoy cluster name routing to the OpenFGA server.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | Yes |
+
+[↑ Top](#) | [↑ OpenFGA Authorization Configuration](#openfga) {/* if .SubProperties */}
+
+### consistency
+
+OpenFGA Check consistency preference.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+| **Allowed values** | `UNSPECIFIED`, `MINIMIZE_LATENCY`, `HIGHER_CONSISTENCY` |
+
+[↑ Top](#) | [↑ OpenFGA Authorization Configuration](#openfga) {/* if .SubProperties */}
+
+### context
+
+ABAC condition context values. Maps field names to ValueSource objects. Fields that resolve to an empty value are omitted.
+
+| | |
+|---|---|
+| **Type** | `object` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ OpenFGA Authorization Configuration](#openfga) {/* if .SubProperties */}
+
+### contextual_tuples
+
+Contextual tuples included in the Check request for request-scoped relationships. Tuples with unresolvable fields are silently skipped.
+
+| | |
+|---|---|
+| **Type** | [[]ContextualTuple](#openfga-ContextualTuple) |
+| **Required** | No |
+
+[↑ Top](#) | [↑ OpenFGA Authorization Configuration](#openfga) {/* if .SubProperties */}
+
+### deny_body
+
+Response body for denied requests. Defaults to 'Forbidden'.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ OpenFGA Authorization Configuration](#openfga) {/* if .SubProperties */}
+
+### deny_status
+
+HTTP status code for denied requests. Defaults to 403.
+
+| | |
+|---|---|
+| **Type** | `integer` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ OpenFGA Authorization Configuration](#openfga) {/* if .SubProperties */}
+
+### dry_run
+
+Log authorization decisions without enforcing them. Defaults to false.
+
+| | |
+|---|---|
+| **Type** | `boolean` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ OpenFGA Authorization Configuration](#openfga) {/* if .SubProperties */}
+
+### fail_open
+
+Allow requests when the filter cannot enforce a decision. Defaults to false.
+
+| | |
+|---|---|
+| **Type** | `boolean` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ OpenFGA Authorization Configuration](#openfga) {/* if .SubProperties */}
+
+### metadata
+
+When set, writes the authorization decision to dynamic metadata for downstream filters.
+
+| | |
+|---|---|
+| **Type** | [MetadataKey](#openfga-MetadataKey) |
+| **Required** | No |
+
+[↑ Top](#) | [↑ OpenFGA Authorization Configuration](#openfga) {/* if .SubProperties */}
+
+### object
+
+How to extract the object for the Check call. Required when not using rules.
+
+| | |
+|---|---|
+| **Type** | [ValueSource](#openfga-ValueSource) |
+| **Required** | No |
+
+[↑ Top](#) | [↑ OpenFGA Authorization Configuration](#openfga) {/* if .SubProperties */}
+
+### openfga_host
+
+Hostname for the Host header in callouts to OpenFGA.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | Yes |
+
+[↑ Top](#) | [↑ OpenFGA Authorization Configuration](#openfga) {/* if .SubProperties */}
+
+### relation
+
+How to extract the relation for the Check call. Required when not using rules.
+
+| | |
+|---|---|
+| **Type** | [ValueSource](#openfga-ValueSource) |
+| **Required** | No |
+
+[↑ Top](#) | [↑ OpenFGA Authorization Configuration](#openfga) {/* if .SubProperties */}
+
+### rules
+
+Multi-rule config evaluated in order; first match wins. A rule with no match is a catch-all and must be last.
+
+| | |
+|---|---|
+| **Type** | [[]CheckRule](#openfga-CheckRule) |
+| **Required** | No |
+
+[↑ Top](#) | [↑ OpenFGA Authorization Configuration](#openfga) {/* if .SubProperties */}
+
+### store_id
+
+OpenFGA store ID.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | Yes |
+
+[↑ Top](#) | [↑ OpenFGA Authorization Configuration](#openfga) {/* if .SubProperties */}
+
+### timeout_ms
+
+HTTP callout timeout in milliseconds. Defaults to 5000.
+
+| | |
+|---|---|
+| **Type** | `integer` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ OpenFGA Authorization Configuration](#openfga) {/* if .SubProperties */}
+
+### user
+
+How to extract the user for the Check call. Required when using rules.
+
+| | |
+|---|---|
+| **Type** | [ValueSource](#openfga-ValueSource) |
+| **Required** | No |
+
+[↑ Top](#) | [↑ OpenFGA Authorization Configuration](#openfga) {/* if .SubProperties */} {/* range .Properties */}
+
+
+
+<a id="openfga-CheckRule"></a>
+### Custom type: CheckRule
+
+A rule defining how to build the Check tuple for a matched request.
+
+#### match
+
+Conditions for this rule to match. Omit for a catch-all rule.
+
+| | |
+|---|---|
+| **Type** | [RuleMatch](#openfga-RuleMatch) |
+| **Required** | No |
+
+[↑ Top](#) | [↑ OpenFGA Authorization Configuration](#openfga)
+
+#### object
+
+How to extract the object for this rule.
+
+| | |
+|---|---|
+| **Type** | [ValueSource](#openfga-ValueSource) |
+| **Required** | Yes |
+
+[↑ Top](#) | [↑ OpenFGA Authorization Configuration](#openfga)
+
+#### relation
+
+How to extract the relation for this rule.
+
+| | |
+|---|---|
+| **Type** | [ValueSource](#openfga-ValueSource) |
+| **Required** | Yes |
+
+[↑ Top](#) | [↑ OpenFGA Authorization Configuration](#openfga)
+
+#### user
+
+Per-rule user override. Falls back to top-level user if omitted.
+
+| | |
+|---|---|
+| **Type** | [ValueSource](#openfga-ValueSource) |
+| **Required** | No |
+
+[↑ Top](#) | [↑ OpenFGA Authorization Configuration](#openfga) {/* range .Properties */}
+
+<a id="openfga-ContextualTuple"></a>
+### Custom type: ContextualTuple
+
+A contextual tuple with user, relation, and object value sources.
+
+#### object
+
+
+
+| | |
+|---|---|
+| **Type** | [ValueSource](#openfga-ValueSource) |
+| **Required** | Yes |
+
+[↑ Top](#) | [↑ OpenFGA Authorization Configuration](#openfga)
+
+#### relation
+
+
+
+| | |
+|---|---|
+| **Type** | [ValueSource](#openfga-ValueSource) |
+| **Required** | Yes |
+
+[↑ Top](#) | [↑ OpenFGA Authorization Configuration](#openfga)
+
+#### user
+
+
+
+| | |
+|---|---|
+| **Type** | [ValueSource](#openfga-ValueSource) |
+| **Required** | Yes |
+
+[↑ Top](#) | [↑ OpenFGA Authorization Configuration](#openfga) {/* range .Properties */}
+
+<a id="openfga-MetadataKey"></a>
+### Custom type: MetadataKey
+
+Dynamic metadata configuration for writing authorization decisions.
+
+#### key
+
+Key under which the decision is stored within the namespace.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | Yes |
+
+[↑ Top](#) | [↑ OpenFGA Authorization Configuration](#openfga)
+
+#### namespace
+
+Filter-state namespace for the metadata entry.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | Yes |
+
+[↑ Top](#) | [↑ OpenFGA Authorization Configuration](#openfga) {/* range .Properties */}
+
+<a id="openfga-RuleMatch"></a>
+### Custom type: RuleMatch
+
+Conditions for a rule to match. All specified headers must match.
+
+#### headers
+
+Header name to match value. Use "*" to require the header to be present with any non-empty value.
+
+| | |
+|---|---|
+| **Type** | `object` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ OpenFGA Authorization Configuration](#openfga) {/* range .Properties */}
+
+<a id="openfga-ValueSource"></a>
+### Custom type: ValueSource
+
+Extracts a value from the request. Exactly one of value, header, path_segment, or query_param must be set.
+
+#### header
+
+Read value from this request header.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ OpenFGA Authorization Configuration](#openfga)
+
+#### path_segment
+
+Extract the URL path segment at this 0-based index. Negative values count from the end.
+
+| | |
+|---|---|
+| **Type** | `integer` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ OpenFGA Authorization Configuration](#openfga)
+
+#### prefix
+
+Prepend this string to the extracted value.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ OpenFGA Authorization Configuration](#openfga)
+
+#### query_param
+
+Extract the first value of this named query parameter.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ OpenFGA Authorization Configuration](#openfga)
+
+#### value
+
+Static value used as-is.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ OpenFGA Authorization Configuration](#openfga) {/* range .Properties */} {/* range .CustomTypes */} {/* if .CustomTypes */}
+
+
+
+
+<a id="saml"></a>
+## SAML Configuration
+
+Configuration for the SAML 2.0 Service Provider authentication extension.
+**Requires one of:** `idp_metadata_xml`, `idp_metadata_url`s
+
+### acs_path
+
+Assertion Consumer Service endpoint path (e.g. "/saml/acs").
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | Yes |
+
+[↑ Top](#) | [↑ SAML Configuration](#saml) {/* if .SubProperties */}
+
+### allowed_clock_skew
+
+Allowed clock skew for time validation as a Go duration string. Defaults to "5s".
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ SAML Configuration](#saml) {/* if .SubProperties */}
+
+### attribute_headers
+
+Map of SAML attribute names to request header names for forwarding assertions.
+
+| | |
+|---|---|
+| **Type** | `object` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ SAML Configuration](#saml) {/* if .SubProperties */}
+
+### bypass_paths
+
+URL paths that bypass SAML authentication.
+
+| | |
+|---|---|
+| **Type** | `[]string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ SAML Configuration](#saml) {/* if .SubProperties */}
+
+### default_redirect_path
+
+Post-login redirect path when RelayState is empty. Defaults to "/".
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ SAML Configuration](#saml) {/* if .SubProperties */}
+
+### entity_id
+
+Service Provider entity ID (audience URI).
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | Yes |
+
+[↑ Top](#) | [↑ SAML Configuration](#saml) {/* if .SubProperties */}
+
+### idp_metadata_cluster
+
+Envoy cluster used to reach idp_metadata_url. Required when idp_metadata_url is set.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ SAML Configuration](#saml) {/* if .SubProperties */}
+
+### idp_metadata_fetch_delay
+
+Delay before the IdP metadata HttpCallout is issued, as a Go duration string (e.g. "1s", "30s"). Defaults to "1s". Gives Envoy time to start the cluster referenced by idp_metadata_cluster before the callout fires. Only valid in URL mode.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ SAML Configuration](#saml) {/* if .SubProperties */}
+
+### idp_metadata_fetch_max_attempts
+
+Total number of IdP metadata fetch attempts (initial + retries) before giving up. Retries are separated by idp_metadata_fetch_delay. Defaults to 3. Only valid in URL mode.
+
+| | |
+|---|---|
+| **Type** | `integer` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ SAML Configuration](#saml) {/* if .SubProperties */}
+
+### idp_metadata_url
+
+URL to fetch the Identity Provider SAML metadata XML at config-load time. Requires idp_metadata_cluster. Mutually exclusive with idp_metadata_xml.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ SAML Configuration](#saml) {/* if .SubProperties */}
+
+### idp_metadata_xml
+
+Identity Provider SAML metadata XML, supplied inline or read from a file at config-load time. Mutually exclusive with idp_metadata_url.
+
+| | |
+|---|---|
+| **Type** | [DataSource](#saml-DataSource) |
+| **Required** | No |
+
+[↑ Top](#) | [↑ SAML Configuration](#saml) {/* if .SubProperties */}
+
+### metadata_path
+
+SP metadata endpoint path. Defaults to "/saml/metadata".
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ SAML Configuration](#saml) {/* if .SubProperties */}
+
+### name_id_format
+
+NameID format to request from the IdP. Defaults to "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified".
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ SAML Configuration](#saml) {/* if .SubProperties */}
+
+### session
+
+Session and cookie configuration.
+
+| | |
+|---|---|
+| **Type** | `object` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ SAML Configuration](#saml)
+
+
+
+#### session.cookie_domain
+
+Cookie domain attribute. If empty, the cookie is scoped to the request host.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ SAML Configuration](#saml)
+
+
+
+#### session.cookie_name
+
+Session cookie name. Defaults to "_saml_session".
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ SAML Configuration](#saml)
+
+
+
+#### session.cookie_secure
+
+Set the Secure flag on the session cookie. Defaults to true.
+
+| | |
+|---|---|
+| **Type** | `boolean` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ SAML Configuration](#saml)
+
+
+
+#### session.cookie_signing_key
+
+64 hex characters (32 bytes) used as HMAC key for cookie signing. Auto-generated if not set.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+| **Pattern** | `^[0-9a-fA-F]{64}$` |
+
+[↑ Top](#) | [↑ SAML Configuration](#saml)
+
+
+
+#### session.duration
+
+Session duration as a Go duration string (e.g. "8h", "30m"). Defaults to "8h".
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ SAML Configuration](#saml)
+
+   {/* range .SubProperties */} {/* if .SubProperties */}
+
+### sign_authn_requests
+
+Sign AuthnRequests sent to the IdP. Defaults to true.
+
+| | |
+|---|---|
+| **Type** | `boolean` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ SAML Configuration](#saml) {/* if .SubProperties */}
+
+### slo_path
+
+Single Logout endpoint path. Defaults to "/saml/slo".
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ SAML Configuration](#saml) {/* if .SubProperties */}
+
+### sp_cert_pem
+
+SP certificate in PEM format. If omitted, a self-signed certificate is auto-generated. Must be provided together with sp_key_pem.
+
+| | |
+|---|---|
+| **Type** | [DataSource](#saml-DataSource) |
+| **Required** | No |
+
+[↑ Top](#) | [↑ SAML Configuration](#saml) {/* if .SubProperties */}
+
+### sp_key_pem
+
+SP private key in PEM format. Must be provided together with sp_cert_pem.
+
+| | |
+|---|---|
+| **Type** | [DataSource](#saml-DataSource) |
+| **Required** | No |
+
+[↑ Top](#) | [↑ SAML Configuration](#saml) {/* if .SubProperties */}
+
+### subject_header
+
+Request header for the authenticated user's NameID. Defaults to "x-saml-subject".
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ SAML Configuration](#saml) {/* if .SubProperties */} {/* range .Properties */}
+
+
+
+<a id="saml-DataSource"></a>
+### Custom type: DataSource
+
+A data source provided either inline or as a file path. Exactly one must be set.
+**Requires one of:** `inline`, `file`
+
+#### file
+
+Path to a file containing the data.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ SAML Configuration](#saml)
+
+#### inline
+
+Data provided directly as a string.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ SAML Configuration](#saml) {/* range .Properties */} {/* range .CustomTypes */} {/* if .CustomTypes */}
+
+
+
+
+<a id="token-exchange"></a>
+## Token Exchange Configuration
+
+Configuration for the OAuth2 Token Exchange (RFC 8693) extension.
+
+### actor_token
+
+Actor token for delegation scenarios. Requires actor_token_type.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ Token Exchange Configuration](#token-exchange) {/* if .SubProperties */}
+
+### actor_token_type
+
+Token type URI for the actor token. Required when actor_token is set.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ Token Exchange Configuration](#token-exchange) {/* if .SubProperties */}
+
+### audience
+
+Logical name of the target service.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ Token Exchange Configuration](#token-exchange) {/* if .SubProperties */}
+
+### client_id
+
+Client ID for HTTP Basic authentication with the STS endpoint.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | Yes |
+
+[↑ Top](#) | [↑ Token Exchange Configuration](#token-exchange) {/* if .SubProperties */}
+
+### client_secret
+
+Client secret for HTTP Basic authentication with the STS endpoint.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | Yes |
+
+[↑ Top](#) | [↑ Token Exchange Configuration](#token-exchange) {/* if .SubProperties */}
+
+### cluster
+
+Envoy cluster name configured to reach the token exchange (STS) endpoint.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | Yes |
+
+[↑ Top](#) | [↑ Token Exchange Configuration](#token-exchange) {/* if .SubProperties */}
+
+### requested_token_type
+
+Desired output token type URI.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ Token Exchange Configuration](#token-exchange) {/* if .SubProperties */}
+
+### resource
+
+Target resource URI. Must be an absolute URI without a fragment component.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ Token Exchange Configuration](#token-exchange) {/* if .SubProperties */}
+
+### scope
+
+Space-delimited list of requested scopes.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ Token Exchange Configuration](#token-exchange) {/* if .SubProperties */}
+
+### subject_token_type
+
+Token type URI for the input subject token. Defaults to "urn:ietf:params:oauth:token-type:access_token".
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ Token Exchange Configuration](#token-exchange) {/* if .SubProperties */}
+
+### timeout_ms
+
+HTTP callout timeout in milliseconds. Defaults to 5000.
+
+| | |
+|---|---|
+| **Type** | `integer` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ Token Exchange Configuration](#token-exchange) {/* if .SubProperties */}
+
+### token_exchange_url
+
+Token exchange endpoint URL. Must contain a host and path (e.g. "https://idp.example.com/token").
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | Yes |
+
+[↑ Top](#) | [↑ Token Exchange Configuration](#token-exchange) {/* if .SubProperties */} {/* range .Properties */} {/* if .CustomTypes */} {/* range . */}

--- a/website/src/pages/docs/reference/manifest.mdx
+++ b/website/src/pages/docs/reference/manifest.mdx
@@ -1,18 +1,24 @@
 ---
 layout: ../../../layouts/DocsLayout.astro
-title: Extension Manifest
-description: Schema for Built On Envoy extension manifest files.
+title: Schema Reference
+description: Schema Reference Documentation
 ---
 
 import ToC from '../../../components/ToC.astro';
 
-# Extension Manifest
-
-Schema for Built On Envoy extension manifest files.
+# Schema Reference
 
 <ToC maxDepth="4"/>
 
-## author
+
+
+
+<a id="reference"></a>
+## Extension Manifest
+
+Schema for Built On Envoy extension manifest files.
+
+### author
 
 Author or organization name.
 
@@ -22,9 +28,9 @@ Author or organization name.
 | **Required** | Yes |
 | **Min length** | 1 |
 
+[↑ Top](#) | [↑ Extension Manifest](#reference) {/* if .SubProperties */}
 
-
-## categories
+### categories
 
 Functional categories of the extension.
 
@@ -34,9 +40,9 @@ Functional categories of the extension.
 | **Required** | Yes |
 | **Allowed values** | `AI`, `Authentication`, `Decoder`, `Examples`, `Misc`, `Network`, `Observability`, `Performance`, `Traffic Control`, `Transform`, `Security` |
 
+[↑ Top](#) | [↑ Extension Manifest](#reference) {/* if .SubProperties */}
 
-
-## composerVersion
+### composerVersion
 
 Version of Built On Envoy Composer. Required if type is `composer` unless the `parent` field is set.
 
@@ -48,9 +54,9 @@ Version of Built On Envoy Composer. Required if type is `composer` unless the `p
 | **Forbidden when** | `parent` is set |
 | **Required when** | `type` is `go` and `parent` is not set |
 
+[↑ Top](#) | [↑ Extension Manifest](#reference) {/* if .SubProperties */}
 
-
-## description
+### description
 
 Short single-line description of the extension.
 
@@ -61,9 +67,9 @@ Short single-line description of the extension.
 | **Min length** | 1 |
 | **Max length** | 200 |
 
+[↑ Top](#) | [↑ Extension Manifest](#reference) {/* if .SubProperties */}
 
-
-## examples
+### examples
 
 Usage examples for the extension.
 
@@ -73,9 +79,11 @@ Usage examples for the extension.
 | **Required** | Yes |
 | **Min items** | 0 |
 
+[↑ Top](#) | [↑ Extension Manifest](#reference)
 
 
-### examples.code
+
+#### examples.code
 
 Code snippet showing usage.
 
@@ -85,8 +93,11 @@ Code snippet showing usage.
 | **Required** | Yes |
 | **Min length** | 1 |
 
+[↑ Top](#) | [↑ Extension Manifest](#reference)
 
-### examples.description
+
+
+#### examples.description
 
 Explanation of what the example demonstrates.
 
@@ -96,8 +107,11 @@ Explanation of what the example demonstrates.
 | **Required** | Yes |
 | **Min length** | 1 |
 
+[↑ Top](#) | [↑ Extension Manifest](#reference)
 
-### examples.title
+
+
+#### examples.title
 
 Short title for the example.
 
@@ -107,10 +121,11 @@ Short title for the example.
 | **Required** | Yes |
 | **Min length** | 1 |
 
+[↑ Top](#) | [↑ Extension Manifest](#reference)
 
+   {/* range .SubProperties */} {/* if .SubProperties */}
 
-
-## extProc
+### extProc
 
 External processor (ext_proc) configuration.
 
@@ -120,9 +135,11 @@ External processor (ext_proc) configuration.
 | **Required** | No |
 | **Required when** | `type` is `ext_proc` |
 
+[↑ Top](#) | [↑ Extension Manifest](#reference)
 
 
-### extProc.failureModeAllow
+
+#### extProc.failureModeAllow
 
 Whether to allow requests through if the ext_proc server is unavailable or times out.
 
@@ -131,8 +148,11 @@ Whether to allow requests through if the ext_proc server is unavailable or times
 | **Type** | `boolean` |
 | **Required** | No |
 
+[↑ Top](#) | [↑ Extension Manifest](#reference)
 
-### extProc.grpcPort
+
+
+#### extProc.grpcPort
 
 Port the ext_proc gRPC server listens on.
 
@@ -141,8 +161,11 @@ Port the ext_proc gRPC server listens on.
 | **Type** | `integer` |
 | **Required** | No |
 
+[↑ Top](#) | [↑ Extension Manifest](#reference)
 
-### extProc.messageTimeout
+
+
+#### extProc.messageTimeout
 
 Per-message timeout (e.g. '200ms'). Envoy waits this long for each ProcessingResponse.
 
@@ -151,8 +174,11 @@ Per-message timeout (e.g. '200ms'). Envoy waits this long for each ProcessingRes
 | **Type** | `string` |
 | **Required** | No |
 
+[↑ Top](#) | [↑ Extension Manifest](#reference)
 
-### extProc.processingMode
+
+
+#### extProc.processingMode
 
 Controls which HTTP phases are forwarded to the ext_proc server.
 
@@ -161,10 +187,11 @@ Controls which HTTP phases are forwarded to the ext_proc server.
 | **Type** | `object` |
 | **Required** | No |
 
+[↑ Top](#) | [↑ Extension Manifest](#reference)
 
+   {/* range .SubProperties */} {/* if .SubProperties */}
 
-
-## extensionSet
+### extensionSet
 
 Whether this manifest defines a set of extensions.
 
@@ -173,9 +200,9 @@ Whether this manifest defines a set of extensions.
 | **Type** | `boolean` |
 | **Required** | No |
 
+[↑ Top](#) | [↑ Extension Manifest](#reference) {/* if .SubProperties */}
 
-
-## featured
+### featured
 
 Whether to feature this extension in UI/listings.
 
@@ -184,9 +211,9 @@ Whether to feature this extension in UI/listings.
 | **Type** | `boolean` |
 | **Required** | No |
 
+[↑ Top](#) | [↑ Extension Manifest](#reference) {/* if .SubProperties */}
 
-
-## filterType
+### filterType
 
 Envoy filter type. Defaults to `http` if not specified.
 
@@ -196,9 +223,9 @@ Envoy filter type. Defaults to `http` if not specified.
 | **Required** | No |
 | **Allowed values** | `http`, `network`, `listener`, `udp_listener` |
 
+[↑ Top](#) | [↑ Extension Manifest](#reference) {/* if .SubProperties */}
 
-
-## license
+### license
 
 SPDX license identifier.
 
@@ -208,9 +235,9 @@ SPDX license identifier.
 | **Required** | Yes |
 | **Min length** | 1 |
 
+[↑ Top](#) | [↑ Extension Manifest](#reference) {/* if .SubProperties */}
 
-
-## longDescription
+### longDescription
 
 Detailed multi-line description with markdown support.
 
@@ -220,9 +247,9 @@ Detailed multi-line description with markdown support.
 | **Required** | Yes |
 | **Min length** | 1 |
 
+[↑ Top](#) | [↑ Extension Manifest](#reference) {/* if .SubProperties */}
 
-
-## lua
+### lua
 
 Lua extension configuration.
 
@@ -233,9 +260,11 @@ Lua extension configuration.
 | **Required when** | `type` is `lua` |
 | **Requires one of** | `path`, `inline` |
 
+[↑ Top](#) | [↑ Extension Manifest](#reference)
 
 
-### lua.inline
+
+#### lua.inline
 
 Inline Lua script code.
 
@@ -245,8 +274,11 @@ Inline Lua script code.
 | **Required** | No |
 | **Min length** | 1 |
 
+[↑ Top](#) | [↑ Extension Manifest](#reference)
 
-### lua.path
+
+
+#### lua.path
 
 Path to the Lua script file.
 
@@ -256,10 +288,11 @@ Path to the Lua script file.
 | **Required** | No |
 | **Min length** | 1 |
 
+[↑ Top](#) | [↑ Extension Manifest](#reference)
 
+   {/* range .SubProperties */} {/* if .SubProperties */}
 
-
-## maxEnvoyVersion
+### maxEnvoyVersion
 
 Maximum compatible Envoy version.
 
@@ -269,9 +302,9 @@ Maximum compatible Envoy version.
 | **Required** | No |
 | **Pattern** | `^\d+\.\d+\.\d+$` |
 
+[↑ Top](#) | [↑ Extension Manifest](#reference) {/* if .SubProperties */}
 
-
-## minEnvoyVersion
+### minEnvoyVersion
 
 Minimum compatible Envoy version.
 
@@ -281,9 +314,9 @@ Minimum compatible Envoy version.
 | **Required** | No |
 | **Pattern** | `^\d+\.\d+\.\d+$` |
 
+[↑ Top](#) | [↑ Extension Manifest](#reference) {/* if .SubProperties */}
 
-
-## name
+### name
 
 Unique identifier for the extension.
 
@@ -294,9 +327,9 @@ Unique identifier for the extension.
 | **Min length** | 1 |
 | **Pattern** | `^[a-z][.a-z0-9-_]*$` |
 
+[↑ Top](#) | [↑ Extension Manifest](#reference) {/* if .SubProperties */}
 
-
-## nativeHttpFilters
+### nativeHttpFilters
 
 Native Envoy HTTP filters that BOE must emit in the HCM filter chain together with this extension's generated HTTP filter.
 
@@ -308,9 +341,11 @@ Native Envoy HTTP filters that BOE must emit in the HCM filter chain together wi
 | **Forbidden when** | `type` is `wasm` |
 | **Forbidden when** | `type` is `composer` |
 
+[↑ Top](#) | [↑ Extension Manifest](#reference)
 
 
-### nativeHttpFilters.after
+
+#### nativeHttpFilters.after
 
 Native Envoy HTTP filters to emit after this extension's generated HTTP filter, in the order listed.
 
@@ -320,8 +355,11 @@ Native Envoy HTTP filters to emit after this extension's generated HTTP filter, 
 | **Required** | No |
 | **Min items** | 1 |
 
+[↑ Top](#) | [↑ Extension Manifest](#reference)
 
-### nativeHttpFilters.before
+
+
+#### nativeHttpFilters.before
 
 Native Envoy HTTP filters to emit before this extension's generated HTTP filter, in the order listed.
 
@@ -331,10 +369,11 @@ Native Envoy HTTP filters to emit before this extension's generated HTTP filter,
 | **Required** | No |
 | **Min items** | 1 |
 
+[↑ Top](#) | [↑ Extension Manifest](#reference)
 
+   {/* range .SubProperties */} {/* if .SubProperties */}
 
-
-## parent
+### parent
 
 Parent extension set whose version will be used. When set, the `version` and `composerVersion` fields can't be set.
 
@@ -345,9 +384,9 @@ Parent extension set whose version will be used. When set, the `version` and `co
 | **Min length** | 1 |
 | **Pattern** | `^[a-z][a-z0-9-_.]*$` |
 
+[↑ Top](#) | [↑ Extension Manifest](#reference) {/* if .SubProperties */}
 
-
-## tags
+### tags
 
 Searchable tags for categorization.
 
@@ -360,9 +399,9 @@ Searchable tags for categorization.
 | **Item pattern** | `^[a-z][a-z0-9-]*$` |
 | **Item min length** | 1 |
 
+[↑ Top](#) | [↑ Extension Manifest](#reference) {/* if .SubProperties */}
 
-
-## type
+### type
 
 Type of the extension.
 
@@ -372,9 +411,9 @@ Type of the extension.
 | **Required** | Yes |
 | **Allowed values** | `lua`, `wasm`, `rust`, `go`, `composer`, `ext_proc` |
 
+[↑ Top](#) | [↑ Extension Manifest](#reference) {/* if .SubProperties */}
 
-
-## version
+### version
 
 Semantic version of the extension. Required unless the `parent` field is set.
 
@@ -386,4 +425,4 @@ Semantic version of the extension. Required unless the `parent` field is set.
 | **Forbidden when** | `parent` is set |
 | **Required when** | `parent` is not set |
 
-
+[↑ Top](#) | [↑ Extension Manifest](#reference) {/* if .SubProperties */} {/* range .Properties */} {/* if .CustomTypes */} {/* range . */}

--- a/website/src/pages/docs/sidebar-cli.yaml
+++ b/website/src/pages/docs/sidebar-cli.yaml
@@ -25,3 +25,5 @@ sections:
         href: /docs/reference/environment-variables
       - title: Extension manifest
         href: /docs/reference/manifest
+      - title: Extension configuration
+        href: /docs/reference/extensions

--- a/website/src/pages/extensions/[name].astro
+++ b/website/src/pages/extensions/[name].astro
@@ -45,6 +45,70 @@ function formatTypeName(type: string): string {
 		.map(word => word.charAt(0).toUpperCase() + word.slice(1))
 		.join(' ');
 }
+
+const fileServerConfigMarkdown = `# File Server Configuration
+
+Configuration for the File Server extension. Serves static files from the local filesystem through Envoy.
+
+## content_types
+
+Custom file extension to content-type mappings. Keys are file suffixes without dots (e.g. "html", "css").
+
+| | |
+|---|---|
+| **Type** | \`object\` |
+| **Required** | No |
+
+## default_content_type
+
+Default content-type when the file extension is not found in content_types.
+
+| | |
+|---|---|
+| **Type** | \`string\` |
+| **Required** | No |
+
+## directory_index_files
+
+Files to serve for directory requests (e.g. ["index.html"]). File names must not contain slashes.
+
+| | |
+|---|---|
+| **Type** | \`[]string\` |
+| **Required** | No |
+| **Item pattern** | \`^[^/]*$\` |
+
+## path_mappings
+
+Mappings from URL path prefixes to filesystem path prefixes. At least one mapping is required. Duplicate request path prefixes are not allowed.
+
+| | |
+|---|---|
+| **Type** | \`[]object\` |
+| **Required** | Yes |
+| **Min items** | 1 |
+
+### path_mappings.file_path_prefix
+
+Filesystem path prefix to map to (e.g. "/var/www/").
+
+| | |
+|---|---|
+| **Type** | \`string\` |
+| **Required** | Yes |
+| **Min length** | 1 |
+
+### path_mappings.request_path_prefix
+
+URL path prefix to match (e.g. "/static/").
+
+| | |
+|---|---|
+| **Type** | \`string\` |
+| **Required** | Yes |
+| **Min length** | 1 |
+`;
+
 ---
 
 <!DOCTYPE html>
@@ -163,6 +227,12 @@ function formatTypeName(type: string): string {
 									))}
 								</div>
 							</div>
+							{extension.configReferencePath && (
+								<div class="sidebar-section">
+									<h3>Resources</h3>
+									<a href={extension.configReferencePath} class="sidebar-ref-link">Configuration Reference →</a>
+								</div>
+							)}
 						</aside>
 					</div>
 				</div>

--- a/website/src/styles/extension-detail.css
+++ b/website/src/styles/extension-detail.css
@@ -461,6 +461,17 @@
 	letter-spacing: 0.5px;
 }
 
+.sidebar-ref-link {
+	color: var(--primary);
+	text-decoration: none;
+	font-size: 14px;
+	font-weight: 500;
+}
+
+.sidebar-ref-link:hover {
+	text-decoration: underline;
+}
+
 .categories {
 	display: flex;
 	flex-wrap: wrap;

--- a/website/src/utils/extensions.ts
+++ b/website/src/utils/extensions.ts
@@ -26,6 +26,7 @@ export interface Extension {
 	examples?: Example[];
 	sourcePath: string;
 	sourceUrl: string;
+	configReferencePath?: string;
 }
 
 /**


### PR DESCRIPTION
This change generalizes the JSON Schema docs generation to also generate reference docs for the Extension config schemas. It adds a page with the config reference for all the extensions that have a config schema, and on each extension page that has a schema, it links to the corresponding reference docs.
It also enhances the JSON schema reference generation to support custom types defined in the config schema.

Preview here: https://deploy-preview-448--builtonenvoy.netlify.app/