### PR TITLE
use -trimpath for all go build to fix error where composer-lite cannot works

### DIFF
--- a/cli/cmd/templates/create/ext_proc/Dockerfile.tmpl
+++ b/cli/cmd/templates/create/ext_proc/Dockerfile.tmpl
@@ -16,7 +16,7 @@ COPY . .
 RUN go mod download all
 
 # Build the ext_proc server binary
-RUN CGO_ENABLED=0 go build -a -ldflags="-s -w" -o ./out/ext_proc-server .
+RUN CGO_ENABLED=0 go build -trimpath -a -ldflags="-s -w" -o ./out/ext_proc-server .
 
 FROM scratch AS final
 

--- a/cli/cmd/templates/create/ext_proc/Makefile.tmpl
+++ b/cli/cmd/templates/create/ext_proc/Makefile.tmpl
@@ -75,7 +75,7 @@ create_builder:
 
 .PHONY: build
 build:  ## Compile the extproc server binary
-	CGO_ENABLED=0 go build -a -ldflags="-s -w" -o ./out/ext_proc-server .
+	CGO_ENABLED=0 go build -trimpath -a -ldflags="-s -w" -o ./out/ext_proc-server .
 
 .PHONY: test
 test:  ## Run the tests

--- a/cli/cmd/templates/create/ext_proc/manifest.yaml.tmpl
+++ b/cli/cmd/templates/create/ext_proc/manifest.yaml.tmpl
@@ -14,7 +14,7 @@ longDescription: |
   ## Building
 
   ```bash
-  go build -o ext_proc-server .
+  go build -trimpath -o ext_proc-server .
   ```
 
   ## Running

--- a/cli/cmd/templates/create/go/Dockerfile.plugin.tmpl
+++ b/cli/cmd/templates/create/go/Dockerfile.plugin.tmpl
@@ -16,7 +16,7 @@ COPY . .
 RUN go mod download all
 
 # Build go plugin
-RUN CGO_ENABLED=1 go build -buildmode=plugin -o plugin.so ./standalone
+RUN CGO_ENABLED=1 go build -trimpath -buildmode=plugin -o plugin.so ./standalone
 
 FROM scratch AS final
 

--- a/cli/cmd/templates/create/go/Dockerfile.tmpl
+++ b/cli/cmd/templates/create/go/Dockerfile.tmpl
@@ -23,7 +23,7 @@ RUN apt-get install -y --no-install-recommends \
 RUN go mod download all
 
 # Build go shared library
-RUN CGO_ENABLED=1 go build -buildmode=c-shared -o lib${NAME}.so ./main
+RUN CGO_ENABLED=1 go build -trimpath -buildmode=c-shared -o lib${NAME}.so ./main
 
 FROM scratch AS final
 

--- a/cli/cmd/templates/create/go/Makefile.tmpl
+++ b/cli/cmd/templates/create/go/Makefile.tmpl
@@ -80,11 +80,11 @@ create_builder:
 
 .PHONY: build
 build:  ## Compile the extension into an Envoy Dynamic Module
-	CGO_ENABLED=1 go build -buildmode=c-shared -o lib$(NAME).so ./main
+	CGO_ENABLED=1 go build -trimpath -buildmode=c-shared -o lib$(NAME).so ./main
 
 .PHONY: build-plugin
 build-plugin:  ## Compile the extension into a Go plugin, loadable by the Composer Dynamic Module
-	go build -buildmode=plugin -o plugin.so ./standalone
+	go build -trimpath -buildmode=plugin -o plugin.so ./standalone
 
 .PHONY: test
 test:  ## Run the tests

--- a/extensions/Dockerfile.extproc
+++ b/extensions/Dockerfile.extproc
@@ -19,7 +19,7 @@ COPY . .
 RUN go mod download all
 
 # Build the ext_proc server binary
-RUN CGO_ENABLED=0 go build -a -ldflags="-s -w" -o ./out/ext_proc-server .
+RUN CGO_ENABLED=0 go build -trimpath -a -ldflags="-s -w" -o ./out/ext_proc-server .
 
 FROM scratch AS final
 

--- a/extensions/composer/Dockerfile
+++ b/extensions/composer/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get install -y --no-install-recommends \
 RUN go mod download all
 ARG BUILD_TAG=""
 # Build go shared library
-RUN CGO_ENABLED=1 go build -buildmode=c-shared ${BUILD_TAG} -o libcomposer.so ./main
+RUN CGO_ENABLED=1 go build -trimpath -buildmode=c-shared ${BUILD_TAG} -o libcomposer.so ./main
 
 FROM scratch AS final
 

--- a/extensions/composer/goplugin-loader/README.md
+++ b/extensions/composer/goplugin-loader/README.md
@@ -35,7 +35,7 @@ Plugins must:
 ## Building a Plugin
 
 ```bash
-go build -buildmode=plugin -o myplugin.so ./myplugin
+go build -trimpath -buildmode=plugin -o myplugin.so ./myplugin
 ```
 
 ## Configuration

--- a/website/src/pages/docs/extension-types.mdx
+++ b/website/src/pages/docs/extension-types.mdx
@@ -84,7 +84,7 @@ loader module) that will load the plugin.
 ### How it works
 
 1. Your extension exports a `WellKnownHttpFilterConfigFactories()` function as its entry point.
-2. The extension is compiled with `go build -buildmode=plugin` to produce a `.so` file.
+2. The extension is compiled with `go build -trimpath -buildmode=plugin` to produce a `.so` file.
 3. At runtime, the Composer's plugin loader opens the `.so` file and validates that it was built
    with the same Go version and matching dependency versions before registering its filters.
 

--- a/website/src/pages/docs/packaging-prod.mdx
+++ b/website/src/pages/docs/packaging-prod.mdx
@@ -244,7 +244,7 @@ If you have your own custom Go extensions (created with [boe create](/docs/cli/c
 The Dynamic Module can be compiled as follows:
 
 ```shell
-CGO_ENABLED=1 go build -buildmode=c-shared -o libmyboe.so main.go
+CGO_ENABLED=1 go build -trimpath -buildmode=c-shared -o libmyboe.so main.go
 ```
 
 This will produce a Go Dynamic Module with all the configured extensions that can be safely loaded into Envoy without having to worry about


### PR DESCRIPTION
use -trimpath for all go build to fix error where composer-lite cannot works:

```
[2026-06-05 18:43:43.865][4002665][warning][dynamic_modules] [source/extensions/dynamic_modules/abi_impl.cc:57] Failed to load configuration: failed to handle dynamic module plugin example-go: failed to create config factory for plugin example-go: failed to open plugin as Go plugin module: plugin.Open("example-go"): plugin was built with a different version of package internal/goarch
```