### PR TITLE
rust: add scaffolding for other filter types

### DIFF
--- a/cli/cmd/create.go
+++ b/cli/cmd/create.go
@@ -28,7 +28,7 @@ var templateFS embed.FS
 // Create is a command to create a new extension template.
 type Create struct {
 	Type            string `help:"Type of the extension (go, rust, ext_proc)." default:"go" enum:"go,rust,ext_proc"`
-	FilterType      string `help:"Filter type (http, network). Network filters are only supported for rust." default:"http" enum:"http,network"`
+	FilterType      string `help:"Filter type (http, network, listener, udp_listener). Network, listener, and udp_listener filters are only supported for rust." default:"http" enum:"http,network,listener,udp_listener"`
 	Name            string `arg:"" help:"Name of the extension."`
 	Path            string `help:"Output directory for the extension. Defaults to the extension name." type:"path"`
 	ComposerVersion string `name:"composer-version" help:"Composer version for Go extensions. Resolved from the registry if not set."`
@@ -44,11 +44,15 @@ func (c *Create) Help() string { return createHelp }
 
 // Validate is called by Kong after parsing to validate the command arguments.
 func (c *Create) Validate() error {
-	if c.Type == "go" && c.FilterType == "network" {
-		return fmt.Errorf("network filter scaffolding is not supported for %q extensions; use --type rust", c.Type)
+	if c.FilterType == "" {
+		c.FilterType = "http"
 	}
-	if c.Type == "ext_proc" && c.FilterType == "network" {
-		return fmt.Errorf("network filter scaffolding is not supported for %q extensions", c.Type)
+
+	if c.Type == "go" && c.FilterType != "http" {
+		return fmt.Errorf("only http filter scaffolding is supported for %q extensions; use --type rust for other filter types", c.Type)
+	}
+	if c.Type == "ext_proc" && c.FilterType != "http" {
+		return fmt.Errorf("only http filter scaffolding is supported for %q extensions; use --type rust for other filter types", c.Type)
 	}
 	return nil
 }
@@ -204,12 +208,8 @@ func createRustExtension(logger *slog.Logger, path, name, filterType string) err
 		"LibName": extensions.RustLibNameFromName(name),
 	}
 
-	libTemplate := "templates/create/rust/lib_http.rs.tmpl"
-	manifestTemplate := "templates/create/rust/manifest_http.yaml.tmpl"
-	if filterType == "network" {
-		libTemplate = "templates/create/rust/lib_network.rs.tmpl"
-		manifestTemplate = "templates/create/rust/manifest_network.yaml.tmpl"
-	}
+	libTemplate := fmt.Sprintf("templates/create/rust/lib_%s.rs.tmpl", filterType)
+	manifestTemplate := fmt.Sprintf("templates/create/rust/manifest_%s.yaml.tmpl", filterType)
 
 	// Map of output filename to template filename
 	files := map[string]string{

--- a/cli/cmd/create_help.md
+++ b/cli/cmd/create_help.md
@@ -37,6 +37,18 @@ Create a Rust network (L4) filter extension:
     boe create my-tcp-extension --type rust --filter-type network
     ```
 
+Create a Rust listener (L4) filter extension:
+
+    ```shell
+    boe create my-listener-extension --type rust --filter-type listener
+    ```
+
+Create a Rust UDP listener filter extension:
+
+    ```shell
+    boe create my-udp-extension --type rust --filter-type udp_listener
+    ```
+
 Create an ExtProc extension:
 
     ```shell
@@ -50,6 +62,7 @@ Create an ExtProc extension:
       Network filters are not currently supported for Go extensions.
     - **rust**: A dynamic module extension using the Envoy dynamic modules SDK for Rust.
       Generates Rust source files and Cargo.toml for building a dynamic library.
-      Supports both HTTP filters (default) and network (L4) filters via `--filter-type`.
+      Supports HTTP filters (default), network (L4) filters, listener (L4) filters,
+      and UDP listener filters via `--filter-type`.
     - **ext_proc**: An extension that runs as an Envoy External Processor server as an
       independent process.

--- a/cli/cmd/create_test.go
+++ b/cli/cmd/create_test.go
@@ -366,7 +366,7 @@ func TestCreateRust_UdpListenerFilter_Run(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(manifest), "name: "+name)
 	assert.Contains(t, string(manifest), "type: rust")
-	assert.Contains(t, string(manifest), "filterType: udp_listener")
+	assert.Contains(t, string(manifest), "filterType: [udp_listener]")
 
 	// verify src/lib.rs contains udp listener filter constructs, not HTTP, network, or listener.
 	// #nosec G304
@@ -405,7 +405,7 @@ func TestCreateRust_ListenerFilter_Run(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(manifest), "name: "+name)
 	assert.Contains(t, string(manifest), "type: rust")
-	assert.Contains(t, string(manifest), "filterType: listener")
+	assert.Contains(t, string(manifest), "filterType: [listener]")
 
 	// verify src/lib.rs contains listener filter constructs, not HTTP or network.
 	// #nosec G304

--- a/cli/cmd/create_test.go
+++ b/cli/cmd/create_test.go
@@ -420,10 +420,21 @@ func TestCreateRust_ListenerFilter_Run(t *testing.T) {
 	assert.NotContains(t, string(libRs), "NetworkFilterConfig")
 }
 
-func TestCreateFilter_Unsupported(t *testing.T) {
+func TestValidate(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		c := &Create{
+			Type: "go",
+			Name: "test-extension",
+		}
+
+		err := c.Validate()
+		require.NoError(t, err)
+		require.Equal(t, "http", c.FilterType) // default filter type is set
+	})
+
 	for _, extensionType := range []string{"go", "ext_proc"} {
 		for _, filterType := range []string{"network", "listener", "udp_listener"} {
-			t.Run(fmt.Sprintf("%s_%s", extensionType, filterType), func(t *testing.T) {
+			t.Run(fmt.Sprintf("invalid_%s_%s", extensionType, filterType), func(t *testing.T) {
 				c := &Create{
 					Type:       extensionType,
 					FilterType: filterType,

--- a/cli/cmd/create_test.go
+++ b/cli/cmd/create_test.go
@@ -52,8 +52,10 @@ Flags:
   -h, --help                       Show context-sensitive help.
 
       --type="go"                  Type of the extension (go, rust, ext_proc).
-      --filter-type="http"         Filter type (http, network). Network filters
-                                   are only supported for rust.
+      --filter-type="http"         Filter type (http, network, listener,
+                                   udp_listener). Network, listener, and
+                                   udp_listener filters are only supported for
+                                   rust.
       --path=STRING                Output directory for the extension. Defaults
                                    to the extension name.
       --composer-version=STRING    Composer version for Go extensions. Resolved
@@ -243,9 +245,10 @@ func TestCreateRust_Run(t *testing.T) {
 	name := "my-rust-extension"
 
 	c := &Create{
-		Type: "rust",
-		Name: name,
-		Path: tmpDir,
+		Type:       "rust",
+		FilterType: "http",
+		Name:       name,
+		Path:       tmpDir,
 	}
 
 	err := c.Run(t.Context(), &xdg.Directories{}, internaltesting.NewTLogger(t))
@@ -340,18 +343,97 @@ func TestCreateRust_NetworkFilter_Run(t *testing.T) {
 	assert.NotContains(t, string(libRs), "HttpFilterConfig")
 }
 
-func TestCreateGo_NetworkFilter_Unsupported(t *testing.T) {
-	for _, extensionType := range []string{"go", "ext_proc"} {
-		t.Run(extensionType, func(t *testing.T) {
-			c := &Create{
-				Type:       extensionType,
-				FilterType: "network",
-				Name:       "test-extension",
-			}
+func TestCreateRust_UdpListenerFilter_Run(t *testing.T) {
+	tmpDir := t.TempDir()
+	name := "my-udp-extension"
 
-			err := c.Validate()
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), fmt.Sprintf("network filter scaffolding is not supported for %q extensions", extensionType))
-		})
+	c := &Create{
+		Type:       "rust",
+		FilterType: "udp_listener",
+		Name:       name,
+		Path:       tmpDir,
+	}
+
+	err := c.Run(t.Context(), &xdg.Directories{}, internaltesting.NewTLogger(t))
+	require.NoError(t, err)
+
+	repoPath := filepath.Join(tmpDir, name)
+	require.DirExists(t, repoPath)
+
+	// verify manifest.yaml content
+	// #nosec G304
+	manifest, err := os.ReadFile(filepath.Join(repoPath, "manifest.yaml"))
+	require.NoError(t, err)
+	assert.Contains(t, string(manifest), "name: "+name)
+	assert.Contains(t, string(manifest), "type: rust")
+	assert.Contains(t, string(manifest), "filterType: udp_listener")
+
+	// verify src/lib.rs contains udp listener filter constructs, not HTTP, network, or listener.
+	// #nosec G304
+	libRs, err := os.ReadFile(filepath.Join(repoPath, "src/lib.rs"))
+	require.NoError(t, err)
+	assert.Contains(t, string(libRs), "declare_udp_listener_filter_init_functions!")
+	assert.Contains(t, string(libRs), "UdpListenerFilterConfig")
+	assert.Contains(t, string(libRs), "fn on_data")
+	assert.NotContains(t, string(libRs), "declare_init_functions!")
+	assert.NotContains(t, string(libRs), "declare_network_filter_init_functions!")
+	assert.NotContains(t, string(libRs), "declare_listener_filter_init_functions!")
+	assert.NotContains(t, string(libRs), "HttpFilterConfig")
+	assert.NotContains(t, string(libRs), "NetworkFilterConfig")
+}
+
+func TestCreateRust_ListenerFilter_Run(t *testing.T) {
+	tmpDir := t.TempDir()
+	name := "my-listener-extension"
+
+	c := &Create{
+		Type:       "rust",
+		FilterType: "listener",
+		Name:       name,
+		Path:       tmpDir,
+	}
+
+	err := c.Run(t.Context(), &xdg.Directories{}, internaltesting.NewTLogger(t))
+	require.NoError(t, err)
+
+	repoPath := filepath.Join(tmpDir, name)
+	require.DirExists(t, repoPath)
+
+	// verify manifest.yaml content
+	// #nosec G304
+	manifest, err := os.ReadFile(filepath.Join(repoPath, "manifest.yaml"))
+	require.NoError(t, err)
+	assert.Contains(t, string(manifest), "name: "+name)
+	assert.Contains(t, string(manifest), "type: rust")
+	assert.Contains(t, string(manifest), "filterType: listener")
+
+	// verify src/lib.rs contains listener filter constructs, not HTTP or network.
+	// #nosec G304
+	libRs, err := os.ReadFile(filepath.Join(repoPath, "src/lib.rs"))
+	require.NoError(t, err)
+	assert.Contains(t, string(libRs), "declare_listener_filter_init_functions!")
+	assert.Contains(t, string(libRs), "ListenerFilterConfig")
+	assert.Contains(t, string(libRs), "fn on_accept")
+	assert.NotContains(t, string(libRs), "declare_init_functions!")
+	assert.NotContains(t, string(libRs), "declare_network_filter_init_functions!")
+	assert.NotContains(t, string(libRs), "HttpFilterConfig")
+	assert.NotContains(t, string(libRs), "NetworkFilterConfig")
+}
+
+func TestCreateFilter_Unsupported(t *testing.T) {
+	for _, extensionType := range []string{"go", "ext_proc"} {
+		for _, filterType := range []string{"network", "listener", "udp_listener"} {
+			t.Run(fmt.Sprintf("%s_%s", extensionType, filterType), func(t *testing.T) {
+				c := &Create{
+					Type:       extensionType,
+					FilterType: filterType,
+					Name:       "test-extension",
+				}
+
+				err := c.Validate()
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), fmt.Sprintf("only http filter scaffolding is supported for %q extensions", extensionType))
+			})
+		}
 	}
 }

--- a/cli/cmd/templates/create/rust/Cargo.toml.tmpl
+++ b/cli/cmd/templates/create/rust/Cargo.toml.tmpl
@@ -7,9 +7,11 @@ repository = "https://github.com/tetratelabs/built-on-envoy"
 
 [dependencies]
 # The SDK version must match the Envoy version due to the strict compatibility requirements.
-envoy-proxy-dynamic-modules-rust-sdk = { git = "https://github.com/envoyproxy/envoy", rev = "f1dd21b16c244bda00edfb5ffce577e12d0d2ec2" }
+envoy-proxy-dynamic-modules-rust-sdk = { git = "https://github.com/envoyproxy/envoy", rev = "a0d2e3fc35eaa23283a7204eecb62ea2fd166a26" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+
+[workspace]
 
 [lib]
 name = "{{ .LibName }}"

--- a/cli/cmd/templates/create/rust/Cargo.toml.tmpl
+++ b/cli/cmd/templates/create/rust/Cargo.toml.tmpl
@@ -7,7 +7,7 @@ repository = "https://github.com/tetratelabs/built-on-envoy"
 
 [dependencies]
 # The SDK version must match the Envoy version due to the strict compatibility requirements.
-envoy-proxy-dynamic-modules-rust-sdk = { git = "https://github.com/envoyproxy/envoy", rev = "a0d2e3fc35eaa23283a7204eecb62ea2fd166a26" }
+envoy-proxy-dynamic-modules-rust-sdk = { git = "https://github.com/envoyproxy/envoy", rev = "af5b6f36ff77a04f3a4c734a42f62057ffca7b3a" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 

--- a/cli/cmd/templates/create/rust/Dockerfile.tmpl
+++ b/cli/cmd/templates/create/rust/Dockerfile.tmpl
@@ -10,7 +10,7 @@
 # Multi-stage build for Rust dynamic modules
 
 # Build stage
-FROM rust:1.84-bookworm AS builder
+FROM rust:1.96-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && \

--- a/cli/cmd/templates/create/rust/lib_listener.rs.tmpl
+++ b/cli/cmd/templates/create/rust/lib_listener.rs.tmpl
@@ -86,9 +86,7 @@ impl<ELF: EnvoyListenerFilter> ListenerFilter<ELF> for Filter {
     fn on_close(&mut self, _envoy_filter: &mut ELF) {}
 }
 
-fn init(
-    _server_factory_context_ptr: abi::envoy_dynamic_module_type_server_factory_context_envoy_ptr,
-) -> bool {
+fn init() -> bool {
     true
 }
 

--- a/cli/cmd/templates/create/rust/lib_listener.rs.tmpl
+++ b/cli/cmd/templates/create/rust/lib_listener.rs.tmpl
@@ -1,0 +1,137 @@
+// Copyright Built On Envoy
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+use envoy_proxy_dynamic_modules_rust_sdk::*;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+// The raw filter config that will be deserialized from the JSON configuration.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct RawFilterConfig {
+    #[serde(default)]
+    log_tag: String,
+}
+
+impl Default for RawFilterConfig {
+    fn default() -> Self {
+        RawFilterConfig {
+            log_tag: "example".to_string(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct FilterConfigImpl {
+    log_tag: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct FilterConfig {
+    config: Arc<FilterConfigImpl>,
+}
+
+impl FilterConfig {
+    pub fn new(filter_config: &str) -> Option<Self> {
+        let raw: RawFilterConfig = if filter_config.is_empty() {
+            RawFilterConfig::default()
+        } else {
+            match serde_json::from_str(filter_config) {
+                Ok(cfg) => cfg,
+                Err(err) => {
+                    eprintln!("Error parsing filter config: {err}");
+                    return None;
+                }
+            }
+        };
+
+        Some(FilterConfig {
+            config: Arc::new(FilterConfigImpl {
+                log_tag: raw.log_tag,
+            }),
+        })
+    }
+}
+
+impl<ELF: EnvoyListenerFilter> ListenerFilterConfig<ELF> for FilterConfig {
+    fn new_listener_filter(&self, _envoy: &mut ELF) -> Box<dyn ListenerFilter<ELF>> {
+        Box::new(Filter {
+            config: self.config.clone(),
+        })
+    }
+}
+
+pub struct Filter {
+    config: Arc<FilterConfigImpl>,
+}
+
+impl<ELF: EnvoyListenerFilter> ListenerFilter<ELF> for Filter {
+    fn on_accept(
+        &mut self,
+        _envoy_filter: &mut ELF,
+    ) -> abi::envoy_dynamic_module_type_on_listener_filter_status {
+        // TODO: Implement your own custom logic here.
+        envoy_log_info!("{{ .Name }}: OnAccept tag={}", self.config.log_tag);
+        abi::envoy_dynamic_module_type_on_listener_filter_status::Continue
+    }
+
+    fn on_data(
+        &mut self,
+        _envoy_filter: &mut ELF,
+    ) -> abi::envoy_dynamic_module_type_on_listener_filter_status {
+        abi::envoy_dynamic_module_type_on_listener_filter_status::Continue
+    }
+
+    fn on_close(&mut self, _envoy_filter: &mut ELF) {}
+}
+
+fn init(
+    _server_factory_context_ptr: abi::envoy_dynamic_module_type_server_factory_context_envoy_ptr,
+) -> bool {
+    true
+}
+
+fn new_listener_filter_config_fn<EC: EnvoyListenerFilterConfig, ELF: EnvoyListenerFilter>(
+    _envoy_filter_config: &mut EC,
+    filter_name: &str,
+    filter_config: &[u8],
+) -> Option<Box<dyn ListenerFilterConfig<ELF>>> {
+    let filter_config = std::str::from_utf8(filter_config).unwrap_or("");
+    match filter_name {
+        "{{ .Name }}" => FilterConfig::new(filter_config)
+            .map(|config| Box::new(config) as Box<dyn ListenerFilterConfig<ELF>>),
+        _ => panic!("Unknown filter name: {filter_name}"),
+    }
+}
+
+declare_listener_filter_init_functions!(init, new_listener_filter_config_fn);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_filter_config() {
+        let filter_config = FilterConfig::new(
+            r#"{
+                "log_tag": "test"
+            }"#,
+        );
+        assert!(filter_config.is_some());
+        assert_eq!(filter_config.unwrap().config.log_tag, "test");
+    }
+
+    #[test]
+    fn test_new_filter_config_default() {
+        let filter_config = FilterConfig::new("");
+        assert!(filter_config.is_some());
+        assert_eq!(filter_config.unwrap().config.log_tag, "example");
+    }
+
+    #[test]
+    fn test_new_filter_config_invalid_json() {
+        let filter_config = FilterConfig::new("{invalid");
+        assert!(filter_config.is_none());
+    }
+}

--- a/cli/cmd/templates/create/rust/lib_listener.rs.tmpl
+++ b/cli/cmd/templates/create/rust/lib_listener.rs.tmpl
@@ -79,6 +79,7 @@ impl<ELF: EnvoyListenerFilter> ListenerFilter<ELF> for Filter {
     fn on_data(
         &mut self,
         _envoy_filter: &mut ELF,
+        _data_length: usize,
     ) -> abi::envoy_dynamic_module_type_on_listener_filter_status {
         abi::envoy_dynamic_module_type_on_listener_filter_status::Continue
     }

--- a/cli/cmd/templates/create/rust/lib_udp_listener.rs.tmpl
+++ b/cli/cmd/templates/create/rust/lib_udp_listener.rs.tmpl
@@ -1,0 +1,135 @@
+// Copyright Built On Envoy
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+use envoy_proxy_dynamic_modules_rust_sdk::*;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+// The raw filter config that will be deserialized from the JSON configuration.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct RawFilterConfig {
+    #[serde(default)]
+    log_tag: String,
+}
+
+impl Default for RawFilterConfig {
+    fn default() -> Self {
+        RawFilterConfig {
+            log_tag: "example".to_string(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct FilterConfigImpl {
+    log_tag: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct FilterConfig {
+    config: Arc<FilterConfigImpl>,
+}
+
+impl FilterConfig {
+    pub fn new(filter_config: &str) -> Option<Self> {
+        let raw: RawFilterConfig = if filter_config.is_empty() {
+            RawFilterConfig::default()
+        } else {
+            match serde_json::from_str(filter_config) {
+                Ok(cfg) => cfg,
+                Err(err) => {
+                    eprintln!("Error parsing filter config: {err}");
+                    return None;
+                }
+            }
+        };
+
+        Some(FilterConfig {
+            config: Arc::new(FilterConfigImpl {
+                log_tag: raw.log_tag,
+            }),
+        })
+    }
+}
+
+impl<ELF: EnvoyUdpListenerFilter> UdpListenerFilterConfig<ELF> for FilterConfig {
+    fn new_udp_listener_filter(&self, _envoy: &mut ELF) -> Box<dyn UdpListenerFilter<ELF>> {
+        Box::new(Filter {
+            config: self.config.clone(),
+        })
+    }
+}
+
+pub struct Filter {
+    config: Arc<FilterConfigImpl>,
+}
+
+impl<ELF: EnvoyUdpListenerFilter> UdpListenerFilter<ELF> for Filter {
+    fn on_data(
+        &mut self,
+        envoy_filter: &mut ELF,
+    ) -> abi::envoy_dynamic_module_type_on_udp_listener_filter_status {
+        // TODO: Implement your own custom logic here.
+        let (chunks, total_length) = envoy_filter.get_datagram_data();
+        envoy_log_info!(
+            "{{ .Name }}: OnData tag={} bytes={}",
+            self.config.log_tag,
+            total_length
+        );
+        let _ = chunks;
+        abi::envoy_dynamic_module_type_on_udp_listener_filter_status::Continue
+    }
+}
+
+fn init() -> bool {
+    true
+}
+
+fn new_udp_listener_filter_config_fn<
+    EC: EnvoyUdpListenerFilterConfig,
+    ELF: EnvoyUdpListenerFilter,
+>(
+    _envoy_filter_config: &mut EC,
+    filter_name: &str,
+    filter_config: &[u8],
+) -> Option<Box<dyn UdpListenerFilterConfig<ELF>>> {
+    let filter_config = std::str::from_utf8(filter_config).unwrap_or("");
+    match filter_name {
+        "{{ .Name }}" => FilterConfig::new(filter_config)
+            .map(|config| Box::new(config) as Box<dyn UdpListenerFilterConfig<ELF>>),
+        _ => panic!("Unknown filter name: {filter_name}"),
+    }
+}
+
+declare_udp_listener_filter_init_functions!(init, new_udp_listener_filter_config_fn);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_filter_config() {
+        let filter_config = FilterConfig::new(
+            r#"{
+                "log_tag": "test"
+            }"#,
+        );
+        assert!(filter_config.is_some());
+        assert_eq!(filter_config.unwrap().config.log_tag, "test");
+    }
+
+    #[test]
+    fn test_new_filter_config_default() {
+        let filter_config = FilterConfig::new("");
+        assert!(filter_config.is_some());
+        assert_eq!(filter_config.unwrap().config.log_tag, "example");
+    }
+
+    #[test]
+    fn test_new_filter_config_invalid_json() {
+        let filter_config = FilterConfig::new("{invalid");
+        assert!(filter_config.is_none());
+    }
+}

--- a/cli/cmd/templates/create/rust/manifest_listener.yaml.tmpl
+++ b/cli/cmd/templates/create/rust/manifest_listener.yaml.tmpl
@@ -36,7 +36,7 @@ tags:
   - filter
 license: Apache-2.0
 type: rust
-filterType: listener
+filterType: [listener]
 examples:
   - title: Basic Usage
     description: Run the extension with default configuration

--- a/cli/cmd/templates/create/rust/manifest_listener.yaml.tmpl
+++ b/cli/cmd/templates/create/rust/manifest_listener.yaml.tmpl
@@ -1,0 +1,51 @@
+name: {{ .Name }}
+version: 0.1.0
+categories:
+  - Misc
+author: Unknown
+description: A custom Rust listener (L4) extension.
+longDescription: |
+  A custom Rust listener filter built with Envoy's dynamic module framework.
+
+  Listener filters run before a Connection object is created, allowing early
+  inspection and modification of accepted connections.
+
+  ## Features
+
+  * **Connection inspection**: Inspects connections on accept before routing
+  * **Configurable**: Configure the log tag via JSON config
+
+  ## Configuration
+
+  Configure the extension with a JSON object:
+  - `log_tag`: The tag to log on accepted connections (default: "example")
+
+  ## Building
+
+  This is a Rust dynamic module that must be compiled to a shared library.
+
+  ```bash
+  cargo build --release
+  ```
+
+  The compiled library will be at `target/release/lib{{ .LibName }}.{so,dylib}`
+tags:
+  - rust
+  - dynamic-module
+  - listener
+  - filter
+license: Apache-2.0
+type: rust
+filterType: listener
+examples:
+  - title: Basic Usage
+    description: Run the extension with default configuration
+    code: |
+      boe run --extension {{ .Name }}
+  - title: Custom Log Tag
+    description: Configure a custom log tag
+    code: |
+      boe run --extension {{ .Name }} --config '
+        {
+          "log_tag": "my-custom-tag"
+        }'

--- a/cli/cmd/templates/create/rust/manifest_udp_listener.yaml.tmpl
+++ b/cli/cmd/templates/create/rust/manifest_udp_listener.yaml.tmpl
@@ -32,11 +32,11 @@ longDescription: |
 tags:
   - rust
   - dynamic-module
-  - udp_listener
+  - udp-listener
   - filter
 license: Apache-2.0
 type: rust
-filterType: udp_listener
+filterType: [udp_listener]
 examples:
   - title: Basic Usage
     description: Run the extension with default configuration

--- a/cli/cmd/templates/create/rust/manifest_udp_listener.yaml.tmpl
+++ b/cli/cmd/templates/create/rust/manifest_udp_listener.yaml.tmpl
@@ -1,0 +1,51 @@
+name: {{ .Name }}
+version: 0.1.0
+categories:
+  - Misc
+author: Unknown
+description: A custom Rust UDP listener filter extension.
+longDescription: |
+  A custom Rust UDP listener filter built with Envoy's dynamic module framework.
+
+  UDP listener filters inspect and optionally transform UDP datagrams received
+  on a UDP listener before they are forwarded.
+
+  ## Features
+
+  * **Datagram inspection**: Logs incoming UDP datagrams with a configurable tag
+  * **Configurable**: Configure the log tag via JSON config
+
+  ## Configuration
+
+  Configure the extension with a JSON object:
+  - `log_tag`: The tag to log on received datagrams (default: "example")
+
+  ## Building
+
+  This is a Rust dynamic module that must be compiled to a shared library.
+
+  ```bash
+  cargo build --release
+  ```
+
+  The compiled library will be at `target/release/lib{{ .LibName }}.{so,dylib}`
+tags:
+  - rust
+  - dynamic-module
+  - udp_listener
+  - filter
+license: Apache-2.0
+type: rust
+filterType: udp_listener
+examples:
+  - title: Basic Usage
+    description: Run the extension with default configuration
+    code: |
+      boe run --extension {{ .Name }}
+  - title: Custom Log Tag
+    description: Configure a custom log tag
+    code: |
+      boe run --extension {{ .Name }} --config '
+        {
+          "log_tag": "my-custom-tag"
+        }'

--- a/cli/e2e/create_test.go
+++ b/cli/e2e/create_test.go
@@ -135,103 +135,52 @@ func TestCreateGoWithDockerSupport(t *testing.T) {
 	})
 }
 
-func TestCreateRustWithDockerSupport(t *testing.T) {
+func TestCreateRustNetworkAndListenerFilters(t *testing.T) {
 	tmpDir := t.TempDir()
 	ctx := t.Context()
 
 	t.Setenv("BOE_REGISTRY_INSECURE", "true")
 	t.Setenv("BOE_REGISTRY", registryAddr)
 
-	// Create a new extension
-	process := internaltesting.RunCLI(t, cliBin, "create", "test-docker", "--path", tmpDir,
-		"--type", "rust")
-	status, err := process.Wait()
-	require.NoError(t, err)
-	require.Equal(t, 0, status.ExitCode())
+	for _, filterType := range []extensions.FilterType{
+		extensions.FilterTypeNetwork,
+		extensions.FilterTypeListener,
+		extensions.FilterTypeUDPListener,
+	} {
+		t.Run(string(filterType), func(t *testing.T) {
+			name := fmt.Sprintf("test-docker-%s", filterType)
+			// Create a new rust extension
+			process := internaltesting.RunCLI(t, cliBin, "create", name,
+				"--path", tmpDir, "--type", "rust", "--filter-type", string(filterType))
+			status, err := process.Wait()
+			require.NoError(t, err)
+			require.Equal(t, 0, status.ExitCode())
 
-	version := "0.1.0"
-	extensionDir := filepath.Join(tmpDir, "test-docker")
-	// Create a dummy config.schema.json to test it gets included in the download for Go extensions.
-	require.NoError(t, os.WriteFile(filepath.Join(extensionDir, "config.schema.json"), []byte(`{}`), 0o600))
+			extensionDir := filepath.Join(tmpDir, name)
+			version := "0.1.0"
 
-	t.Run("makefile_image_target", func(t *testing.T) {
-		// #nosec G204
-		makeCmd := exec.CommandContext(ctx, "make", "build_image")
-		makeCmd.Dir = extensionDir
-		output, err := makeCmd.CombinedOutput()
-		t.Logf("make build_image output: %s", string(output))
-		require.NoError(t, err, "Makefile build_image target should be valid")
+			manifest := &extensions.Manifest{
+				Name:        name,
+				Version:     version,
+				Type:        extensions.TypeRust,
+				FilterTypes: []extensions.FilterType{filterType},
+			}
 
-		// Pull the image manifest and check contents
-		manifest := &extensions.Manifest{Name: "test-docker", Version: version, Type: extensions.TypeRust}
-		pushOCIImageForDownload(t, extensionDir, "./Dockerfile", manifest)
-		requireDownloadHasFiles(t, manifest, "manifest.yaml", "config.schema.json")
-	})
+			// Building the image compiles the scaffolded Rust filter
+			// project end-to-end, catching template regressions that unit tests
+			// (which only check file contents) can't catch.
+			// #nosec G204
+			makeCmd := exec.CommandContext(ctx, "make", "build_image")
+			makeCmd.Dir = extensionDir
+			output, err := makeCmd.CombinedOutput()
+			t.Logf("make build_image output: %s", string(output))
+			require.NoError(t, err, "Makefile build_image target should be valid")
 
-	t.Run("makefile_code_target", func(t *testing.T) {
-		// #nosec G204
-		makeCmd := exec.CommandContext(ctx, "make", "push_code")
-		makeCmd.Dir = extensionDir
-		output, err := makeCmd.CombinedOutput()
-		t.Logf("make push_code output: %s", string(output))
-		require.NoError(t, err, "Makefile push_code target should be valid")
-
-		// Pull the image manifest and check annotations
-		fetchManifest(t, registryAddr, "extension-src-test-docker", version)
-	})
-}
-
-func TestCreateRustNetworkWithDockerSupport(t *testing.T) {
-	tmpDir := t.TempDir()
-	ctx := t.Context()
-
-	t.Setenv("BOE_REGISTRY_INSECURE", "true")
-	t.Setenv("BOE_REGISTRY", registryAddr)
-
-	// Create a new rust network filter extension
-	process := internaltesting.RunCLI(t, cliBin, "create", "test-docker-network",
-		"--path", tmpDir, "--type", "rust", "--filter-type", "network")
-	status, err := process.Wait()
-	require.NoError(t, err)
-	require.Equal(t, 0, status.ExitCode())
-
-	extensionDir := filepath.Join(tmpDir, "test-docker-network")
-	version := "0.1.0"
-
-	manifest := &extensions.Manifest{
-		Name:        "test-docker-network",
-		Version:     version,
-		Type:        extensions.TypeRust,
-		FilterTypes: []extensions.FilterType{extensions.FilterTypeNetwork},
+			// Push local image to registry and check its annotations
+			pushOCIImageForDownload(t, extensionDir, "./Dockerfile", manifest)
+			requireDownloadHasFiles(t, manifest, "manifest.yaml")
+		})
 	}
-
-	t.Run("makefile_image_target", func(t *testing.T) {
-		// Building the image compiles the scaffolded Rust network filter
-		// project end-to-end, catching template regressions that unit tests
-		// (which only check file contents) can't catch.
-		// #nosec G204
-		makeCmd := exec.CommandContext(ctx, "make", "build_image")
-		makeCmd.Dir = extensionDir
-		output, err := makeCmd.CombinedOutput()
-		t.Logf("make build_image output: %s", string(output))
-		require.NoError(t, err, "Makefile build_image target should be valid")
-
-		// Push local image to registry and check its annotations
-		pushOCIImageForDownload(t, extensionDir, "./Dockerfile", manifest)
-		requireDownloadHasFiles(t, manifest, "manifest.yaml")
-	})
-
-	t.Run("makefile_code_target", func(t *testing.T) {
-		// #nosec G204
-		makeCmd := exec.CommandContext(ctx, "make", "push_code")
-		makeCmd.Dir = extensionDir
-		output, err := makeCmd.CombinedOutput()
-		t.Logf("make push_code output: %s", string(output))
-		require.NoError(t, err, "Makefile push_code target should be valid")
-
-		// Pull the image manifest and check annotations
-		fetchManifest(t, registryAddr, "extension-src-test-docker-network", version)
-	})
 }
 
 // pushOCIImageForDownload pushes the extension image to the test registry in OCI format,

--- a/cli/e2e/create_test.go
+++ b/cli/e2e/create_test.go
@@ -136,6 +136,8 @@ func TestCreateGoWithDockerSupport(t *testing.T) {
 }
 
 func TestCreateRustNetworkAndListenerFilters(t *testing.T) {
+	internaltesting.MaybeSkipLongRunningTest(t)
+
 	tmpDir := t.TempDir()
 	ctx := t.Context()
 

--- a/cli/e2e/run_test.go
+++ b/cli/e2e/run_test.go
@@ -151,6 +151,7 @@ func TestRustLocalExtension(t *testing.T) {
 	proxyPort := ports[0]
 	internaltesting.RunEnvoy(t, cliBin, proxyPort, ports[1],
 		"--log-level", "dynamic_modules:debug",
+		"--envoy-version", "dev-latest",
 		"--local", dataDir+"/rust-e2e",
 	)
 

--- a/extensions/Dockerfile.rust
+++ b/extensions/Dockerfile.rust
@@ -5,8 +5,7 @@
 
 # Multi-stage build for Rust dynamic modules
 
-# Build stage
-FROM rust:1.84-bookworm AS builder
+FROM rust:1.96-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && \

--- a/website/src/pages/docs/cli/create.mdx
+++ b/website/src/pages/docs/cli/create.mdx
@@ -47,6 +47,18 @@ Create a Rust network (L4) filter extension:
     boe create my-tcp-extension --type rust --filter-type network
     ```
 
+Create a Rust listener (L4) filter extension:
+
+    ```shell
+    boe create my-listener-extension --type rust --filter-type listener
+    ```
+
+Create a Rust UDP listener filter extension:
+
+    ```shell
+    boe create my-udp-extension --type rust --filter-type udp_listener
+    ```
+
 Create an ExtProc extension:
 
     ```shell
@@ -60,7 +72,8 @@ Create an ExtProc extension:
       Network filters are not currently supported for Go extensions.
     - **rust**: A dynamic module extension using the Envoy dynamic modules SDK for Rust.
       Generates Rust source files and Cargo.toml for building a dynamic library.
-      Supports both HTTP filters (default) and network (L4) filters via `--filter-type`.
+      Supports HTTP filters (default), network (L4) filters, listener (L4) filters,
+      and UDP listener filters via `--filter-type`.
     - **ext_proc**: An extension that runs as an Envoy External Processor server as an
       independent process.
 
@@ -85,7 +98,7 @@ boe create --help
 | Name | Description | Type | Default | Env Var | Required |
 |------|-------------|------|---------|-----|----------|
 | `--type` | Type of the extension (go, rust, ext_proc). | `string` | `go` | - | No |
-| `--filter-type` | Filter type (http, network). Network filters are only supported for rust. | `string` | `http` | - | No |
+| `--filter-type` | Filter type (http, network, listener, udp_listener). Network, listener, and udp_listener filters are only supported for rust. | `string` | `http` | - | No |
 | `--path` | Output directory for the extension. Defaults to the extension name. | `string` | - | - | No |
 | `--composer-version` | Composer version for Go extensions. Resolved from the registry if not set. | `string` | - | - | No |
 


### PR DESCRIPTION
Part of https://github.com/tetratelabs/built-on-envoy/issues/375 and https://github.com/tetratelabs/built-on-envoy/issues/370