### PR TITLE
create: generate the config schema

### DIFF
--- a/cli/cmd/create.go
+++ b/cli/cmd/create.go
@@ -96,6 +96,7 @@ func createGoExtension(logger *slog.Logger, dirs *xdg.Directories, path, name, c
 		"plugin.go":          "templates/create/go/plugin.go.tmpl",
 		"plugin_test.go":     "templates/create/go/plugin_test.go.tmpl",
 		"manifest.yaml":      "templates/create/go/manifest.yaml.tmpl",
+		"config.schema.json": "templates/create/go/config.schema.json.tmpl",
 		"Makefile":           "templates/create/go/Makefile.tmpl",
 		"go.mod":             "templates/create/go/go.mod.tmpl",
 		"Dockerfile":         "templates/create/go/Dockerfile.tmpl",
@@ -210,12 +211,14 @@ func createRustExtension(logger *slog.Logger, path, name, filterType string) err
 
 	libTemplate := fmt.Sprintf("templates/create/rust/lib_%s.rs.tmpl", filterType)
 	manifestTemplate := fmt.Sprintf("templates/create/rust/manifest_%s.yaml.tmpl", filterType)
+	configSchemaTemplate := fmt.Sprintf("templates/create/rust/config.schema.%s.json.tmpl", filterType)
 
 	// Map of output filename to template filename
 	files := map[string]string{
 		"src/lib.rs":         libTemplate,
 		"Cargo.toml":         "templates/create/rust/Cargo.toml.tmpl",
 		"manifest.yaml":      manifestTemplate,
+		"config.schema.json": configSchemaTemplate,
 		".gitignore":         "templates/create/rust/gitignore.tmpl",
 		".dockerignore":      "templates/create/rust/dockerignore.tmpl",
 		".cargo/config.toml": "templates/create/rust/cargo-config.toml.tmpl",

--- a/cli/cmd/create_test.go
+++ b/cli/cmd/create_test.go
@@ -96,6 +96,7 @@ func TestCreateGo_Run(t *testing.T) {
 			"plugin.go",
 			"plugin_test.go",
 			"manifest.yaml",
+			"config.schema.json",
 			"Makefile",
 			"go.mod",
 			"Dockerfile",
@@ -116,6 +117,12 @@ func TestCreateGo_Run(t *testing.T) {
 		require.NoError(t, err)
 		assert.Contains(t, string(manifest), "name: "+name)
 		assert.Contains(t, string(manifest), "type: go")
+
+		// verify config.schema.json content
+		// #nosec G304
+		configSchema, err := os.ReadFile(filepath.Join(repoPath, "config.schema.json"))
+		require.NoError(t, err)
+		assert.Contains(t, string(configSchema), `"header_value": {`)
 
 		// verify plugin.go content
 		// #nosec G304
@@ -261,6 +268,7 @@ func TestCreateRust_Run(t *testing.T) {
 		"src/lib.rs",
 		"Cargo.toml",
 		"manifest.yaml",
+		"config.schema.json",
 		".gitignore",
 		".dockerignore",
 		".cargo/config.toml",
@@ -278,6 +286,12 @@ func TestCreateRust_Run(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(manifest), "name: "+name)
 	assert.Contains(t, string(manifest), "type: rust")
+
+	// verify config.schema.json content
+	// #nosec G304
+	configSchema, err := os.ReadFile(filepath.Join(repoPath, "config.schema.json"))
+	require.NoError(t, err)
+	assert.Contains(t, string(configSchema), `"header_value": {`)
 
 	// verify Cargo.toml content
 	// #nosec G304
@@ -332,6 +346,12 @@ func TestCreateRust_NetworkFilter_Run(t *testing.T) {
 	assert.Contains(t, string(manifest), "type: rust")
 	assert.Contains(t, string(manifest), "filterType: [network]")
 
+	// verify config.schema.json content
+	// #nosec G304
+	configSchema, err := os.ReadFile(filepath.Join(repoPath, "config.schema.json"))
+	require.NoError(t, err)
+	assert.Contains(t, string(configSchema), `"log_tag": {`)
+
 	// verify src/lib.rs contains network filter constructs, not HTTP.
 	// #nosec G304
 	libRs, err := os.ReadFile(filepath.Join(repoPath, "src/lib.rs"))
@@ -343,7 +363,7 @@ func TestCreateRust_NetworkFilter_Run(t *testing.T) {
 	assert.NotContains(t, string(libRs), "HttpFilterConfig")
 }
 
-func TestCreateRust_UdpListenerFilter_Run(t *testing.T) {
+func TestCreateRust_UDPListenerFilter_Run(t *testing.T) {
 	tmpDir := t.TempDir()
 	name := "my-udp-extension"
 
@@ -367,6 +387,12 @@ func TestCreateRust_UdpListenerFilter_Run(t *testing.T) {
 	assert.Contains(t, string(manifest), "name: "+name)
 	assert.Contains(t, string(manifest), "type: rust")
 	assert.Contains(t, string(manifest), "filterType: [udp_listener]")
+
+	// verify config.schema.json content
+	// #nosec G304
+	configSchema, err := os.ReadFile(filepath.Join(repoPath, "config.schema.json"))
+	require.NoError(t, err)
+	assert.Contains(t, string(configSchema), `"log_tag": {`)
 
 	// verify src/lib.rs contains udp listener filter constructs, not HTTP, network, or listener.
 	// #nosec G304
@@ -406,6 +432,12 @@ func TestCreateRust_ListenerFilter_Run(t *testing.T) {
 	assert.Contains(t, string(manifest), "name: "+name)
 	assert.Contains(t, string(manifest), "type: rust")
 	assert.Contains(t, string(manifest), "filterType: [listener]")
+
+	// verify config.schema.json content
+	// #nosec G304
+	configSchema, err := os.ReadFile(filepath.Join(repoPath, "config.schema.json"))
+	require.NoError(t, err)
+	assert.Contains(t, string(configSchema), `"log_tag": {`)
 
 	// verify src/lib.rs contains listener filter constructs, not HTTP or network.
 	// #nosec G304

--- a/cli/cmd/templates/create/go/config.schema.json.tmpl
+++ b/cli/cmd/templates/create/go/config.schema.json.tmpl
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "{{ .Name }}/config.schema.json",
+  "title": "{{ .Name }} Configuration",
+  "description": "Configuration for the {{ .Name }} extension.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "header_value": {
+      "type": "string",
+      "description": "Custom value for the header to add. Defaults to \"example\" if not set."
+    }
+  }
+}

--- a/cli/cmd/templates/create/rust/config.schema.http.json.tmpl
+++ b/cli/cmd/templates/create/rust/config.schema.http.json.tmpl
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "{{ .Name }}/config.schema.json",
+  "title": "{{ .Name }} Configuration",
+  "description": "Configuration for the {{ .Name }} extension.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "header_value": {
+      "type": "string",
+      "description": "Custom value for the header to add. Defaults to \"example\" if not set."
+    }
+  }
+}

--- a/cli/cmd/templates/create/rust/config.schema.listener.json.tmpl
+++ b/cli/cmd/templates/create/rust/config.schema.listener.json.tmpl
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "{{ .Name }}/config.schema.json",
+  "title": "{{ .Name }} Configuration",
+  "description": "Configuration for the {{ .Name }} extension.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "log_tag": {
+      "type": "string",
+      "description": "Custom value for the log tag to use. Defaults to \"example\" if not set."
+    }
+  }
+}

--- a/cli/cmd/templates/create/rust/config.schema.network.json.tmpl
+++ b/cli/cmd/templates/create/rust/config.schema.network.json.tmpl
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "{{ .Name }}/config.schema.json",
+  "title": "{{ .Name }} Configuration",
+  "description": "Configuration for the {{ .Name }} extension.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "log_tag": {
+      "type": "string",
+      "description": "Custom value for the log tag to use. Defaults to \"example\" if not set."
+    }
+  }
+}

--- a/cli/cmd/templates/create/rust/config.schema.udp_listener.json.tmpl
+++ b/cli/cmd/templates/create/rust/config.schema.udp_listener.json.tmpl
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "{{ .Name }}/config.schema.json",
+  "title": "{{ .Name }} Configuration",
+  "description": "Configuration for the {{ .Name }} extension.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "log_tag": {
+      "type": "string",
+      "description": "Custom value for the log tag to use. Defaults to \"example\" if not set."
+    }
+  }
+}


### PR DESCRIPTION
Generate the config schema when generating extensions. Now that the UI PR https://github.com/tetratelabs/built-on-envoy/pull/464 supports showing local extensions, having a default config schema produced is a nice experience to let the users try their local extensions in the UI, and having a visual way of providing the config.