### PR TITLE
Revert "ci: use zig as the C compiler for all composer platforms (#442)"

### DIFF
--- a/extensions/Dockerfile.rust
+++ b/extensions/Dockerfile.rust
@@ -3,69 +3,37 @@
 # The full text of the Apache license is available in the LICENSE file at
 # the root of the repo.
 
-# Pin the builder to the CI runner platform so cross-OS compilation
-# (e.g. darwin from a Linux runner) works without OS-level emulation.
-FROM --platform=$BUILDPLATFORM rust:1.84-bookworm AS builder
+# Multi-stage build for Rust dynamic modules
 
-ARG TARGETOS
-ARG TARGETARCH
-ARG ZIG_VERSION=0.16.0
+# Build stage
+FROM rust:1.84-bookworm AS builder
 
+# Install build dependencies
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends clang libclang-dev xz-utils && \
+    apt-get install -y clang libclang-dev && \
     rm -rf /var/lib/apt/lists/*
 
-RUN wget -qO zig.tar.xz "https://ziglang.org/download/${ZIG_VERSION}/zig-$(uname -m)-linux-${ZIG_VERSION}.tar.xz" && \
-    tar xf zig.tar.xz && mv zig-*/zig /usr/local/bin/ && mv zig-*/lib /usr/local/lib/zig && \
-    rm -rf zig.tar.xz zig-*
-
-# zig cc cannot resolve macOS SDK flags without a full SDK install.
-COPY <<'ZIGCC' /usr/local/bin/zigcc
-#!/bin/sh
-skip=false; f=
-for a in "$@"; do
-  if $skip; then skip=false; continue; fi
-  case "$a" in
-    -Wl,-flat_namespace|-Wl,-bind_at_load|-Wl,--unresolved-symbols*|-lresolv) ;;
-    -framework|-arch) skip=true ;;
-    *) f="$f $a" ;;
-  esac
-done
-exec zig cc $f
-ZIGCC
-RUN chmod +x /usr/local/bin/zigcc
-
 WORKDIR /workspace
+
+# The extension source will be mounted at build time
 COPY . .
 
-RUN RUST_ARCH=$(echo $TARGETARCH | sed 's/amd64/x86_64/;s/arm64/aarch64/') && \
-    case "$TARGETOS" in \
-      darwin) \
-        RUST_TARGET="${RUST_ARCH}-apple-darwin"; \
-        ZIG_TARGET="${RUST_ARCH}-macos"; \
-        EXT=dylib; \
-        export BINDGEN_EXTRA_CLANG_ARGS="--target=${RUST_TARGET} -isystem /usr/local/lib/zig/libc/include/any-darwin-any"; \
-        ;; \
-      *) \
-        RUST_TARGET="${RUST_ARCH}-unknown-linux-gnu"; \
-        ZIG_TARGET="${RUST_ARCH}-linux-gnu"; \
-        EXT=so; \
-        ;; \
-    esac && \
-    rustup target add $RUST_TARGET && \
-    printf '#!/bin/sh\nexec zigcc -target %s "$@"\n' "$ZIG_TARGET" > /usr/local/bin/zigcc-target && \
-    chmod +x /usr/local/bin/zigcc-target && \
-    eval "export CARGO_TARGET_$(echo $RUST_TARGET | tr 'a-z-' 'A-Z_')_LINKER=zigcc-target" && \
-    cargo build --release --target $RUST_TARGET --target-dir ./target && \
-    ORIGINAL_NAME=$(grep "^name:" manifest.yaml | sed 's/[^:]*:[[:space:]]*//g' | tr -d '"') && \
-    RUST_LIB_NAME=$(echo "$ORIGINAL_NAME" | tr '-' '_') && \
-    mkdir -p /output && \
-    cp ./target/$RUST_TARGET/release/lib${RUST_LIB_NAME}.$EXT /output/lib${ORIGINAL_NAME}.$EXT
+# Build the Rust extension
+RUN cargo build --release --target-dir ./target
 
+# Copy the library from Rust output (with underscores) to original name (with dashes)
+RUN mkdir -p /output
+RUN ORIGINAL_NAME=$(grep "^name:" manifest.yaml | sed 's/[^:]*:[[:space:]]*//g' | tr -d '"'); \
+    RUST_LIB_NAME=$(echo "$ORIGINAL_NAME" | tr '-' '_'); \
+    cp ./target/release/lib${RUST_LIB_NAME}.so /output/lib${ORIGINAL_NAME}.so
+
+# Final stage - minimal image with just the compiled library
 FROM scratch AS final
 
-COPY --from=builder /output/lib*.* /
+# Copy the compiled library from builder
+COPY --from=builder /output/*.so /
 COPY --from=builder /workspace/manifest.yaml /
 # Use a wildcard to copy config.schema.json if it exists, since COPY will fail if the file does not exist and we want to
 # allow for optional presence of this file.
 COPY --from=builder /workspace/config.schema.json* /
+

--- a/extensions/Makefile
+++ b/extensions/Makefile
@@ -152,7 +152,7 @@ push_lua: create_builder
 		--tag $(IMAGE) $(DEV_TAG) \
 		--file Dockerfile.code ./$(EXTENSION_PATH)
 
-PLATFORMS ?= linux/arm64,linux/amd64,darwin/arm64
+PLATFORMS ?= linux/arm64,linux/amd64
 .PHONY: push_rust
 push_rust: create_builder
 	@echo "Building and pushing Rust extension image for multiple architectures: $(IMAGE)"

--- a/extensions/composer/Dockerfile
+++ b/extensions/composer/Dockerfile
@@ -5,49 +5,20 @@
 
 ARG GO_VERSION
 
-# Pin the builder to the CI runner platform so cross-OS compilation
-# (e.g. darwin from a Linux runner) works without OS-level emulation.
-FROM --platform=$BUILDPLATFORM golang:${GO_VERSION} AS builder
-
-ARG TARGETOS
-ARG TARGETARCH
-ARG ZIG_VERSION=0.16.0
+FROM golang:${GO_VERSION} AS builder
 
 WORKDIR /workspace
 COPY . .
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-    ca-certificates wget git ssh netcat-openbsd xz-utils
-
-RUN wget -qO zig.tar.xz "https://ziglang.org/download/${ZIG_VERSION}/zig-$(uname -m)-linux-${ZIG_VERSION}.tar.xz" && \
-    tar xf zig.tar.xz && mv zig-*/zig /usr/local/bin/ && mv zig-*/lib /usr/local/lib/zig && \
-    rm -rf zig.tar.xz zig-*
-
-# zig cc cannot resolve macOS SDK flags without a full SDK install.
-COPY <<'ZIGCC' /usr/local/bin/zigcc
-#!/bin/sh
-skip=false; f=
-for a in "$@"; do
-  if $skip; then skip=false; continue; fi
-  case "$a" in
-    -Wl,-flat_namespace|-Wl,-bind_at_load|-Wl,--unresolved-symbols*|-lresolv) ;;
-    -framework|-arch) skip=true ;;
-    *) f="$f $a" ;;
-  esac
-done
-exec zig cc $f
-ZIGCC
-RUN chmod +x /usr/local/bin/zigcc
+# Install necessary tools for cgo
+RUN apt-get update
+RUN apt-get install -y --no-install-recommends \
+    ca-certificates wget git ssh netcat-openbsd gcc build-essential binutils binutils-gold
 
 RUN go mod download all
 ARG BUILD_TAG=""
-
-RUN ZIG_TARGET=$(echo $TARGETARCH | sed 's/arm64/aarch64/;s/amd64/x86_64/') && \
-    case "$TARGETOS" in darwin) ZIG_TARGET="$ZIG_TARGET-macos" ;; *) ZIG_TARGET="$ZIG_TARGET-linux-gnu" ;; esac && \
-    CC="zigcc -target $ZIG_TARGET" \
-    CGO_ENABLED=1 GOOS=$TARGETOS GOARCH=$TARGETARCH \
-    go build -trimpath -buildmode=c-shared ${BUILD_TAG} -o libcomposer.so ./main
+# Build go shared library
+RUN CGO_ENABLED=1 go build -buildmode=c-shared ${BUILD_TAG} -o libcomposer.so ./main
 
 FROM scratch AS final
 

--- a/extensions/composer/Dockerfile.plugin
+++ b/extensions/composer/Dockerfile.plugin
@@ -9,51 +9,19 @@
 
 ARG GO_VERSION
 
-# Pin the builder to the CI runner platform so cross-OS compilation
-# (e.g. darwin from a Linux runner) works without OS-level emulation.
-FROM --platform=$BUILDPLATFORM golang:${GO_VERSION} AS builder
+FROM golang:${GO_VERSION} AS builder
 
-ARG TARGETOS
-ARG TARGETARCH
 ARG EXTENSION_PATH
-ARG ZIG_VERSION=0.16.0
 
 WORKDIR /workspace
 COPY . .
-
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends xz-utils && \
-    rm -rf /var/lib/apt/lists/*
-
-RUN wget -qO zig.tar.xz "https://ziglang.org/download/${ZIG_VERSION}/zig-$(uname -m)-linux-${ZIG_VERSION}.tar.xz" && \
-    tar xf zig.tar.xz && mv zig-*/zig /usr/local/bin/ && mv zig-*/lib /usr/local/lib/zig && \
-    rm -rf zig.tar.xz zig-*
-
-# zig cc cannot resolve macOS SDK flags without a full SDK install.
-COPY <<'ZIGCC' /usr/local/bin/zigcc
-#!/bin/sh
-skip=false; f=
-for a in "$@"; do
-  if $skip; then skip=false; continue; fi
-  case "$a" in
-    -Wl,-flat_namespace|-Wl,-bind_at_load|-Wl,--unresolved-symbols*|-lresolv) ;;
-    -framework|-arch) skip=true ;;
-    *) f="$f $a" ;;
-  esac
-done
-exec zig cc $f
-ZIGCC
-RUN chmod +x /usr/local/bin/zigcc
 
 RUN go mod download all
 
 # BUILD_TAG is used to to include coraza waf build tags, populated by Makefile.plugin via --build-arg
 ARG BUILD_TAG=""
-RUN ZIG_TARGET=$(echo $TARGETARCH | sed 's/arm64/aarch64/;s/amd64/x86_64/') && \
-    case "$TARGETOS" in darwin) ZIG_TARGET="$ZIG_TARGET-macos" ;; *) ZIG_TARGET="$ZIG_TARGET-linux-gnu" ;; esac && \
-    CC="zigcc -target $ZIG_TARGET" \
-    CGO_ENABLED=1 GOOS=$TARGETOS GOARCH=$TARGETARCH \
-    go build -trimpath -ldflags="-s -w" -buildmode=plugin ${BUILD_TAG} -o plugin.so ./$EXTENSION_PATH/standalone
+# Build go plugin
+RUN CGO_ENABLED=1 go build -trimpath -buildmode=plugin ${BUILD_TAG} -o plugin.so ./$EXTENSION_PATH/standalone
 
 FROM scratch AS final
 

--- a/extensions/composer/Makefile
+++ b/extensions/composer/Makefile
@@ -167,7 +167,7 @@ build_image:
 
 # For default push operation, we will also prefer to build a multi-platform image to support
 # both amd64 and arm64 architectures, and push it to the registry.
-PLATFORMS ?= linux/arm64,linux/amd64,darwin/arm64
+PLATFORMS ?= linux/arm64,linux/amd64
 .PHONY: push_image
 push_image: create_builder  ## Build and push docker image for the plugin for cross-platform support
 	@echo "Building and pushing image..."

--- a/extensions/composer/Makefile.plugin
+++ b/extensions/composer/Makefile.plugin
@@ -129,7 +129,7 @@ build_image:
 
 # For default push operation, we will also prefer to build a multi-platform image to support
 # both amd64 and arm64 architectures, and push it to the registry.
-PLATFORMS ?= linux/arm64,linux/amd64,darwin/arm64
+PLATFORMS ?= linux/arm64,linux/amd64
 .PHONY: push_image
 push_image: create_builder ## Build and push docker image for the plugin for cross-platform support
 	@echo "Building and pushing image..."


### PR DESCRIPTION
This reverts commit 20c7f1155f2d09cb60e57c7ad3c78af1babb98a4.

The "plugin" packages produced for max osx are broken. Until we figure out how Go plugins can properly be cross-compiled to OSX, let's better revert the zig change and keep only packages for Linux.

Details below:

```
$ ./cli/out/boe-darwin-arm64 download example-go --dev --path /tmp/down
→ Downloading example-go for darwin/arm64...
Extension downloaded to: /tmp/down/extensions/goplugin/example-go/0.7.0-dev
```
Use this simple main to load the cross-compiled Go plugin:
```
package main

import (
	"os"
	"plugin"
)

func main() {
	_, err := plugin.Open(os.Args[1])
	if err != nil {
		panic(err)
	}
}
```
Then try to load it:
```
$ go run main.go /tmp/down/extensions/goplugin/example-go/0.7.0-dev/plugin.so
fatal error: runtime: no plugin module data

goroutine 1 gp=0x5a7d3a73a1e0 m=0 mp=0x1008d5d60 [running]:
runtime.throw({0x1007ab971?, 0x5a7d3a73a1e0?})
	/opt/homebrew/Cellar/go/1.26.4/libexec/src/runtime/panic.go:1229 +0x38 fp=0x5a7d3a7c1bb0 sp=0x5a7d3a7c1b80 pc=0x100763648
plugin.lastmoduleinit()
	/opt/homebrew/Cellar/go/1.26.4/libexec/src/runtime/plugin.go:23 +0x700 fp=0x5a7d3a7c1ca0 sp=0x5a7d3a7c1bb0 pc=0x100763d60
plugin.open({0x16f716e57, 0x3c})
	/opt/homebrew/Cellar/go/1.26.4/libexec/src/plugin/plugin_dlopen.go:77 +0x3f8 fp=0x5a7d3a7c1f10 sp=0x5a7d3a7c1ca0 pc=0x1007a52a8
plugin.Open(...)
	/opt/homebrew/Cellar/go/1.26.4/libexec/src/plugin/plugin.go:84
main.main()
	/Users/nacx/src/built-on-envoy/main.go:9 +0x34 fp=0x5a7d3a7c1f30 sp=0x5a7d3a7c1f10 pc=0x1007a5904
runtime.main()
	/opt/homebrew/Cellar/go/1.26.4/libexec/src/runtime/proc.go:290 +0x2b4 fp=0x5a7d3a7c1fd0 sp=0x5a7d3a7c1f30 pc=0x1007327a4
runtime.goexit({})
	/opt/homebrew/Cellar/go/1.26.4/libexec/src/runtime/asm_arm64.s:1447 +0x4 fp=0x5a7d3a7c1fd0 sp=0x5a7d3a7c1fd0 pc=0x100769e64

goroutine 2 gp=0x5a7d3a73ad20 m=nil [force gc (idle)]:
runtime.gopark(0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
	/opt/homebrew/Cellar/go/1.26.4/libexec/src/runtime/proc.go:462 +0xbc fp=0x5a7d3a7aef90 sp=0x5a7d3a7aef70 pc=0x100763e2c
runtime.goparkunlock(...)
	/opt/homebrew/Cellar/go/1.26.4/libexec/src/runtime/proc.go:468
runtime.forcegchelper()
	/opt/homebrew/Cellar/go/1.26.4/libexec/src/runtime/proc.go:375 +0xb4 fp=0x5a7d3a7aefd0 sp=0x5a7d3a7aef90 pc=0x100732ac4
runtime.goexit({})
	/opt/homebrew/Cellar/go/1.26.4/libexec/src/runtime/asm_arm64.s:1447 +0x4 fp=0x5a7d3a7aefd0 sp=0x5a7d3a7aefd0 pc=0x100769e64
created by runtime.init.7 in goroutine 1
	/opt/homebrew/Cellar/go/1.26.4/libexec/src/runtime/proc.go:363 +0x24

goroutine 3 gp=0x5a7d3a73b680 m=nil [GC sweep wait]:
runtime.gopark(0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
	/opt/homebrew/Cellar/go/1.26.4/libexec/src/runtime/proc.go:462 +0xbc fp=0x5a7d3a7af770 sp=0x5a7d3a7af750 pc=0x100763e2c
runtime.goparkunlock(...)
	/opt/homebrew/Cellar/go/1.26.4/libexec/src/runtime/proc.go:468
runtime.bgsweep(0x5a7d3a75e100)
	/opt/homebrew/Cellar/go/1.26.4/libexec/src/runtime/mgcsweep.go:279 +0x9c fp=0x5a7d3a7af7b0 sp=0x5a7d3a7af770 pc=0x10071ca4c
runtime.gcenable.gowrap1()
	/opt/homebrew/Cellar/go/1.26.4/libexec/src/runtime/mgc.go:214 +0x20 fp=0x5a7d3a7af7d0 sp=0x5a7d3a7af7b0 pc=0x10070dae0
runtime.goexit({})
	/opt/homebrew/Cellar/go/1.26.4/libexec/src/runtime/asm_arm64.s:1447 +0x4 fp=0x5a7d3a7af7d0 sp=0x5a7d3a7af7d0 pc=0x100769e64
created by runtime.gcenable in goroutine 1
	/opt/homebrew/Cellar/go/1.26.4/libexec/src/runtime/mgc.go:214 +0x6c

goroutine 4 gp=0x5a7d3a73b860 m=nil [GC scavenge wait]:
runtime.gopark(0x5a7d3a75e100?, 0x1007b0470?, 0x1?, 0x0?, 0x5a7d3a73b860?)
	/opt/homebrew/Cellar/go/1.26.4/libexec/src/runtime/proc.go:462 +0xbc fp=0x5a7d3a7aff60 sp=0x5a7d3a7aff40 pc=0x100763e2c
runtime.goparkunlock(...)
	/opt/homebrew/Cellar/go/1.26.4/libexec/src/runtime/proc.go:468
runtime.(*scavengerState).park(0x1008d5260)
	/opt/homebrew/Cellar/go/1.26.4/libexec/src/runtime/mgcscavenge.go:425 +0x5c fp=0x5a7d3a7aff90 sp=0x5a7d3a7aff60 pc=0x10071a50c
runtime.bgscavenge(0x5a7d3a75e100)
	/opt/homebrew/Cellar/go/1.26.4/libexec/src/runtime/mgcscavenge.go:653 +0x44 fp=0x5a7d3a7affb0 sp=0x5a7d3a7aff90 pc=0x10071aa64
runtime.gcenable.gowrap2()
	/opt/homebrew/Cellar/go/1.26.4/libexec/src/runtime/mgc.go:215 +0x20 fp=0x5a7d3a7affd0 sp=0x5a7d3a7affb0 pc=0x10070daa0
runtime.goexit({})
	/opt/homebrew/Cellar/go/1.26.4/libexec/src/runtime/asm_arm64.s:1447 +0x4 fp=0x5a7d3a7affd0 sp=0x5a7d3a7affd0 pc=0x100769e64
created by runtime.gcenable in goroutine 1
	/opt/homebrew/Cellar/go/1.26.4/libexec/src/runtime/mgc.go:215 +0xac

goroutine 5 gp=0x5a7d3a73ba40 m=nil [GOMAXPROCS updater (idle)]:
runtime.gopark(0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
	/opt/homebrew/Cellar/go/1.26.4/libexec/src/runtime/proc.go:462 +0xbc fp=0x5a7d3a7b0770 sp=0x5a7d3a7b0750 pc=0x100763e2c
runtime.goparkunlock(...)
	/opt/homebrew/Cellar/go/1.26.4/libexec/src/runtime/proc.go:468
runtime.updateMaxProcsGoroutine()
	/opt/homebrew/Cellar/go/1.26.4/libexec/src/runtime/proc.go:7095 +0xf4 fp=0x5a7d3a7b07d0 sp=0x5a7d3a7b0770 pc=0x100741234
runtime.goexit({})
	/opt/homebrew/Cellar/go/1.26.4/libexec/src/runtime/asm_arm64.s:1447 +0x4 fp=0x5a7d3a7b07d0 sp=0x5a7d3a7b07d0 pc=0x100769e64
created by runtime.defaultGOMAXPROCSUpdateEnable in goroutine 1
	/opt/homebrew/Cellar/go/1.26.4/libexec/src/runtime/proc.go:7083 +0x48

goroutine 6 gp=0x5a7d3a7ee1e0 m=nil [finalizer wait]:
runtime.gopark(0x0?, 0x0?, 0xb8?, 0xe5?, 0x100764974?)
	/opt/homebrew/Cellar/go/1.26.4/libexec/src/runtime/proc.go:462 +0xbc fp=0x5a7d3a7ae580 sp=0x5a7d3a7ae560 pc=0x100763e2c
runtime.runFinalizers()
	/opt/homebrew/Cellar/go/1.26.4/libexec/src/runtime/mfinal.go:210 +0x100 fp=0x5a7d3a7ae7d0 sp=0x5a7d3a7ae580 pc=0x10070cbb0
runtime.goexit({})
	/opt/homebrew/Cellar/go/1.26.4/libexec/src/runtime/asm_arm64.s:1447 +0x4 fp=0x5a7d3a7ae7d0 sp=0x5a7d3a7ae7d0 pc=0x100769e64
created by runtime.createfing in goroutine 1
	/opt/homebrew/Cellar/go/1.26.4/libexec/src/runtime/mfinal.go:172 +0x78
exit status 2
```