### PR TITLE
gen-config: remove validations at the config generation stage

### DIFF
--- a/cli/internal/envoy/extension.go
+++ b/cli/internal/envoy/extension.go
@@ -262,21 +262,12 @@ func (d DynamicModuleFilterGenerator) GenerateFilterConfig(manifest *extensions.
 func (c ComposerFilterGenerator) GenerateFilterConfig(manifest *extensions.Manifest, dirs *xdg.Directories, config string) (*ExtensionResources, error) {
 	c.Logger.Info("generating composer filter config for extension", "name", manifest.Name, "config", config)
 
-	cachedComposerPath := extensions.LocalCacheComposerLib(dirs, manifest.ComposerVersion)
-	if _, err := os.Stat(cachedComposerPath); os.IsNotExist(err) {
-		// TODO(wbpcode): Download the composer binary from the URL specified in the manifest.
-		return nil, fmt.Errorf("composer binary not found at %s", cachedComposerPath)
-	}
-
 	var pluginURL string
 	if manifest.Remote && manifest.SourceRegistry != "" {
 		// For remote extensions, use oci:// URL so config is portable.
 		pluginURL = "oci://" + extensions.RepositoryName(manifest.SourceRegistry, manifest.Name) + ":" + manifest.SourceTag
 	} else {
 		cachedPluginPath := extensions.LocalCacheExtension(dirs, manifest)
-		if _, err := os.Stat(cachedPluginPath); os.IsNotExist(err) {
-			return nil, fmt.Errorf("go plugin binary not found at %s", cachedPluginPath)
-		}
 		pluginURL = "file://" + cachedPluginPath
 	}
 

--- a/cli/internal/envoy/extension_test.go
+++ b/cli/internal/envoy/extension_test.go
@@ -7,7 +7,6 @@ package envoy
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -468,25 +467,6 @@ func TestComposerFilterGenerator(t *testing.T) {
 		Remote:          true,
 	}
 
-	// Case 1: Composer binary missing
-	_, err := GenerateFilterConfig(logger, manifest, dirs, "")
-	require.ErrorContains(t, err, "composer binary not found")
-
-	// Create Composer binary
-	composerPath := extensions.LocalCacheComposerDir(dirs, manifest.ComposerVersion)
-	require.NoError(t, os.MkdirAll(composerPath, 0o750))
-	require.NoError(t, os.WriteFile(filepath.Join(composerPath, "libcomposer.so"), []byte("fake binary"), 0o600))
-
-	// Case 2: Plugin binary missing
-	_, err = GenerateFilterConfig(logger, manifest, dirs, "")
-	require.ErrorContains(t, err, "go plugin binary not found")
-
-	// Create Plugin binary
-	pluginPath := filepath.Join(dirs.DataHome, "extensions", "goplugin", manifest.Name, manifest.Version)
-	require.NoError(t, os.MkdirAll(pluginPath, 0o750))
-	require.NoError(t, os.WriteFile(filepath.Join(pluginPath, "plugin.so"), []byte("fake binary"), 0o600))
-
-	// Case 3: Success without config
 	got, err := GenerateFilterConfig(logger, manifest, dirs, "")
 	require.NoError(t, err)
 


### PR DESCRIPTION
Remove the cache validations in the DYM config generation. At that stage, we should assume files already exist, as they have already been fetched by the `run` command.
Removing the validation allows users to call `boe gen-config --extension example-go` (and other composer extensions) when the cache is empty because they never ran before and the composer extension is not there.
