### PR TITLE
to support single platfrom image push

### DIFF
--- a/cli/cmd/templates/create/ext_proc/Makefile.tmpl
+++ b/cli/cmd/templates/create/ext_proc/Makefile.tmpl
@@ -109,6 +109,12 @@ build_image:  ## Build the OCI image for the extproc server
 # For default push operation, we will also prefer to build a multi-platform image to support
 # both amd64 and arm64 architectures, and push it to the registry.
 PLATFORMS ?= linux/arm64,linux/amd64
+# index,manifest: annotations are only valid for multi-platform (OCI index) exports.
+ifneq (,$(findstring $(comma),$(PLATFORMS)))
+  PUSH_ANNOTATIONS := $(MULTI_OCI_ANNOTATIONS)
+else
+  PUSH_ANNOTATIONS := $(BASE_OCI_ANNOTATIONS) $(BINARY_ARTIFACT)
+endif
 .PHONY: push_image
 push_image: create_builder  ## Build and push OCI image for the extproc server
 	@echo "Building and pushing image..."
@@ -116,7 +122,7 @@ push_image: create_builder  ## Build and push OCI image for the extproc server
 		--builder $(BUILDER_NAME) \
 		--output type=registry,oci-mediatypes=true$(registry_output) \
 		--provenance=false \
-		$(MULTI_OCI_ANNOTATIONS) \
+		$(PUSH_ANNOTATIONS) \
 		--tag $(IMAGE) \
 		-f ./Dockerfile .
 

--- a/cli/cmd/templates/create/go/Makefile.tmpl
+++ b/cli/cmd/templates/create/go/Makefile.tmpl
@@ -147,8 +147,10 @@ endif
 # index,manifest: annotations are only valid for multi-platform (OCI index) exports.
 ifneq (,$(findstring $(comma),$(PLATFORMS)))
   PUSH_ANNOTATIONS := $(MULTI_OCI_ANNOTATIONS)
+  PUSH_CSHARED_ANNOTATION := $(subst --annotation ",--annotation "index$(comma)manifest:,$(CSHARED_ARTIFACT))
 else
   PUSH_ANNOTATIONS := $(BASE_OCI_ANNOTATIONS) $(BINARY_ARTIFACT)
+  PUSH_CSHARED_ANNOTATION := $(CSHARED_ARTIFACT)
 endif
 .PHONY: push_image
 push_image: create_builder  ## Build and push the OCI image for the extension Dynamic Module
@@ -159,7 +161,7 @@ push_image: create_builder  ## Build and push the OCI image for the extension Dy
 		--provenance=false \
 		--build-arg NAME="$(NAME)" \
 		$(PUSH_ANNOTATIONS) \
-		$(subst --annotation ",--annotation "index$(comma)manifest:,$(CSHARED_ARTIFACT)) \
+		$(PUSH_CSHARED_ANNOTATION) \
 		--tag $(IMAGE) \
 		-f ./Dockerfile .
 

--- a/cli/cmd/templates/create/rust/Makefile.tmpl
+++ b/cli/cmd/templates/create/rust/Makefile.tmpl
@@ -132,6 +132,12 @@ build_image: create_builder  ## Build the OCI image for the extension Dynamic Mo
 # For default push operation, we will also prefer to build a multi-platform image to support
 # both amd64 and arm64 architectures, and push it to the registry.
 PLATFORMS ?= linux/arm64,linux/amd64
+# index,manifest: annotations are only valid for multi-platform (OCI index) exports.
+ifneq (,$(findstring $(comma),$(PLATFORMS)))
+  PUSH_ANNOTATIONS := $(MULTI_OCI_ANNOTATIONS)
+else
+  PUSH_ANNOTATIONS := $(BASE_OCI_ANNOTATIONS) $(BINARY_ARTIFACT)
+endif
 .PHONY: push_image
 push_image: create_builder  ## Build and push the OCI image for the extension Dynamic Module
 	@echo "Building and pushing image..."
@@ -139,7 +145,7 @@ push_image: create_builder  ## Build and push the OCI image for the extension Dy
 		--builder $(BUILDER_NAME) \
 		--output type=registry,oci-mediatypes=true$(registry_output) \
 		--provenance=false \
-		$(MULTI_OCI_ANNOTATIONS) \
+		$(PUSH_ANNOTATIONS) \
 		--tag $(IMAGE) \
 		-f ./Dockerfile .
 

--- a/extensions/Makefile
+++ b/extensions/Makefile
@@ -161,7 +161,7 @@ else
 endif
 .PHONY: push_rust
 push_rust: create_builder
-	@echo "Building and pushing Rust extension image for multiple architectures: $(IMAGE)"
+	@echo "Building and pushing Rust extension image for platforms ($(PLATFORMS)): $(IMAGE)"
 	@docker buildx build \
 		--builder $(BUILDER_NAME) \
 		--platform=$(PLATFORMS) \

--- a/extensions/Makefile
+++ b/extensions/Makefile
@@ -153,6 +153,12 @@ push_lua: create_builder
 		--file Dockerfile.code ./$(EXTENSION_PATH)
 
 PLATFORMS ?= linux/arm64,linux/amd64
+# index,manifest: annotations are only valid for multi-platform (OCI index) exports.
+ifneq (,$(findstring $(comma),$(PLATFORMS)))
+  PUSH_ANNOTATIONS := $(MULTI_OCI_ANNOTATIONS)
+else
+  PUSH_ANNOTATIONS := $(BASE_OCI_ANNOTATIONS) $(BINARY_ARTIFACT)
+endif
 .PHONY: push_rust
 push_rust: create_builder
 	@echo "Building and pushing Rust extension image for multiple architectures: $(IMAGE)"
@@ -161,7 +167,7 @@ push_rust: create_builder
 		--platform=$(PLATFORMS) \
 		--output type=registry,oci-mediatypes=true$(registry_output) \
 		--provenance=false \
-		$(MULTI_OCI_ANNOTATIONS) \
+		$(PUSH_ANNOTATIONS) \
 		--tag $(IMAGE) $(DEV_TAG) \
 		--file Dockerfile.rust ./$(EXTENSION_PATH)
 
@@ -174,7 +180,7 @@ push_extproc: create_builder
 		--output type=registry,oci-mediatypes=true$(registry_output) \
 		--provenance=false \
 		--build-arg GO_VERSION="$(GO_VERSION)" \
-		$(MULTI_OCI_ANNOTATIONS) \
+		$(PUSH_ANNOTATIONS) \
 		--tag $(IMAGE) $(DEV_TAG) \
 		--file Dockerfile.extproc ./$(EXTENSION_PATH)
 

--- a/extensions/composer/Makefile
+++ b/extensions/composer/Makefile
@@ -125,7 +125,8 @@ CSHARED_ARTIFACT := --annotation "io.tetratelabs.built-on-envoy.extension.cshare
 # Multi-platform OCI annotations (with index,manifest prefix, for binary artifacts)
 MULTI_OCI_ANNOTATIONS := \
 	$(subst --annotation ",--annotation "index$(comma)manifest:,$(BASE_OCI_ANNOTATIONS)) \
-	$(subst --annotation ",--annotation "index$(comma)manifest:,$(BINARY_ARTIFACT))
+	$(subst --annotation ",--annotation "index$(comma)manifest:,$(BINARY_ARTIFACT)) \
+	$(subst --annotation ",--annotation "index$(comma)manifest:,$(CSHARED_ARTIFACT))
 
 BUILDER_NAME := boe-builder
 .PHONY: create_builder
@@ -168,6 +169,12 @@ build_image:
 # For default push operation, we will also prefer to build a multi-platform image to support
 # both amd64 and arm64 architectures, and push it to the registry.
 PLATFORMS ?= linux/arm64,linux/amd64
+# index,manifest: annotations are only valid for multi-platform (OCI index) exports.
+ifneq (,$(findstring $(comma),$(PLATFORMS)))
+  PUSH_ANNOTATIONS := $(MULTI_OCI_ANNOTATIONS)
+else
+  PUSH_ANNOTATIONS := $(BASE_OCI_ANNOTATIONS) $(BINARY_ARTIFACT) $(CSHARED_ARTIFACT)
+endif
 .PHONY: push_image
 push_image: create_builder  ## Build and push docker image for the plugin for cross-platform support
 	@echo "Building and pushing image..."
@@ -175,8 +182,7 @@ push_image: create_builder  ## Build and push docker image for the plugin for cr
 		--builder $(BUILDER_NAME) \
 		--output type=registry,oci-mediatypes=true$(registry_output) \
 		--provenance=false \
-		$(MULTI_OCI_ANNOTATIONS) \
-		$(subst --annotation ",--annotation "index$(comma)manifest:,$(CSHARED_ARTIFACT)) \
+		$(PUSH_ANNOTATIONS) \
 		--build-arg BUILD_TAG="$(COMPOSER_BUILD_TAG)" \
 		--build-arg GO_VERSION="$(GO_VERSION)" \
 		--tag $(IMAGE) $(DEV_TAG) \
@@ -216,7 +222,7 @@ install_plugins: ## Install all plugins locally
 	@for dir in $(PLUGIN_CLEAN_DIRS); do \
 		$(MAKE) -f Makefile.plugin install EXTENSION_PATH=$$dir; \
 	done
-	
+
 # Envoy runs in a Linux container, so the integration library must be Linux.
 .PHONY: test-integration
 test-integration: force_target_os := $(OS)

--- a/extensions/composer/Makefile.plugin
+++ b/extensions/composer/Makefile.plugin
@@ -79,7 +79,6 @@ BASE_OCI_ANNOTATIONS := \
 # Artifact type annotations
 BINARY_ARTIFACT    := --annotation "io.tetratelabs.built-on-envoy.extension.artifact=binary"
 SOURCE_ARTIFACT    := --annotation "io.tetratelabs.built-on-envoy.extension.artifact=source"
-NOCSHARED_ARTIFACT := --annotation "io.tetratelabs.built-on-envoy.extension.cshared=false"
 
 # Multi-platform OCI annotations (with index,manifest prefix, for binary artifacts)
 comma := ,
@@ -122,7 +121,6 @@ build_image:
 		--build-arg BUILD_TAG="$(PLUGIN_BUILD_TAG)" \
 		--build-arg GO_VERSION="$(GO_VERSION)" \
 		$(BASE_OCI_ANNOTATIONS) \
-		$(NOCSHARED_ARTIFACT) \
 		$(BINARY_ARTIFACT) \
 		-t $(IMAGE)-linux-$(ARCH) \
 		-f ./Dockerfile.plugin .
@@ -130,6 +128,12 @@ build_image:
 # For default push operation, we will also prefer to build a multi-platform image to support
 # both amd64 and arm64 architectures, and push it to the registry.
 PLATFORMS ?= linux/arm64,linux/amd64
+# index,manifest: annotations are only valid for multi-platform (OCI index) exports.
+ifneq (,$(findstring $(comma),$(PLATFORMS)))
+  PUSH_ANNOTATIONS := $(MULTI_OCI_ANNOTATIONS)
+else
+  PUSH_ANNOTATIONS := $(BASE_OCI_ANNOTATIONS) $(BINARY_ARTIFACT)
+endif
 .PHONY: push_image
 push_image: create_builder ## Build and push docker image for the plugin for cross-platform support
 	@echo "Building and pushing image..."
@@ -141,7 +145,6 @@ push_image: create_builder ## Build and push docker image for the plugin for cro
 		--build-arg EXTENSION_PATH=$(EXTENSION_PATH) \
 		--build-arg BUILD_TAG="$(PLUGIN_BUILD_TAG)" \
 		--build-arg GO_VERSION="$(GO_VERSION)" \
-		$(MULTI_OCI_ANNOTATIONS) \
-		$(subst --annotation ",--annotation "index$(comma)manifest:,$(NOCSHARED_ARTIFACT)) \
+		$(PUSH_ANNOTATIONS) \
 		--tag $(IMAGE) $(DEV_TAG) \
 		-f ./Dockerfile.plugin .


### PR DESCRIPTION
In the previous implementation, if we set the PLATFORMS to single arch, the push_image will fail because single arch image cannot support `index` annotations.
This PR addressed that.