### PR TITLE
merge the local/remote source processing

### DIFF
--- a/cli/cmd/genconfig.go
+++ b/cli/cmd/genconfig.go
@@ -102,7 +102,7 @@ func (g *GenConfig) Run(ctx context.Context, dirs *xdg.Directories, logger *slog
 	}
 
 	// If we're only generating config to print to the stdout, we can skip building the extensions
-	// but if we're exporting it, we need ot build to make sure the extension files exist.
+	// but if we're exporting it, we need to build to make sure the extension files exist.
 	downloaded, err := downloadExtensions(ctx, downloader, g.Extensions, true)
 	if err != nil {
 		return err

--- a/cli/cmd/genconfig_test.go
+++ b/cli/cmd/genconfig_test.go
@@ -371,7 +371,7 @@ func TestGenConfigWriteConfig(t *testing.T) {
 			logger = internaltesting.NewTLogger(t)
 			dirs   = &xdg.Directories{DataHome: t.TempDir()}
 
-			gpl    = &extensions.Manifest{Name: extensions.GoPluginLoaderName, Type: extensions.TypeGo, CShared: true, Bundle: extensions.ComposerBundle, Version: "1.0.0"}
+			gpl    = &extensions.Manifest{Name: extensions.GoPluginLoaderName, Type: extensions.TypeGo, CShared: true, Parent: extensions.ComposerBundle, Version: "1.0.0"}
 			gplLib = extensions.LocalCacheExtension(dirs, gpl) // resolves to dym/composer/1.0.0/libcomposer.so
 		)
 		require.NoError(t, os.MkdirAll(filepath.Dir(gplLib), 0o750))

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -15,7 +15,6 @@ import (
 	"maps"
 	"net"
 	"os"
-	"path/filepath"
 	"runtime"
 	"slices"
 	"strconv"
@@ -264,83 +263,27 @@ func downloadExtensions(ctx context.Context, downloader *extensions.Downloader, 
 
 		switch artifact.ArtifactType {
 		case extensions.ArtifactBinary:
-			if artifact.Manifest.Type == extensions.TypeGo {
+			if artifact.Manifest.Type == extensions.TypeGo && !artifact.Manifest.CShared {
 				// Ensure the composer is downloaded before running any extensions that may depend on it.
-				if err = extensions.CheckOrDownloadLibComposer(ctx, downloader, artifact.Manifest.ComposerVersion, extensions.ComposerArtifactLite); err != nil {
+				if err = extensions.CheckOrDownloadLibComposer(ctx, downloader, artifact.Manifest.ComposerVersion,
+					extensions.ComposerArtifactLite); err != nil {
 					return nil, fmt.Errorf("failed to download libcomposer %s for extension %s: %w",
 						artifact.Manifest.ComposerVersion, name, err)
 				}
+				composerManifest, _ := extensions.GetComposerManifest(downloader.Dirs, artifact.Manifest.ComposerVersion)
+				if composerManifest != nil {
+					extensions.ResolveVersionsWithParent(artifact.ExtensionManifest, composerManifest)
+				}
 			}
-			downloaded = append(downloaded, artifact.Manifest)
-
+			artifact.ExtensionManifest.CShared = artifact.Manifest.CShared
+			downloaded = append(downloaded, artifact.ExtensionManifest)
 		case extensions.ArtifactSource:
-			switch artifact.Manifest.Type {
-			// If the downloaded artifact is the composer bundle, we need to find the path to the extension
-			// inside the composer source tree.
-			case extensions.TypeComposer:
-				var manifest, composerManifest *extensions.Manifest
-				extensionSrc := extensions.LocalCacheComposerExtensionSourceDir(downloader.Dirs, artifact.Manifest, name)
-				if extensionSrc == "" {
-					return nil, fmt.Errorf("invalid source artifact for Go extension %s: missing expected source directory: %s", name, artifact.Path)
-				}
-				downloader.Logger.Info("loading downloaded extension manifest", "path", extensionSrc)
-
-				manifest, err = extensions.LoadLocalManifest(filepath.Join(extensionSrc, "manifest.yaml"))
-				if err != nil {
-					return nil, fmt.Errorf("failed to load manifest for composer extension %s from source artifact %q: %w",
-						name, extensionSrc, err)
-				}
-				composerManifestPath := filepath.Join(extensions.LocalCacheComposerSourceArtifactDir(downloader.Dirs, artifact.Manifest), "manifest.yaml")
-				composerManifest, err = extensions.LoadLocalManifest(composerManifestPath)
-				if err != nil {
-					return nil, fmt.Errorf("failed to load composer parent manifest for composer extension %s from source artifact %q: %w",
-						name, extensionSrc, err)
-				}
-
-				extensions.ResolveVersionsWithParent(manifest, composerManifest)
-				manifest.Remote = true // Mark the manifest as remote since it is from a downloaded artifact
-
-				if build {
-					fmt.Printf("→ %sBuilding %s...%s\n", internal.ANSIBold, name, internal.ANSIReset)
-					downloader.Logger.Info("building downloaded Go extension", "name", manifest.Name, "version", artifact.Manifest.Version)
-					// Build libcomposer from the downloaded source if it does not exist in the local cache.
-					if _, err = os.Stat(extensions.LocalCacheComposerLib(downloader.Dirs, artifact.Manifest.Version)); err != nil {
-						if err = extensions.BuildLibComposer(downloader.Logger, downloader.Dirs, artifact.Path, artifact.Manifest.Version, false); err != nil {
-							return nil, fmt.Errorf("failed to build libcomposer %s for extension %s: %w",
-								artifact.Manifest.Version, name, err)
-						}
-					}
-					if _, err = extensions.BuildExtensionFromPath(downloader.Logger, downloader.Dirs, manifest, extensionSrc); err != nil {
-						return nil, fmt.Errorf("failed to build Go extension %s from source artifact: %w", name, err)
-					}
-				}
-
-				downloaded = append(downloaded, manifest)
-
-			case extensions.TypeRust:
-				if build {
-					fmt.Printf("→ %sBuilding %s...%s\n", internal.ANSIBold, name, internal.ANSIReset)
-					downloader.Logger.Info("building downloaded Rust extension", "name", artifact.Manifest.Name, "version", artifact.Manifest.Version)
-
-					if err = extensions.CheckOrBuildDynamicModule(downloader.Logger, downloader.Dirs, artifact.Manifest, artifact.Path); err != nil {
-						return nil, fmt.Errorf("failed to build Rust extension %s from source artifact: %w", name, err)
-					}
-				}
-				downloaded = append(downloaded, artifact.Manifest)
-
-			case extensions.TypeExtProc:
-				if build {
-					fmt.Printf("→ %sBuilding %s...%s\n", internal.ANSIBold, name, internal.ANSIReset)
-					downloader.Logger.Info("building downloaded ExtProc extension", "name", artifact.Manifest.Name, "version", artifact.Manifest.Version)
-					if err = extensions.CheckOrBuildExtProcBinary(downloader.Logger, downloader.Dirs, artifact.Manifest, artifact.Path); err != nil {
-						return nil, fmt.Errorf("failed to build ExtProc extension %s from source artifact: %w", name, err)
-					}
-				}
-				downloaded = append(downloaded, artifact.Manifest)
-			default:
-				downloaded = append(downloaded, artifact.Manifest)
+			handleSourceError := handleExtensionSource(ctx, downloader, artifact.Manifest, artifact.ExtensionManifest,
+				artifact.Path, downloader.Logger, build)
+			if handleSourceError != nil {
+				return nil, handleSourceError
 			}
-
+			downloaded = append(downloaded, artifact.ExtensionManifest)
 		default:
 			return nil, fmt.Errorf("unknown artifact type %q for extension %s", artifact.ArtifactType, name)
 		}
@@ -373,7 +316,7 @@ func resolveGoPluginLoader(ctx context.Context, downloader *extensions.Downloade
 		Name:            extensions.GoPluginLoaderName,
 		Type:            extensions.TypeGo,
 		CShared:         true,
-		Bundle:          extensions.ComposerBundle,
+		Parent:          extensions.ComposerBundle,
 		Version:         version,
 		ComposerVersion: version,
 		// Marked remote so extensionPositions.sort can match it by reference, like
@@ -426,7 +369,9 @@ func parseLogLevels(logLevel string) (string, string, error) {
 var errFailedToLoadLocalManifest = errors.New("failed to load local manifest")
 
 // loadLocalManifests loads extension manifests from the specified local paths.
-func loadLocalManifests(ctx context.Context, logger *slog.Logger, downloader *extensions.Downloader, paths []string, build bool) ([]*extensions.Manifest, error) {
+func loadLocalManifests(ctx context.Context, logger *slog.Logger, downloader *extensions.Downloader,
+	paths []string, build bool,
+) ([]*extensions.Manifest, error) {
 	manifests := make([]*extensions.Manifest, 0, len(paths))
 
 	for _, path := range paths {
@@ -437,55 +382,47 @@ func loadLocalManifests(ctx context.Context, logger *slog.Logger, downloader *ex
 			return nil, fmt.Errorf("%w from %s: %w", errFailedToLoadLocalManifest, path, err)
 		}
 
+		// This local extension may be a sub-extension of an extension bundle (e.g., a filter in the composer
+		// source tree, a filter in Rust extension bundle and so on).
+		// If so, we need to find the root manifest because we treat an extension bundle as a unit for version and
+		// compilation management.
+		var rootManifest *extensions.Manifest
+		var rootPath string
 		if manifest.Parent != "" {
-			parent, err := resolveParent(ctx, downloader, manifest)
+			rootManifest, rootPath, err = resolveParentNoFallback(manifest)
 			if err != nil {
 				return nil, fmt.Errorf("%w from %s: %w", errFailedToLoadLocalManifest, path, err)
 			}
-			extensions.ResolveVersionsWithParent(manifest, parent)
+			extensions.ResolveVersionsWithParent(manifest, rootManifest)
 		}
-
-		if build {
-			switch manifest.Type {
-			case extensions.TypeGo:
-				fmt.Printf("→ %sBuilding %s...%s\n", internal.ANSIBold, manifest.Name, internal.ANSIReset)
-				downloader.Logger.Info("building local Go extension", "name", manifest.Name, "version", manifest.Version)
-				cshared, err := extensions.BuildExtensionFromPath(downloader.Logger, downloader.Dirs, manifest, path)
-				if err != nil {
-					return nil, err
-				}
-				if !cshared {
-					// Old-style plugin needs libcomposer to load it.
-					if err := extensions.DownloadLibComposerAndBuildIfNeeded(ctx, downloader, manifest.ComposerVersion, extensions.ComposerArtifactSource); err != nil {
-						return nil, err
-					}
-				}
-				manifest.CShared = cshared
-			case extensions.TypeRust:
-				fmt.Printf("→ %sBuilding %s...%s\n", internal.ANSIBold, manifest.Name, internal.ANSIReset)
-				downloader.Logger.Info("building local Rust extension", "name", manifest.Name, "version", manifest.Version)
-				// Build dynamic module (currently supports Rust)
-				if err := extensions.BuildDynamicModule(downloader.Logger, downloader.Dirs, manifest, path); err != nil {
-					return nil, err
-				}
-			case extensions.TypeExtProc:
-				fmt.Printf("→ %sBuilding %s...%s\n", internal.ANSIBold, manifest.Name, internal.ANSIReset)
-				downloader.Logger.Info("building local ext_proc extension", "name", manifest.Name, "version", manifest.Version)
-				if err := extensions.BuildExtProcBinary(downloader.Logger, downloader.Dirs, manifest, path); err != nil {
-					return nil, err
-				}
-			}
+		if rootManifest == nil {
+			rootManifest = manifest
+			rootPath = path
 		}
-
+		err = handleExtensionSource(ctx, downloader, rootManifest, manifest, rootPath, logger, build)
+		if err != nil {
+			return nil, err
+		}
 		manifests = append(manifests, manifest)
 	}
 
 	return manifests, nil
 }
 
+func resolveParentNoFallback(m *extensions.Manifest) (*extensions.Manifest, string, error) {
+	parent, dir, err := extensions.FindLocalParentManifest(m)
+	if err != nil {
+		return nil, "", err
+	}
+	if parent != nil {
+		return parent, dir, nil
+	}
+	return nil, "", fmt.Errorf("parent manifest %q not found locally for extension %s", m.Parent, m.Name)
+}
+
 // resolveParent finds the parent manifest locally, falling back to the registry.
 func resolveParent(ctx context.Context, downloader *extensions.Downloader, m *extensions.Manifest) (*extensions.Manifest, error) {
-	parent, err := extensions.FindLocalParentManifest(m)
+	parent, _, err := extensions.FindLocalParentManifest(m)
 	if err != nil {
 		return nil, err
 	}
@@ -543,11 +480,10 @@ func warnMultipleGoExtensions(manifests []*extensions.Manifest) {
 	seen := make(map[string]bool)
 	for _, ext := range manifests {
 		if ext.Type == extensions.TypeGo && ext.CShared {
-			name := ext.Name
-			if ext.Bundle != "" {
-				name = ext.Bundle
-			}
-			seen[name+":"+ext.Version] = true
+			// ModuleName collapses bundle-hosted extensions (parent set, e.g.
+			// goplugin-loader) onto the shared bundle library name, so several
+			// extensions sharing one composer runtime count as a single library.
+			seen[extensions.ModuleName(ext)+":"+ext.Version] = true
 		}
 	}
 	if len(seen) < 2 {
@@ -585,5 +521,65 @@ func validateComposerCompat(manifests []*extensions.Manifest) error {
 			"all Go extensions must use the same composer version", b.String())
 	}
 
+	return nil
+}
+
+// handleExtensionSource builds the bundle root from source (composer, Go, Rust or ext_proc) and
+// resolves the extension's runtime metadata (CShared, inherited versions) from the build result.
+// When build is false the build step is skipped entirely — used by config generation and tests
+// that only need manifest resolution, not compiled artifacts.
+func handleExtensionSource(ctx context.Context, downloader *extensions.Downloader, rootManifest *extensions.Manifest,
+	extensionManifest *extensions.Manifest, rootPath string, logger *slog.Logger, build bool,
+) error {
+	if !build {
+		return nil
+	}
+	// The source artifact must be present on disk before we can build it. A missing directory
+	// means the download produced no source tree, so fail fast with a clear message rather than
+	// letting the underlying build tool fail obscurely (e.g. chdir into a non-existent path).
+	if info, err := os.Stat(rootPath); err != nil || !info.IsDir() {
+		return fmt.Errorf("source directory for extension %s does not exist: %s", rootManifest.Name, rootPath)
+	}
+	switch rootManifest.Type {
+	case extensions.TypeComposer:
+		fmt.Printf("→ %sBuilding composer for %s...%s\n", internal.ANSIBold, rootManifest.Name, internal.ANSIReset)
+		logger.Info("building composer from local source", "name", rootManifest.Name, "version", rootManifest.Version)
+		if err := extensions.BuildComposer(logger, downloader.Dirs, rootPath, rootManifest.Version); err != nil {
+			return fmt.Errorf("failed to build libcomposer for local extension %s: %w", rootManifest.Name, err)
+		}
+		extensionManifest.CShared = true
+	case extensions.TypeGo:
+		fmt.Printf("→ %sBuilding %s...%s\n", internal.ANSIBold, rootManifest.Name, internal.ANSIReset)
+		logger.Info("building local Go extension", "name", rootManifest.Name, "version", rootManifest.Version)
+		cshared, err := extensions.BuildExtensionFromPath(logger, downloader.Dirs, rootManifest, rootPath)
+		if err != nil {
+			return fmt.Errorf("failed to build local Go extension %s: %w", rootManifest.Name, err)
+		}
+		if !cshared {
+			if err = extensions.CheckOrDownloadLibComposer(ctx, downloader, rootManifest.ComposerVersion,
+				extensions.ComposerArtifactLite); err != nil {
+				return fmt.Errorf("failed to download libcomposer %s for extension %s: %w",
+					rootManifest.ComposerVersion, rootManifest.Name, err)
+			}
+			composerManifest, _ := extensions.GetComposerManifest(downloader.Dirs, rootManifest.ComposerVersion)
+			if composerManifest != nil {
+				extensions.ResolveVersionsWithParent(extensionManifest, composerManifest)
+			}
+		}
+		extensionManifest.CShared = cshared
+	case extensions.TypeRust:
+		fmt.Printf("→ %sBuilding %s...%s\n", internal.ANSIBold, rootManifest.Name, internal.ANSIReset)
+		downloader.Logger.Info("building local Rust extension", "name", rootManifest.Name, "version", rootManifest.Version)
+		// Build dynamic module (currently supports Rust)
+		if err := extensions.BuildDynamicModule(downloader.Logger, downloader.Dirs, rootManifest, rootPath); err != nil {
+			return err
+		}
+	case extensions.TypeExtProc:
+		fmt.Printf("→ %sBuilding %s...%s\n", internal.ANSIBold, rootManifest.Name, internal.ANSIReset)
+		downloader.Logger.Info("building local ext_proc extension", "name", rootManifest.Name, "version", rootManifest.Version)
+		if err := extensions.BuildExtProcBinary(downloader.Logger, downloader.Dirs, rootManifest, rootPath); err != nil {
+			return err
+		}
+	}
 	return nil
 }

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -556,9 +556,16 @@ func handleExtensionSource(ctx context.Context, downloader *extensions.Downloade
 			return fmt.Errorf("failed to build local Go extension %s: %w", rootManifest.Name, err)
 		}
 		if !cshared {
-			if err = extensions.CheckOrDownloadLibComposer(ctx, downloader, rootManifest.ComposerVersion,
-				extensions.ComposerArtifactLite); err != nil {
-				return fmt.Errorf("failed to download libcomposer %s for extension %s: %w",
+			// A locally-built old-style Go plugin is loaded via plugin.Open and must link against a
+			// libcomposer built from the same source with the same toolchain/deps; a prebuilt lite
+			// binary would be ABI-incompatible. Build from source unconditionally rather than via
+			// CheckOrDownloadLibComposer: that cache is keyed only by version and shares the
+			// dym/composer/<version>/libcomposer.so slot with the downloaded lite binary, so a cached
+			// binary (from goplugin-loader or a downloaded plugin) would otherwise be reused here and
+			// reintroduce the ABI mismatch.
+			if err = extensions.DownloadLibComposerAndBuildIfNeeded(ctx, downloader, rootManifest.ComposerVersion,
+				extensions.ComposerArtifactSource); err != nil {
+				return fmt.Errorf("failed to build libcomposer %s for extension %s: %w",
 					rootManifest.ComposerVersion, rootManifest.Name, err)
 			}
 			composerManifest, _ := extensions.GetComposerManifest(downloader.Dirs, rootManifest.ComposerVersion)

--- a/cli/cmd/run_test.go
+++ b/cli/cmd/run_test.go
@@ -618,7 +618,9 @@ examples: []
 		d := newTestDownloader(t, t.TempDir(), mock)
 		_, err := loadLocalManifests(t.Context(), logger, d, []string{tmpDir}, false)
 		require.ErrorIs(t, err, errFailedToLoadLocalManifest)
-		require.ErrorContains(t, err, "downloading parent composer")
+		// loadLocalManifests resolves parents locally only (no registry fallback), so a
+		// missing local parent fails fast rather than attempting a download.
+		require.ErrorContains(t, err, `parent manifest "composer" not found locally`)
 	})
 }
 
@@ -868,15 +870,19 @@ func TestDownloadExtensions(t *testing.T) {
 	})
 
 	t.Run("multiple extensions", func(t *testing.T) {
+		// A single shared mock returns the same artifact for every ref, and
+		// ResolveExtensionManifest now keys off the ref name matching the artifact title,
+		// so both refs use the titled name (only the count is asserted here).
 		mock := &mockOCIClient{
 			annotations: map[string]string{
+				ocispec.AnnotationTitle:               "ext-a",
 				extensions.OCIAnnotationExtensionType: string(extensions.TypeLua),
 				extensions.OCIAnnotationArtifact:      extensions.ArtifactBinary,
 			},
 		}
 		d := newTestDownloader(t, t.TempDir(), mock)
 
-		manifests, err := downloadExtensions(t.Context(), d, []string{"ext-a:1.0.0", "ext-b:2.0.0"}, false)
+		manifests, err := downloadExtensions(t.Context(), d, []string{"ext-a:1.0.0", "ext-a:2.0.0"}, false)
 		require.NoError(t, err)
 		require.Len(t, manifests, 2)
 	})
@@ -929,12 +935,12 @@ func TestDownloadExtensions(t *testing.T) {
 	})
 
 	t.Run("source Go extension", func(t *testing.T) {
-		composerVersion := "0.1.0"
+		composerVersion := "1.0.0"
 		composer := &extensions.Manifest{Name: "composer", Version: composerVersion, Type: extensions.TypeComposer}
 		dirs := &xdg.Directories{DataHome: t.TempDir()}
 
 		// Precreate the manifests to simulate a successful download
-		composerDir := extensions.LocalCacheComposerSourceArtifactDir(dirs, composer)
+		composerDir := extensions.LocalCacheExtensionSourceArtifactDir(dirs, composer)
 		childDir := filepath.Join(composerDir, "composer-child")
 		require.NoError(t, os.MkdirAll(childDir, 0o750))
 
@@ -975,9 +981,9 @@ func TestDownloadExtensions(t *testing.T) {
 		}
 		d := newTestDownloader(t, t.TempDir(), mock)
 
-		_, err := downloadExtensions(t.Context(), d, []string{"my-go-src:1.0.0"}, false)
+		_, err := downloadExtensions(t.Context(), d, []string{"my-go-src:1.0.0"}, true)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "missing expected source directory")
+		require.Contains(t, err.Error(), "source directory for extension my-go-src does not exist")
 	})
 
 	t.Run("source Rust extension with no Cargo.toml", func(t *testing.T) {
@@ -992,7 +998,7 @@ func TestDownloadExtensions(t *testing.T) {
 
 		_, err := downloadExtensions(t.Context(), d, []string{"my-rust-src:1.0.0"}, true)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "no Cargo.toml found")
+		require.Contains(t, err.Error(), "source directory for extension my-rust-src does not exist")
 	})
 
 	t.Run("source ExtProc extension with no go.mod", func(t *testing.T) {
@@ -1007,7 +1013,7 @@ func TestDownloadExtensions(t *testing.T) {
 
 		_, err := downloadExtensions(t.Context(), d, []string{"my-extproc-src:1.0.0"}, true)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "no go.mod found")
+		require.Contains(t, err.Error(), "source directory for extension my-extproc-src does not exist")
 	})
 
 	t.Run("source non-composer non-dynamic-module extension", func(t *testing.T) {
@@ -1040,6 +1046,9 @@ func TestDownloadExtensions(t *testing.T) {
 			}
 			return &mockOCIClient{
 				annotations: map[string]string{
+					// Title must match the ref name so the first extension resolves cleanly
+					// and processing reaches (and fails on) the second extension.
+					ocispec.AnnotationTitle:               "ext-ok",
 					extensions.OCIAnnotationExtensionType: string(extensions.TypeLua),
 					extensions.OCIAnnotationArtifact:      extensions.ArtifactBinary,
 				},
@@ -1067,7 +1076,7 @@ func TestDownloadExtensions(t *testing.T) {
 		require.Equal(t, extensions.GoPluginLoaderName, m.Name)
 		require.Equal(t, extensions.TypeGo, m.Type)
 		require.True(t, m.CShared, "goplugin-loader must be treated as a c-shared dynamic module")
-		require.Equal(t, extensions.ComposerBundle, m.Bundle)
+		require.Equal(t, extensions.ComposerBundle, m.Parent)
 		require.Equal(t, "1.0.0", m.Version)
 		require.Equal(t, "1.0.0", m.ComposerVersion)
 		require.True(t, m.Remote)
@@ -1188,6 +1197,10 @@ examples: []
 
 		mock := &mockOCIClient{
 			annotations: map[string]string{
+				// Title must match the parent name so ResolveExtensionManifest treats the
+				// downloaded artifact as the parent itself rather than searching it for a
+				// differently-named child extension.
+				ocispec.AnnotationTitle:               "custom-parent",
 				extensions.OCIAnnotationExtensionType: string(extensions.TypeComposer),
 			},
 			tags: []string{"1.2.3"},
@@ -1312,16 +1325,18 @@ func TestWarnMultipleGoExtensions(t *testing.T) {
 			},
 		},
 		{
-			name: "multiple goplugin-loaders share one bundle runtime - no warning",
+			name: "multiple bundle members share one runtime - no warning",
+			// Distinct bundle members (different names) that share the composer runtime via
+			// Parent must collapse to a single library and not warn.
 			extensions: []*extensions.Manifest{
-				{Name: extensions.GoPluginLoaderName, Type: extensions.TypeGo, CShared: true, Bundle: extensions.ComposerBundle, Version: "1.0.0"},
-				{Name: extensions.GoPluginLoaderName, Type: extensions.TypeGo, CShared: true, Bundle: extensions.ComposerBundle, Version: "1.0.0"},
+				{Name: "ext-1", Type: extensions.TypeGo, CShared: true, Parent: extensions.ComposerBundle, Version: "1.0.0"},
+				{Name: "ext-2", Type: extensions.TypeGo, CShared: true, Parent: extensions.ComposerBundle, Version: "1.0.0"},
 			},
 		},
 		{
 			name: "goplugin-loader plus a distinct c-shared Go - warning",
 			extensions: []*extensions.Manifest{
-				{Name: extensions.GoPluginLoaderName, Type: extensions.TypeGo, CShared: true, Bundle: extensions.ComposerBundle, Version: "1.0.0"},
+				{Name: extensions.GoPluginLoaderName, Type: extensions.TypeGo, CShared: true, Parent: extensions.ComposerBundle, Version: "1.0.0"},
 				{Name: "ext-2", Type: extensions.TypeGo, CShared: true, Version: "2.0.0"},
 			},
 			wantWarning:  true,

--- a/cli/cmd/run_test.go
+++ b/cli/cmd/run_test.go
@@ -986,7 +986,7 @@ func TestDownloadExtensions(t *testing.T) {
 		require.Contains(t, err.Error(), "source directory for extension my-go-src does not exist")
 	})
 
-	t.Run("source Rust extension with no Cargo.toml", func(t *testing.T) {
+	t.Run("source Rust extension but missing source dir", func(t *testing.T) {
 		mock := &mockOCIClient{
 			annotations: map[string]string{
 				ocispec.AnnotationTitle:               "my-rust-src",
@@ -1001,7 +1001,28 @@ func TestDownloadExtensions(t *testing.T) {
 		require.Contains(t, err.Error(), "source directory for extension my-rust-src does not exist")
 	})
 
+	t.Run("source Rust extension with no Cargo.toml", func(t *testing.T) {
+		dataHome := t.TempDir()
+		mock := &mockOCIClient{
+			annotations: map[string]string{
+				ocispec.AnnotationTitle:               "my-rust-src",
+				extensions.OCIAnnotationExtensionType: string(extensions.TypeRust),
+				extensions.OCIAnnotationArtifact:      extensions.ArtifactSource,
+			},
+		}
+		d := newTestDownloader(t, dataHome, mock)
+
+		// Pre-create the source artifact directory so os.Stat passes and the build tool is invoked.
+		srcDir := extensions.LocalCacheExtensionSourceArtifactDir(d.Dirs, &extensions.Manifest{Name: "my-rust-src", Version: "1.0.0"})
+		require.NoError(t, os.MkdirAll(srcDir, 0o750))
+
+		_, err := downloadExtensions(t.Context(), d, []string{"my-rust-src:1.0.0"}, true)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to build Rust dynamic module")
+	})
+
 	t.Run("source ExtProc extension with no go.mod", func(t *testing.T) {
+		dataHome := t.TempDir()
 		mock := &mockOCIClient{
 			annotations: map[string]string{
 				ocispec.AnnotationTitle:               "my-extproc-src",
@@ -1009,11 +1030,15 @@ func TestDownloadExtensions(t *testing.T) {
 				extensions.OCIAnnotationArtifact:      extensions.ArtifactSource,
 			},
 		}
-		d := newTestDownloader(t, t.TempDir(), mock)
+		d := newTestDownloader(t, dataHome, mock)
+
+		// Pre-create the source artifact directory so os.Stat passes and the build tool is invoked.
+		srcDir := extensions.LocalCacheExtensionSourceArtifactDir(d.Dirs, &extensions.Manifest{Name: "my-extproc-src", Version: "1.0.0"})
+		require.NoError(t, os.MkdirAll(srcDir, 0o750))
 
 		_, err := downloadExtensions(t.Context(), d, []string{"my-extproc-src:1.0.0"}, true)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "source directory for extension my-extproc-src does not exist")
+		require.Contains(t, err.Error(), "failed to build ext_proc server")
 	})
 
 	t.Run("source non-composer non-dynamic-module extension", func(t *testing.T) {

--- a/cli/e2e/download_test.go
+++ b/cli/e2e/download_test.go
@@ -68,8 +68,8 @@ func TestDownloadComposerSource(t *testing.T) {
 
 	dirs := &xdg.Directories{DataHome: path}
 	manifest := &extensions.Manifest{Name: "composer", Version: "0.3.0"}
-	require.DirExists(t, extensions.LocalCacheComposerSourceArtifactDir(dirs, manifest))
-	require.DirExists(t, extensions.LocalCacheComposerExtensionSourceDir(dirs, manifest, "example-go"))
+	require.DirExists(t, extensions.LocalCacheExtensionSourceArtifactDir(dirs, manifest))
+	require.DirExists(t, extensions.LocalCacheExtensionSourceDir(dirs, manifest, "example-go"))
 }
 
 func requireDownloadHasFiles(t *testing.T, manifest *extensions.Manifest, files ...string) {

--- a/cli/internal/envoy/extension_test.go
+++ b/cli/internal/envoy/extension_test.go
@@ -626,7 +626,7 @@ func TestGoPluginLoaderBundle(t *testing.T) {
 		Name:            extensions.GoPluginLoaderName,
 		Type:            extensions.TypeGo,
 		CShared:         true,
-		Bundle:          extensions.ComposerBundle,
+		Parent:          extensions.ComposerBundle,
 		Version:         "v1.0.0",
 		ComposerVersion: "v1.0.0",
 	}
@@ -699,7 +699,7 @@ func TestNonComposerBundle(t *testing.T) {
 	manifest := &extensions.Manifest{
 		Name:        "rate-limit",
 		Type:        extensions.TypeRust,
-		Bundle:      "rustextensions",
+		Parent:      "rustextensions",
 		FilterTypes: []extensions.FilterType{extensions.FilterTypeHTTP},
 		Version:     "v1.0.0",
 	}

--- a/cli/internal/envoy/runner_test.go
+++ b/cli/internal/envoy/runner_test.go
@@ -96,7 +96,7 @@ func TestSetupDynamicModuleSearchPath(t *testing.T) {
 	goPluginLoader := func() *extensions.Manifest {
 		return &extensions.Manifest{
 			Name: extensions.GoPluginLoaderName, Type: extensions.TypeGo, CShared: true,
-			Bundle: extensions.ComposerBundle, Version: composerVersion, ComposerVersion: composerVersion,
+			Parent: extensions.ComposerBundle, Version: composerVersion, ComposerVersion: composerVersion,
 		}
 	}
 	legacyGoPlugin := &extensions.Manifest{

--- a/cli/internal/extensions/directories.go
+++ b/cli/internal/extensions/directories.go
@@ -18,12 +18,43 @@ func LocalCacheManifest(dirs *xdg.Directories, manifest *Manifest) string {
 	return filepath.Join(LocalCacheExtensionDir(dirs, manifest), "manifest.yaml")
 }
 
+// LocalCacheExtensionManifest returns the path to the manifest.yaml of the extension named
+// extensionName within a downloaded artifact. For a standalone artifact (extensionName matches the
+// artifact, or is empty) it is the manifest at the artifact root; otherwise the artifact is treated
+// as a bundle and its source tree is walked to find the named child's manifest.
+func LocalCacheExtensionManifest(dirs *xdg.Directories, artifactManifest *Manifest, artifactType,
+	extensionName string,
+) (string, error) {
+	var base string
+	if artifactType == ArtifactSource {
+		base = LocalCacheExtensionSourceArtifactDir(dirs, artifactManifest)
+	} else {
+		base = LocalCacheExtensionDir(dirs, artifactManifest)
+	}
+
+	if artifactManifest.Name == extensionName || extensionName == "" {
+		// Standalone extension, manifest is at the root of the extension directory.
+		return filepath.Join(base, "manifest.yaml"), nil
+	}
+	// Find the extension manifest by walking the extension directory.
+	path, err := FindExtensionPath(base, extensionName)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(path, "manifest.yaml"), nil
+}
+
 // ModuleName returns the dynamic-module name for the manifest. Bundle-hosted
 // extensions (e.g. goplugin-loader) are served by a shared bundle library named
 // after the bundle (e.g. libcomposer.so); otherwise the extension's own name.
 func ModuleName(manifest *Manifest) string {
-	if manifest.Bundle != "" {
-		return manifest.Bundle
+	// A Go plugin (not c-shared) is loaded by composer and has no bundle library of its own.
+	if manifest.Type == TypeGo && !manifest.CShared {
+		return manifest.Name
+	}
+
+	if manifest.Parent != "" {
+		return manifest.Parent
 	}
 	return manifest.Name
 }
@@ -83,38 +114,20 @@ func LocalCacheExtension(dirs *xdg.Directories, manifest *Manifest) string {
 	}
 }
 
-// LocalCacheComposerSourceArtifactDir returns the local cache directory for the composer
-// source artifact based on the manifest.
-func LocalCacheComposerSourceArtifactDir(dirs *xdg.Directories, manifest *Manifest) string {
-	return filepath.Join(dirs.DataHome, "extensions", "src", manifest.Name, manifest.Version)
+// LocalCacheExtensionSourceArtifactDir returns the local cache directory for a downloaded source
+// artifact (extensions/src/<name>/<version>), keyed by its manifest. Used for any source artifact
+// that is built on the client — the composer and general bundles alike.
+func LocalCacheExtensionSourceArtifactDir(dirs *xdg.Directories, manifest *Manifest) string {
+	moduleName := ModuleName(manifest)
+	return filepath.Join(dirs.DataHome, "extensions", "src", moduleName, manifest.Version)
 }
 
-// LocalCacheComposerExtensionSourceDir returns the local cache directory for the composer extension source code
-// based on the extension name. It looks for the manifest.yaml file in the composer source artifact directory
-// to find the matching extension name and returns its path.
-func LocalCacheComposerExtensionSourceDir(dirs *xdg.Directories, manifest *Manifest, name string) string {
-	base := LocalCacheComposerSourceArtifactDir(dirs, manifest)
-	var extensionPath string
-
-	_ = filepath.WalkDir(base, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if d.Name() == "manifest.yaml" {
-			m, err := LoadLocalManifest(path)
-			if err != nil {
-				return err
-			}
-
-			if m.Name == name {
-				extensionPath = filepath.Dir(path)
-				return filepath.SkipDir
-			}
-		}
-		return nil
-	})
-
-	return extensionPath
+// LocalCacheExtensionSourceDir returns the source directory of the child extension named `name`
+// within a downloaded source artifact, by walking the extracted tree for the manifest.yaml whose
+// name matches. Used for composer plugins and general bundle children alike.
+func LocalCacheExtensionSourceDir(dirs *xdg.Directories, manifest *Manifest, name string) string {
+	path, _ := FindExtensionPath(LocalCacheExtensionSourceArtifactDir(dirs, manifest), name)
+	return path
 }
 
 // LocalCacheComposerDir returns the local cache directory for the composer.
@@ -125,4 +138,41 @@ func LocalCacheComposerDir(dirs *xdg.Directories, version string) string {
 // LocalCacheComposerLib returns the local cache path for the composer lib.
 func LocalCacheComposerLib(dirs *xdg.Directories, version string) string {
 	return filepath.Join(LocalCacheComposerDir(dirs, version), "libcomposer.so")
+}
+
+// LocalCacheComposerSourceDir returns the local cache directory of the composer source artifact
+// for the given version (extensions/src/composer/<version>).
+func LocalCacheComposerSourceDir(dirs *xdg.Directories, version string) string {
+	return filepath.Join(dirs.DataHome, "extensions", "src", "composer", version)
+}
+
+// FindExtensionPath walks the directory tree rooted at base and returns the directory containing
+// the manifest.yaml whose name matches extensionName. It returns an error if the tree cannot be
+// walked or no matching extension is found.
+func FindExtensionPath(base string, extensionName string) (string, error) {
+	var extensionPath string
+
+	if err := filepath.WalkDir(base, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.Name() == "manifest.yaml" {
+			m, err := LoadLocalManifest(path)
+			if err != nil {
+				return err
+			}
+			if m.Name == extensionName {
+				extensionPath = filepath.Dir(path)
+				return filepath.SkipDir
+			}
+		}
+		return nil
+	}); err != nil {
+		return "", err
+	}
+
+	if extensionPath == "" {
+		return "", fmt.Errorf("extension %q not found in %s", extensionName, base)
+	}
+	return extensionPath, nil
 }

--- a/cli/internal/extensions/directories_test.go
+++ b/cli/internal/extensions/directories_test.go
@@ -88,7 +88,7 @@ func TestLocalCacheExtensionDirs(t *testing.T) {
 	// extension's own name/type.
 	goPluginLoader := &Manifest{
 		Name: GoPluginLoaderName, Type: TypeGo, CShared: true,
-		Bundle: ComposerBundle, Version: "1.0.1",
+		Parent: ComposerBundle, Version: "1.0.1",
 	}
 	require.Equal(t, "/home/user/.local/share/extensions/dym/composer/1.0.1",
 		LocalCacheExtensionDir(dirs, goPluginLoader))
@@ -98,7 +98,7 @@ func TestLocalCacheExtensionDirs(t *testing.T) {
 	// A non-composer bundle resolves to lib<bundle>.so under the bundle's dir.
 	rustBundleMember := &Manifest{
 		Name: "rate-limit", Type: TypeRust,
-		Bundle: "rustextensions", Version: "3.1.0",
+		Parent: "rustextensions", Version: "3.1.0",
 	}
 	require.Equal(t, "/home/user/.local/share/extensions/dym/rustextensions/3.1.0",
 		LocalCacheExtensionDir(dirs, rustBundleMember))
@@ -137,13 +137,13 @@ examples:
       boe run --extension ` + name
 }
 
-func TestLocalCacheComposerExtensionSourceDir(t *testing.T) {
+func TestLocalCacheExtensionSourceDir(t *testing.T) {
 	t.Run("finds matching extension in source directory", func(t *testing.T) {
 		dirs := &xdg.Directories{DataHome: t.TempDir()}
 		manifest := &Manifest{Name: "my-set", Version: "1.0.0", Type: TypeGo}
 
 		// Create the source artifact directory structure with two extensions
-		base := LocalCacheComposerSourceArtifactDir(dirs, manifest)
+		base := LocalCacheExtensionSourceArtifactDir(dirs, manifest)
 
 		ext1Dir := filepath.Join(base, "ext1")
 		ext2Dir := filepath.Join(base, "ext2")
@@ -156,8 +156,8 @@ func TestLocalCacheComposerExtensionSourceDir(t *testing.T) {
 			[]byte(validManifestYAML("beta")), 0o600))
 
 		// Should find the correct extension directory
-		require.Equal(t, ext1Dir, LocalCacheComposerExtensionSourceDir(dirs, manifest, "alpha"))
-		require.Equal(t, ext2Dir, LocalCacheComposerExtensionSourceDir(dirs, manifest, "beta"))
+		require.Equal(t, ext1Dir, LocalCacheExtensionSourceDir(dirs, manifest, "alpha"))
+		require.Equal(t, ext2Dir, LocalCacheExtensionSourceDir(dirs, manifest, "beta"))
 	})
 
 	t.Run("returns empty string when extension not found", func(t *testing.T) {
@@ -165,14 +165,14 @@ func TestLocalCacheComposerExtensionSourceDir(t *testing.T) {
 		manifest := &Manifest{Name: "my-set", Version: "1.0.0", Type: TypeGo}
 
 		// Create one extension
-		base := LocalCacheComposerSourceArtifactDir(dirs, manifest)
+		base := LocalCacheExtensionSourceArtifactDir(dirs, manifest)
 		extDir := filepath.Join(base, "ext1")
 		require.NoError(t, os.MkdirAll(extDir, 0o750))
 		require.NoError(t, os.WriteFile(filepath.Join(extDir, "manifest.yaml"),
 			[]byte(validManifestYAML("alpha")), 0o600))
 
 		// Search for a non-existent extension
-		require.Empty(t, LocalCacheComposerExtensionSourceDir(dirs, manifest, "nonexistent"))
+		require.Empty(t, LocalCacheExtensionSourceDir(dirs, manifest, "nonexistent"))
 	})
 
 	t.Run("returns empty string when base directory does not exist", func(t *testing.T) {
@@ -180,14 +180,14 @@ func TestLocalCacheComposerExtensionSourceDir(t *testing.T) {
 		manifest := &Manifest{Name: "missing", Version: "1.0.0", Type: TypeGo}
 
 		// Don't create any directories base path doesn't exist
-		require.Empty(t, LocalCacheComposerExtensionSourceDir(dirs, manifest, "anything"))
+		require.Empty(t, LocalCacheExtensionSourceDir(dirs, manifest, "anything"))
 	})
 
 	t.Run("returns empty string when manifest is invalid", func(t *testing.T) {
 		dirs := &xdg.Directories{DataHome: t.TempDir()}
 		manifest := &Manifest{Name: "my-set", Version: "1.0.0", Type: TypeGo}
 
-		base := LocalCacheComposerSourceArtifactDir(dirs, manifest)
+		base := LocalCacheExtensionSourceArtifactDir(dirs, manifest)
 
 		// Create a directory with an invalid manifest
 		badDir := filepath.Join(base, "bad")
@@ -196,14 +196,14 @@ func TestLocalCacheComposerExtensionSourceDir(t *testing.T) {
 			[]byte("not: valid: yaml: ["), 0o600))
 
 		// Walk stops on error, so no result is returned
-		require.Empty(t, LocalCacheComposerExtensionSourceDir(dirs, manifest, "anything"))
+		require.Empty(t, LocalCacheExtensionSourceDir(dirs, manifest, "anything"))
 	})
 
 	t.Run("handles nested directory structures", func(t *testing.T) {
 		dirs := &xdg.Directories{DataHome: t.TempDir()}
 		manifest := &Manifest{Name: "my-set", Version: "2.0.0", Type: TypeGo}
 
-		base := LocalCacheComposerSourceArtifactDir(dirs, manifest)
+		base := LocalCacheExtensionSourceArtifactDir(dirs, manifest)
 
 		// Create a nested directory with a manifest
 		nestedDir := filepath.Join(base, "category", "nested-ext")
@@ -211,6 +211,6 @@ func TestLocalCacheComposerExtensionSourceDir(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(nestedDir, "manifest.yaml"),
 			[]byte(validManifestYAML("nested")), 0o600))
 
-		require.Equal(t, nestedDir, LocalCacheComposerExtensionSourceDir(dirs, manifest, "nested"))
+		require.Equal(t, nestedDir, LocalCacheExtensionSourceDir(dirs, manifest, "nested"))
 	})
 }

--- a/cli/internal/extensions/directories_test.go
+++ b/cli/internal/extensions/directories_test.go
@@ -214,3 +214,67 @@ func TestLocalCacheExtensionSourceDir(t *testing.T) {
 		require.Equal(t, nestedDir, LocalCacheExtensionSourceDir(dirs, manifest, "nested"))
 	})
 }
+
+func TestLocalCacheExtensionManifest(t *testing.T) {
+	t.Run("standalone source artifact", func(t *testing.T) {
+		dirs := &xdg.Directories{DataHome: t.TempDir()}
+		manifest := &Manifest{Name: "my-ext", Version: "1.0.0", Type: TypeGo}
+
+		path, err := LocalCacheExtensionManifest(dirs, manifest, ArtifactSource, "my-ext")
+		require.NoError(t, err)
+		require.Equal(t,
+			filepath.Join(LocalCacheExtensionSourceArtifactDir(dirs, manifest), "manifest.yaml"),
+			path)
+	})
+
+	t.Run("standalone binary artifact", func(t *testing.T) {
+		dirs := &xdg.Directories{DataHome: t.TempDir()}
+		manifest := &Manifest{Name: "my-ext", Version: "1.0.0", Type: TypeRust}
+
+		path, err := LocalCacheExtensionManifest(dirs, manifest, ArtifactBinary, "my-ext")
+		require.NoError(t, err)
+		require.Equal(t,
+			filepath.Join(LocalCacheExtensionDir(dirs, manifest), "manifest.yaml"),
+			path)
+	})
+
+	t.Run("standalone with empty extension name", func(t *testing.T) {
+		dirs := &xdg.Directories{DataHome: t.TempDir()}
+		manifest := &Manifest{Name: "my-ext", Version: "1.0.0", Type: TypeGo}
+
+		path, err := LocalCacheExtensionManifest(dirs, manifest, ArtifactSource, "")
+		require.NoError(t, err)
+		require.Equal(t,
+			filepath.Join(LocalCacheExtensionSourceArtifactDir(dirs, manifest), "manifest.yaml"),
+			path)
+	})
+
+	t.Run("bundle finds child extension manifest", func(t *testing.T) {
+		dirs := &xdg.Directories{DataHome: t.TempDir()}
+		manifest := &Manifest{Name: "my-bundle", Version: "2.0.0", Type: TypeGo}
+
+		// Create the source artifact directory with a child extension
+		base := LocalCacheExtensionSourceArtifactDir(dirs, manifest)
+		childDir := filepath.Join(base, "child-ext")
+		require.NoError(t, os.MkdirAll(childDir, 0o750))
+		require.NoError(t, os.WriteFile(filepath.Join(childDir, "manifest.yaml"),
+			[]byte(validManifestYAML("child-ext")), 0o600))
+
+		path, err := LocalCacheExtensionManifest(dirs, manifest, ArtifactSource, "child-ext")
+		require.NoError(t, err)
+		require.Equal(t, filepath.Join(childDir, "manifest.yaml"), path)
+	})
+
+	t.Run("bundle child not found returns error", func(t *testing.T) {
+		dirs := &xdg.Directories{DataHome: t.TempDir()}
+		manifest := &Manifest{Name: "my-bundle", Version: "2.0.0", Type: TypeGo}
+
+		// Create the base directory but no child
+		base := LocalCacheExtensionSourceArtifactDir(dirs, manifest)
+		require.NoError(t, os.MkdirAll(base, 0o750))
+
+		_, err := LocalCacheExtensionManifest(dirs, manifest, ArtifactSource, "missing-child")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `extension "missing-child" not found`)
+	})
+}

--- a/cli/internal/extensions/downloader.go
+++ b/cli/internal/extensions/downloader.go
@@ -48,10 +48,12 @@ func (d *Downloader) SetClientFactory(f func(logger *slog.Logger, repository, us
 
 // DownloadedExtension represents a downloaded extension with its manifest and local path.
 type DownloadedExtension struct {
-	Manifest       *Manifest // The extension manifest with all metadata.
+	Manifest       *Manifest // The extension manifest of the downloaded artifact.
 	Path           string    // The local path where the extension artifact is downloaded.
 	ArtifactType   string    // The artifact type of the extension (binary or source).
 	ComposerBundle bool      // Whether the downloaded extension is a composer bundle (which may contain multiple extensions).
+	// The specific extension's Manifest. One downloaded artifact may contain multiple extensions.
+	ExtensionManifest *Manifest
 }
 
 // DownloadComposer downloads the composer from the specified repository and version into the downloadDir.
@@ -59,8 +61,8 @@ func (d *Downloader) DownloadComposer(ctx context.Context, version string, artif
 	d.Logger.Info("downloading composer", "repository", d.Registry, "artifact", artifact, "version", version)
 	return d.download(ctx, d.Registry+"/"+artifact, version, func(manifest *ocispec.Manifest) string {
 		extensionManifest := ManifestFromOCI(manifest)
-		if isComposerSourceArtifact(manifest) {
-			return LocalCacheComposerSourceArtifactDir(d.Dirs, extensionManifest)
+		if isSourceArtifact(manifest) {
+			return LocalCacheExtensionSourceArtifactDir(d.Dirs, extensionManifest)
 		}
 		// use the composer version resolved from the manifest, as the input parameter one could be
 		// "latest" which needs to be resolved to a concrete version.
@@ -76,8 +78,8 @@ func (d *Downloader) DownloadExtension(ctx context.Context, name, version string
 
 	artifact, err := d.download(ctx, repository, version, func(manifest *ocispec.Manifest) string {
 		extensionManifest := ManifestFromOCI(manifest)
-		if isComposerSourceArtifact(manifest) {
-			return LocalCacheComposerSourceArtifactDir(d.Dirs, extensionManifest)
+		if isSourceArtifact(manifest) {
+			return LocalCacheExtensionSourceArtifactDir(d.Dirs, extensionManifest)
 		}
 		return LocalCacheExtensionDir(d.Dirs, extensionManifest)
 	})
@@ -85,41 +87,17 @@ func (d *Downloader) DownloadExtension(ctx context.Context, name, version string
 		return DownloadedExtension{}, err
 	}
 
-	// If the Download dir contains the manifest (lua extensions, ext_proc, or downloaded source), load it to get
-	// the full manifest with all extension data.
-	// Composer extensions are different as the manifest is the uber-manifest and we don't want to read that.
-	if !artifact.ComposerBundle {
-		manifestPath := LocalCacheManifest(d.Dirs, artifact.Manifest)
-		if _, err = os.Stat(manifestPath); err == nil {
-			d.Logger.Info("loading manifest from downloaded extension", "path", manifestPath)
-			fromOCI := artifact.Manifest
-			m, err := LoadLocalManifest(manifestPath)
-			if err != nil {
-				return DownloadedExtension{},
-					fmt.Errorf("failed to load manifest from downloaded extension at %q: %w", manifestPath, err)
-			}
-
-			// Composer plugin extension packages contain the extension manifest and the parent composer manifest as well.
-			// If it exists, load it and resolve the versions
-			composerParent := filepath.Join(LocalCacheExtensionDir(d.Dirs, artifact.Manifest), "manifest-composer.yaml")
-			if _, err = os.Stat(composerParent); err == nil {
-				p, err := LoadLocalManifest(composerParent)
-				if err != nil {
-					return DownloadedExtension{},
-						fmt.Errorf("failed to load parent manifest from downloaded extension at %q: %w", composerParent, err)
-				}
-				ResolveVersionsWithParent(m, p)
-			}
-
-			mergeManifestFromOCI(m, fromOCI)
-			artifact.Manifest = m
-		}
-	}
-
 	// Mark the manifest as remote so that config generation knows the extension is
 	// a remote one and can take it into account.
 	artifact.Manifest.Remote = true
 
+	extensionManifest, err := ResolveExtensionManifest(d.Dirs, artifact.Manifest, artifact.ArtifactType,
+		name, d.Logger)
+	if err != nil {
+		return DownloadedExtension{}, fmt.Errorf("failed to resolve extension manifest for %q: %w", name, err)
+	}
+	extensionManifest.Remote = true
+	artifact.ExtensionManifest = extensionManifest
 	return artifact, nil
 }
 
@@ -194,12 +172,44 @@ func (d *Downloader) download(
 		return DownloadedExtension{}, fmt.Errorf("failed to pull artifact for %s:%s: %w", repository, version, err)
 	}
 
+	var rootManifest *Manifest
+	rootManifestPath := filepath.Join(downloadDir, "manifest.yaml")
+	if _, err := os.Stat(rootManifestPath); err == nil {
+		d.Logger.Debug("downloaded artifact contains manifest.yaml at root, validating it", "path", rootManifestPath)
+		rootManifest, err = LoadLocalManifest(rootManifestPath)
+		if err != nil {
+			return DownloadedExtension{}, fmt.Errorf("failed to validate manifest.yaml in downloaded artifact: %w", err)
+		}
+	}
+
+	if rootManifest == nil {
+		d.Logger.Warn("downloaded artifact does not contain a manifest.yaml at root, some metadata may be missing",
+			"path", rootManifestPath)
+		rootManifest = ManifestFromOCI(manifest)
+	} else {
+		// manifest.yaml won't carry the compile-time fields like CShared but it's important so we could
+		// distinguish the Golang extensions and goplugin extensions.
+		ociManifest := ManifestFromOCI(manifest)
+		rootManifest.CShared = ociManifest.CShared
+		if rootManifest.Version == "" {
+			rootManifest.Version = ociManifest.Version
+		}
+		if rootManifest.ComposerVersion == "" {
+			rootManifest.ComposerVersion = ociManifest.ComposerVersion
+		}
+	}
+
 	return DownloadedExtension{
-		Manifest:       ManifestFromOCI(manifest),
+		Manifest:       rootManifest,
 		Path:           downloadDir,
 		ArtifactType:   manifest.Annotations[OCIAnnotationArtifact],
 		ComposerBundle: isComposerSourceArtifact(manifest),
 	}, nil
+}
+
+// isSourceArtifact checks if the downloaded artifact is a source artifact.
+func isSourceArtifact(manifest *ocispec.Manifest) bool {
+	return manifest.Annotations[OCIAnnotationArtifact] == ArtifactSource
 }
 
 // isComposerSourceArtifact checks if the downloaded artifact is a composer source artifact.
@@ -272,17 +282,4 @@ func resolveLatestComposerVersion(ctx context.Context, logger *slog.Logger,
 	}
 	logger.Info("resolved composer version from registry", "version", version)
 	return version, nil
-}
-
-// mergeManifestFromOCI preserves fields from the OCI-annotation-derived
-// manifest when the embedded YAML manifest has them empty. Composer plugins
-// have incomplete manifests because version and composerVersion are inherited
-// from the parent at build time.
-func mergeManifestFromOCI(embedded, fromOCI *Manifest) {
-	if embedded.Version == "" {
-		embedded.Version = fromOCI.Version
-	}
-	if embedded.ComposerVersion == "" {
-		embedded.ComposerVersion = fromOCI.ComposerVersion
-	}
 }

--- a/cli/internal/extensions/downloader_test.go
+++ b/cli/internal/extensions/downloader_test.go
@@ -194,7 +194,7 @@ func TestDownloadExtension(t *testing.T) {
 				},
 			}
 
-			artifact, err := d.DownloadExtension(t.Context(), "extension-myext", tt.version)
+			artifact, err := d.DownloadExtension(t.Context(), "myext", tt.version)
 			require.ErrorIs(t, err, tt.wantErr)
 			if tt.wantErr == nil {
 				require.Equal(t, tt.wantName, artifact.Manifest.Name)
@@ -387,7 +387,8 @@ func TestDownloadComposerExtensionLoadsParentManifest(t *testing.T) {
 		require.Empty(t, ext.Manifest.MaxEnvoyVersion)
 	})
 
-	// The information from the parent manifest should be loaded
+	// The information from the parent manifest should be loaded: ResolveExtensionManifest reads the
+	// sibling manifest-composer.yaml and inherits the parent's Envoy constraints into the extension.
 	t.Run("with parent manifest", func(t *testing.T) {
 		// Create the parent manifest in the download location
 		parentManifest, err := os.ReadFile("testdata/composer_test.yaml")
@@ -471,7 +472,7 @@ func TestResolveLatestComposerVersion(t *testing.T) {
 	}
 }
 
-func TestMergeManifestFromOCI(t *testing.T) {
+func TestMergeManifestFromRoot(t *testing.T) {
 	tests := []struct {
 		name     string
 		embedded *Manifest
@@ -506,7 +507,7 @@ func TestMergeManifestFromOCI(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mergeManifestFromOCI(tt.embedded, tt.fromOCI)
+			mergeManifestFromRoot(tt.embedded, tt.fromOCI)
 			require.Equal(t, tt.expected, tt.embedded)
 		})
 	}

--- a/cli/internal/extensions/libcomposer.go
+++ b/cli/internal/extensions/libcomposer.go
@@ -157,3 +157,44 @@ func BuildLibComposer(logger *slog.Logger, dirs *xdg.Directories, composerSrcPat
 
 	return nil
 }
+
+// BuildComposer builds and installs libcomposer from the composer source tree at composerSrcPath
+// into the local cache, tagging it with the given version.
+func BuildComposer(logger *slog.Logger, dirs *xdg.Directories, composerSrcPath string, version string) error {
+	// Build the libcomposer from source.
+	// #nosec G204
+	cmd := exec.Command("make",
+		"install",
+		"BOE_DATA_HOME="+dirs.DataHome,
+		"NAME=composer",
+		"VERSION="+version,
+	)
+	cmd.Dir = composerSrcPath
+
+	logger.Debug("building composer from source", "version", version, "cmd", cmd.String())
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to build composer from source at %s: %w\nOutput: %s",
+			composerSrcPath, err, string(output))
+	}
+
+	return nil
+}
+
+// GetComposerManifest loads the composer manifest for the given version from the local cache,
+// preferring the source-artifact manifest and falling back to the installed dynamic-module
+// directory. It returns an error if no manifest is found for that version.
+func GetComposerManifest(dirs *xdg.Directories, version string) (*Manifest, error) {
+	sourceDir := LocalCacheComposerSourceDir(dirs, version)
+	manifestPath := filepath.Join(sourceDir, "manifest.yaml")
+	if _, err := os.Stat(manifestPath); err == nil {
+		return LoadLocalManifest(manifestPath)
+	}
+	extensionDir := LocalCacheComposerDir(dirs, version)
+	manifestPath = filepath.Join(extensionDir, "manifest.yaml")
+	if _, err := os.Stat(manifestPath); err == nil {
+		return LoadLocalManifest(manifestPath)
+	}
+	return nil, fmt.Errorf("manifest.yaml not found for composer version %s", version)
+}

--- a/cli/internal/extensions/libcomposer_test.go
+++ b/cli/internal/extensions/libcomposer_test.go
@@ -64,6 +64,30 @@ func TestBuildLibComposer(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestBuildComposer_InvalidPath(t *testing.T) {
+	logger := internaltesting.NewTLogger(t)
+	fakeDirs := &xdg.Directories{DataHome: t.TempDir()}
+	err := BuildComposer(logger, fakeDirs, "/nonexistent/path", "0.1.0")
+	require.ErrorContains(t, err, "failed to build composer from source")
+}
+
+func TestBuildComposer(t *testing.T) {
+	logger := internaltesting.NewTLogger(t)
+	fakeDirs := &xdg.Directories{DataHome: t.TempDir()}
+	composerPath := "../../../extensions/composer"
+
+	composerManifest, err := LoadLocalManifest(filepath.Join(composerPath, "manifest.yaml"))
+	require.NoError(t, err)
+	composerVersion := composerManifest.Version
+
+	err = BuildComposer(logger, fakeDirs, composerPath, composerVersion)
+	require.NoError(t, err)
+
+	// Ensure the libcomposer.so is created via make install.
+	_, err = os.Stat(LocalCacheComposerLib(fakeDirs, composerVersion))
+	require.NoError(t, err)
+}
+
 func TestBuildExtensionFromPath_CShared(t *testing.T) {
 	logger := internaltesting.NewTLogger(t)
 	fakeDirs := &xdg.Directories{DataHome: t.TempDir()}

--- a/cli/internal/extensions/manifest.go
+++ b/cli/internal/extensions/manifest.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/fs"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"slices"
@@ -20,6 +21,7 @@ import (
 	"golang.org/x/mod/semver"
 	"gopkg.in/yaml.v3"
 
+	"github.com/tetratelabs/built-on-envoy/cli/internal/xdg"
 	rootext "github.com/tetratelabs/built-on-envoy/extensions"
 )
 
@@ -68,13 +70,6 @@ type (
 		// (via the main/ directory) rather than as a Go plugin (via standalone/).
 		// Set by BuildExtensionFromPath when the extension has a main/ directory.
 		CShared bool `yaml:"-" json:"-"`
-		// Bundle names a shared "bundle" dynamic module (today only "composer")
-		// that hosts this extension's filter. When set, the filter is loaded
-		// through the bundle's c-shared library (libcomposer.so) instead of the
-		// extension's own .so, the Envoy DynamicModuleConfig name is the bundle
-		// name (loaded globally), and the Envoy filter name is this manifest's
-		// name. Set in code for synthesized manifests; never parsed from YAML.
-		Bundle string `yaml:"-" json:"-"`
 	}
 
 	// Example represents an example usage of an extension.
@@ -355,8 +350,10 @@ func loadManifest(fsys fs.FS, path string, validate bool) (*Manifest, error) {
 }
 
 // resolveVersions resolves the version and composer version for a manifest if it has a parent.
+// Any manifest with a parent inherits from it (a composer Go plugin, or a child of a general
+// bundle of any type). The parent is the composer or bundle root.
 func resolveVersions(m *Manifest, all map[string]*Manifest) error {
-	if m.Type == TypeGo && m.Parent != "" {
+	if m.Parent != "" {
 		parent, ok := all[m.Parent]
 		if !ok {
 			return fmt.Errorf("%w: %s", ErrParentManifestNotFound, m.Parent)
@@ -415,12 +412,12 @@ func LoadLocalManifest(path string) (*Manifest, error) {
 
 // FindLocalParentManifest walks up the directory tree from the manifest's path
 // looking for a parent manifest. Returns (nil, nil) if not found.
-func FindLocalParentManifest(m *Manifest) (*Manifest, error) {
+func FindLocalParentManifest(m *Manifest) (*Manifest, string, error) {
 	dir := filepath.Dir(m.Path)
 	for {
 		parent := filepath.Dir(dir)
 		if parent == dir {
-			return nil, nil
+			return nil, "", nil
 		}
 		dir = parent
 
@@ -434,7 +431,7 @@ func FindLocalParentManifest(m *Manifest) (*Manifest, error) {
 			continue
 		}
 		if cm.Name == m.Parent {
-			return cm, nil
+			return cm, dir, nil
 		}
 	}
 }
@@ -572,4 +569,66 @@ func ResolveMinimumCompatibleEnvoyVersion(manifests []*Manifest) (string, error)
 		return lowestMax, nil
 	}
 	return "", nil
+}
+
+// ResolveExtensionManifest returns the manifest for the extension named extensionName within a
+// downloaded artifact. When the artifact itself is the requested extension it is returned as-is;
+// otherwise the artifact is treated as a bundle and its source tree is searched for the named
+// child, inheriting versions from a sibling composer parent manifest when present.
+func ResolveExtensionManifest(dirs *xdg.Directories, artifactManifest *Manifest, artifactType, extensionName string,
+	logger *slog.Logger,
+) (*Manifest, error) {
+	// Pre-compiled composer plugin packages ship the parent composer manifest as
+	// manifest-composer.yaml alongside the extension; inherit versions from it when present.
+	var composerManifest *Manifest
+	composerParent := filepath.Join(LocalCacheExtensionDir(dirs, artifactManifest), "manifest-composer.yaml")
+	if _, err := os.Stat(composerParent); err == nil {
+		p, err := LoadLocalManifest(composerParent)
+		if err != nil {
+			return nil,
+				fmt.Errorf("failed to load parent manifest from downloaded extension at %q: %w", composerParent, err)
+		}
+		composerManifest = p
+	}
+
+	if artifactManifest.Name == extensionName || extensionName == "" {
+		if composerManifest != nil {
+			ResolveVersionsWithParent(artifactManifest, composerManifest)
+		}
+		return artifactManifest, nil
+	}
+
+	manifestPath, err := LocalCacheExtensionManifest(dirs, artifactManifest, artifactType, extensionName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get local cache manifest path for extension %q: %w", extensionName, err)
+	}
+
+	logger.Info("loading manifest from downloaded extension", "path", manifestPath)
+	m, err := LoadLocalManifest(manifestPath)
+	if err != nil {
+		return nil,
+			fmt.Errorf("failed to load manifest from downloaded extension at %q: %w", manifestPath, err)
+	}
+
+	mergeManifestFromRoot(m, artifactManifest)
+	return m, nil
+}
+
+// mergeManifestFromOCI preserves fields from the OCI-annotation-derived
+// manifest when the embedded YAML manifest has them empty. Composer plugins
+// have incomplete manifests because version and composerVersion are inherited
+// from the parent at build time.
+func mergeManifestFromRoot(embedded, fromOCI *Manifest) {
+	if embedded.Version == "" {
+		embedded.Version = fromOCI.Version
+	}
+	if embedded.ComposerVersion == "" {
+		embedded.ComposerVersion = fromOCI.ComposerVersion
+	}
+	if embedded.MinEnvoyVersion == "" {
+		embedded.MinEnvoyVersion = fromOCI.MinEnvoyVersion
+	}
+	if embedded.MaxEnvoyVersion == "" {
+		embedded.MaxEnvoyVersion = fromOCI.MaxEnvoyVersion
+	}
 }

--- a/cli/internal/extensions/manifest_test.go
+++ b/cli/internal/extensions/manifest_test.go
@@ -394,6 +394,11 @@ func TestValidateParentManifest(t *testing.T) {
 		wantErr bool
 	}{
 		{"parent_valid.yaml", false},
+		// NOTE(general-bundle): resolveVersions now lets non-Go children inherit from a bundle
+		// parent (see TestResolveVersionsForBundleChildren), but manifest.schema.json still
+		// requires a child's `type` to be `go`, so a Rust child currently fails schema
+		// validation. Flip to `false` once the schema allows non-Go bundle children.
+		{"parent_rust_valid.yaml", true},
 		{"parent_invalid_type.yaml", true},
 		{"parent_missing.yaml", true},
 		{"parent_with_version.yaml", true},
@@ -407,6 +412,29 @@ func TestValidateParentManifest(t *testing.T) {
 			require.Equal(t, tt.wantErr, err != nil, err)
 		})
 	}
+}
+
+// TestResolveVersionsForBundleChildren asserts that a non-Go child (here Rust) inherits version
+// and Envoy constraints from its bundle parent. Before resolveVersions was generalized it only
+// ran for Go children, so a Rust bundle child would keep an empty version. The bundle root is
+// language-typed (type: rust) and marked extensionSet; no dedicated bundle type is needed.
+func TestResolveVersionsForBundleChildren(t *testing.T) {
+	root := []byte("name: b\nversion: 3.2.1\nminEnvoyVersion: 1.38.0\ntype: rust\nextensionSet: true\n")
+	childA := []byte("name: child-a\nparent: b\ntype: rust\n")
+	childB := []byte("name: child-b\nparent: b\ntype: rust\n")
+
+	fsys := fstest.MapFS{
+		"manifest.yaml":         {Data: root},
+		"child-a/manifest.yaml": {Data: childA},
+		"child-b/manifest.yaml": {Data: childB},
+	}
+
+	all, err := LoadManifests(fsys, ".", false)
+	require.NoError(t, err)
+
+	require.Equal(t, "3.2.1", all["child-a"].Version)
+	require.Equal(t, "1.38.0", all["child-a"].MinEnvoyVersion)
+	require.Equal(t, "3.2.1", all["child-b"].Version)
 }
 
 func TestHighestMinEnvoyVersion(t *testing.T) {
@@ -719,7 +747,7 @@ examples: []
 		m, err := LoadLocalManifest(filepath.Join(childDir, "manifest.yaml"))
 		require.NoError(t, err)
 
-		parent, err := FindLocalParentManifest(m)
+		parent, _, err := FindLocalParentManifest(m)
 		require.NoError(t, err)
 		require.NotNil(t, parent)
 		require.Equal(t, "test-parent", parent.Name)
@@ -749,7 +777,7 @@ examples: []
 		m, err := LoadLocalManifest(filepath.Join(tmpDir, "manifest.yaml"))
 		require.NoError(t, err)
 
-		parent, err := FindLocalParentManifest(m)
+		parent, _, err := FindLocalParentManifest(m)
 		require.NoError(t, err)
 		require.Nil(t, parent)
 	})

--- a/cli/internal/extensions/registry.go
+++ b/cli/internal/extensions/registry.go
@@ -57,7 +57,7 @@ func NameFromRepository(repository string) string {
 
 // SourceRepositoryName constructs the source repository name for an extension based on the manifest.
 func SourceRepositoryName(registry string, manifest *Manifest) string {
-	if manifest.Type == TypeGo || manifest.Type == TypeComposer {
+	if (manifest.Type == TypeGo && !manifest.CShared) || manifest.Type == TypeComposer {
 		return registry + "/composer-src"
 	}
 	return registry + "/extension-src-" + manifest.Name


### PR DESCRIPTION
- For both remote and local extensions, we use unified function to process the compilation of source code.
- Now, when downloaded the remote extension, we will try the make the artifact manifest and the extension manifest be two different manifests. This is pre change to support general extension bundle.
- existing `parent` is reused, all the full-compiled composer could be used as a general extension bundle.