### PR TITLE
cli: add command to view the CLI logs

### DIFF
--- a/cli/cmd/logs.go
+++ b/cli/cmd/logs.go
@@ -1,0 +1,172 @@
+// Copyright Built On Envoy
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package cmd
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/tetratelabs/built-on-envoy/cli/internal/xdg"
+)
+
+// defaultFollowTail is the number of lines shown when --follow is set without an explicit --tail.
+var defaultFollowTail = 20
+
+// Logs is a command to print the CLI logs.
+type Logs struct {
+	Follow bool `short:"f" help:"Follow the log output (like tail -f)."`
+	Tail   int  `short:"t" name:"tail" help:"Number of recent log lines to show. Defaults to 20 when --follow is set, 0 (all lines) otherwise."`
+
+	output io.Writer `kong:"-"` // Internal field for testing
+}
+
+//go:embed logs_help.md
+var logsHelp string
+
+// Help provides detailed help for the logs command.
+func (l *Logs) Help() string { return logsHelp }
+
+// AfterApply initializes the logs command, ensuring the log file exists.
+func (l *Logs) AfterApply() error {
+	if l.Tail == 0 && l.Follow {
+		l.Tail = defaultFollowTail
+	}
+	return nil
+}
+
+// Run executes the logs command.
+func (l *Logs) Run(ctx context.Context, dirs *xdg.Directories, logger *slog.Logger) error {
+	logger.Debug("handling logs command", "follow", l.Follow, "tail", l.Tail)
+
+	if l.output == nil {
+		l.output = os.Stdout
+	}
+
+	logFile := filepath.Clean(filepath.Join(dirs.StateHome, "boe.log"))
+	if err := os.MkdirAll(dirs.StateHome, 0o750); err != nil {
+		return fmt.Errorf("failed to create state directory: %w", err)
+	}
+
+	// Eagerly create the file if it does not exist instead of failing
+	f, err := os.OpenFile(logFile, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return fmt.Errorf("failed to open log file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	if l.Tail > 0 {
+		if err = printLastLines(f, l.output, l.Tail); err != nil {
+			return err
+		}
+		if !l.Follow {
+			return nil
+		}
+		// Seek to end of file to follow from here.
+		if _, err = f.Seek(0, io.SeekEnd); err != nil {
+			return fmt.Errorf("failed to seek log file: %w", err)
+		}
+	} else {
+		// Print all current content.
+		if _, err = io.Copy(l.output, f); err != nil {
+			return fmt.Errorf("failed to read log file: %w", err)
+		}
+		if !l.Follow {
+			return nil
+		}
+		// File position is already at the end after io.Copy, ready to follow.
+	}
+
+	return followFile(ctx, f, l.output)
+}
+
+// tailChunkSize is the read-chunk size used when scanning backwards for line boundaries.
+const tailChunkSize = 4096
+
+// printLastLines writes the last n lines of f to out by scanning backwards from EOF.
+// Memory usage is O(tailChunkSize), independent of file size.
+func printLastLines(f *os.File, out io.Writer, n int) error {
+	size, err := f.Seek(0, io.SeekEnd)
+	if err != nil {
+		return fmt.Errorf("failed to seek log file: %w", err)
+	}
+	if size == 0 {
+		return nil
+	}
+
+	// Exclude a trailing newline so it doesn't count as an extra empty line.
+	scanEnd := size
+	lastByte := make([]byte, 1)
+	if _, err := f.ReadAt(lastByte, size-1); err != nil {
+		return fmt.Errorf("failed to read log file: %w", err)
+	}
+	if lastByte[0] == '\n' {
+		scanEnd--
+	}
+
+	remaining := n
+	startPos := int64(0)
+	buf := make([]byte, tailChunkSize)
+
+	for pos := scanEnd; pos > 0 && remaining > 0; {
+		chunkStart := pos - int64(tailChunkSize)
+		if chunkStart < 0 {
+			chunkStart = 0
+		}
+		chunk := buf[:pos-chunkStart]
+		if _, err := f.ReadAt(chunk, chunkStart); err != nil && err != io.EOF {
+			return fmt.Errorf("failed to read log file: %w", err)
+		}
+		for i := len(chunk) - 1; i >= 0 && remaining > 0; i-- {
+			if chunk[i] == '\n' {
+				remaining--
+				if remaining == 0 {
+					startPos = chunkStart + int64(i) + 1
+				}
+			}
+		}
+		pos = chunkStart
+	}
+
+	if _, err := f.Seek(startPos, io.SeekStart); err != nil {
+		return fmt.Errorf("failed to seek log file: %w", err)
+	}
+	if _, err := io.Copy(out, f); err != nil {
+		return fmt.Errorf("failed to write output: %w", err)
+	}
+	return nil
+}
+
+// followFile polls f for new content and writes it to out until ctx is done.
+func followFile(ctx context.Context, f *os.File, out io.Writer) error {
+	buf := make([]byte, 4096)
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+		}
+
+		n, err := f.Read(buf)
+		if n > 0 {
+			if _, werr := out.Write(buf[:n]); werr != nil {
+				return werr
+			}
+		}
+		if err == io.EOF {
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("failed to read log file: %w", err)
+		}
+	}
+}

--- a/cli/cmd/logs_help.md
+++ b/cli/cmd/logs_help.md
@@ -1,0 +1,31 @@
+The logs command prints the Built On Envoy CLI logs to stdout.
+By default, it prints all log entries from the current session log file.
+
+Use `--follow` to continuously stream new log entries as they are written,
+similar to `tail -f`. Use `--tail` to limit output to the most recent N lines.
+
+## Examples
+
+Print all logs:
+
+    ```shell
+    boe logs
+    ```
+
+Print the last 50 log lines:
+
+    ```shell
+    boe logs --tail 50
+    ```
+
+Follow the log output in real time:
+
+    ```shell
+    boe logs --follow
+    ```
+
+Show the last 20 lines and continue following:
+
+    ```shell
+    boe logs --follow --tail 20
+    ```

--- a/cli/cmd/logs_test.go
+++ b/cli/cmd/logs_test.go
@@ -1,0 +1,176 @@
+// Copyright Built On Envoy
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/alecthomas/kong"
+	"github.com/stretchr/testify/require"
+
+	internaltesting "github.com/tetratelabs/built-on-envoy/cli/internal/testing"
+	"github.com/tetratelabs/built-on-envoy/cli/internal/xdg"
+)
+
+func TestParseCmdLogsHelp(t *testing.T) {
+	var cli struct {
+		Logs Logs `cmd:"" help:"Print the CLI logs"`
+	}
+
+	var buf bytes.Buffer
+	parser, err := kong.New(&cli,
+		kong.Name("boe"),
+		kong.Writers(&buf, &buf),
+		kong.Exit(func(int) {}),
+	)
+	require.NoError(t, err)
+
+	_, _ = parser.Parse([]string{"logs", "--help"})
+
+	expected := fmt.Sprintf(`Usage: boe logs [flags]
+
+Print the CLI logs
+
+%s
+Flags:
+  -h, --help        Show context-sensitive help.
+
+  -f, --follow      Follow the log output (like tail -f).
+  -t, --tail=INT    Number of recent log lines to show. Defaults to 20 when
+                    --follow is set, 0 (all lines) otherwise.
+`, internaltesting.WrapHelp(logsHelp))
+
+	require.Equal(t, expected, buf.String())
+}
+
+func TestLogsNonExistentFile(t *testing.T) {
+	dirs := &xdg.Directories{
+		StateHome: filepath.Join(t.TempDir(), "nonexistent"),
+	}
+	var buf bytes.Buffer
+	cmd := &Logs{output: &buf}
+
+	require.NoError(t, cmd.Run(t.Context(), dirs, internaltesting.NewTLogger(t)))
+	require.Empty(t, buf.String())
+	require.FileExists(t, filepath.Join(dirs.StateHome, "boe.log"))
+}
+
+func TestLogsAllLines(t *testing.T) {
+	dirs, logContent := newTestLogsState(t, 10)
+	var buf bytes.Buffer
+	cmd := &Logs{output: &buf} // Tail=0 means all lines
+
+	require.NoError(t, cmd.Run(t.Context(), dirs, internaltesting.NewTLogger(t)))
+	require.Equal(t, logContent, buf.String())
+}
+
+func TestLogsTail(t *testing.T) {
+	dirs, _ := newTestLogsState(t, 10)
+	var buf bytes.Buffer
+	cmd := &Logs{Tail: 3, output: &buf}
+
+	require.NoError(t, cmd.Run(t.Context(), dirs, internaltesting.NewTLogger(t)))
+
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	require.Len(t, lines, 3)
+	require.Equal(t, "line 8", lines[0])
+	require.Equal(t, "line 9", lines[1])
+	require.Equal(t, "line 10", lines[2])
+}
+
+func TestLogsTailMoreThanAvailable(t *testing.T) {
+	dirs, logContent := newTestLogsState(t, 5)
+	var buf bytes.Buffer
+	cmd := &Logs{Tail: 100, output: &buf}
+
+	require.NoError(t, cmd.Run(t.Context(), dirs, internaltesting.NewTLogger(t)))
+	require.Equal(t, logContent, buf.String())
+}
+
+func TestLogsAfterApply(t *testing.T) {
+	t.Run("sets default tail when follow is set and tail is unset", func(t *testing.T) {
+		cmd := &Logs{Follow: true}
+		require.NoError(t, cmd.AfterApply())
+		require.Equal(t, defaultFollowTail, cmd.Tail)
+	})
+
+	t.Run("does not change tail when follow is false", func(t *testing.T) {
+		cmd := &Logs{Follow: false}
+		require.NoError(t, cmd.AfterApply())
+		require.Equal(t, 0, cmd.Tail)
+	})
+
+	t.Run("does not override an explicit tail", func(t *testing.T) {
+		cmd := &Logs{Follow: true, Tail: 5}
+		require.NoError(t, cmd.AfterApply())
+		require.Equal(t, 5, cmd.Tail)
+	})
+}
+
+func TestLogsFollow(t *testing.T) {
+	dirs, _ := newTestLogsState(t, 30)
+	logPath := filepath.Clean(filepath.Join(dirs.StateHome, "boe.log"))
+
+	bufs := internaltesting.CaptureOutput("logs")
+	ctx, cancel := context.WithCancel(t.Context())
+
+	done := make(chan error, 1)
+	cmd := &Logs{Follow: true, output: bufs[0]} // no explicit Tail → AfterApply sets it to 20
+	require.NoError(t, cmd.AfterApply())
+	go func() {
+		done <- cmd.Run(ctx, dirs, internaltesting.NewTLogger(t))
+	}()
+
+	// Wait until the goroutine has printed the default tail (last 20 lines).
+	require.Eventually(t, func() bool {
+		return strings.Contains(bufs[0].String(), "line 30")
+	}, 2*time.Second, 10*time.Millisecond)
+
+	// Write a new line while following.
+	f, err := os.OpenFile(logPath, os.O_WRONLY|os.O_APPEND, 0o600)
+	require.NoError(t, err)
+	_, err = fmt.Fprintln(f, "appended line")
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	require.Eventually(t, func() bool {
+		return strings.Contains(bufs[0].String(), "appended line")
+	}, 2*time.Second, 10*time.Millisecond)
+
+	cancel()
+	require.NoError(t, <-done)
+
+	out := bufs[0].String()
+	// Should start at line 11 (last 20 of 30), not line 1.
+	require.NotContains(t, out, "line 1\n")
+	require.Contains(t, out, "line 11\n")
+	require.Contains(t, out, "line 30\n")
+	require.Contains(t, out, "appended line\n")
+}
+
+// newTestLogsState creates a temporary state directory with a boe.log file containing n lines.
+// Returns the directories and the full file content (with trailing newline).
+func newTestLogsState(t *testing.T, n int) (*xdg.Directories, string) {
+	t.Helper()
+	stateHome := t.TempDir()
+	dirs := &xdg.Directories{StateHome: stateHome}
+
+	var sb strings.Builder
+	for i := 1; i <= n; i++ {
+		fmt.Fprintf(&sb, "line %d\n", i)
+	}
+	content := sb.String()
+
+	require.NoError(t, os.WriteFile(filepath.Join(stateHome, "boe.log"), []byte(content), 0o600))
+	return dirs, content
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -37,6 +37,7 @@ const CLIName = "boe"
 type CLI struct {
 	List        List        `cmd:"" help:"List available extensions"`
 	Run         Run         `cmd:"" help:"Run Envoy with extensions"`
+	Logs        Logs        `cmd:"" help:"Print the CLI logs"`
 	Healthcheck Healthcheck `cmd:"" help:"Docker HEALTHCHECK command." hidden:""`
 	GenConfig   GenConfig   `cmd:"" help:"Generate Envoy configuration with extensions"`
 	Create      Create      `cmd:"" help:"Create a new extension template"`

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -37,11 +37,11 @@ const CLIName = "boe"
 type CLI struct {
 	List        List        `cmd:"" help:"List available extensions"`
 	Run         Run         `cmd:"" help:"Run Envoy with extensions"`
-	Logs        Logs        `cmd:"" help:"Print the CLI logs"`
 	Healthcheck Healthcheck `cmd:"" help:"Docker HEALTHCHECK command." hidden:""`
 	GenConfig   GenConfig   `cmd:"" help:"Generate Envoy configuration with extensions"`
 	Create      Create      `cmd:"" help:"Create a new extension template"`
 	Download    Download    `cmd:"" help:"Download extensions from the registry"`
+	Logs        Logs        `cmd:"" help:"Print the CLI logs"`
 	Clean       Clean       `cmd:"" help:"Clean cache directories"`
 	UI          UI          `cmd:"" help:"Start the web UI"`
 	Version     Version     `cmd:"" help:"Print version information"`

--- a/cli/cmd/root_test.go
+++ b/cli/cmd/root_test.go
@@ -139,6 +139,9 @@ Commands:
   run [flags]
     Run Envoy with extensions
 
+  logs [flags]
+    Print the CLI logs
+
   gen-config [flags]
     Generate Envoy configuration with extensions
 

--- a/cli/cmd/root_test.go
+++ b/cli/cmd/root_test.go
@@ -138,21 +138,21 @@ Commands:
 
   run [flags]
     Run Envoy with extensions
-
-  logs [flags]
-    Print the CLI logs
-
-  gen-config [flags]
+	
+	gen-config [flags]
     Generate Envoy configuration with extensions
-
-  create <name> [flags]
+	
+	create <name> [flags]
     Create a new extension template
-
-  download <extension> [flags]
+	
+	download <extension> [flags]
     Download extensions from the registry
-
-  clean [flags]
+	
+	clean [flags]
     Clean cache directories
+	
+	logs [flags]
+	Print the CLI logs
 
   ui [flags]
     Start the web UI

--- a/cli/cmd/root_test.go
+++ b/cli/cmd/root_test.go
@@ -138,21 +138,21 @@ Commands:
 
   run [flags]
     Run Envoy with extensions
-	
-	gen-config [flags]
+
+  gen-config [flags]
     Generate Envoy configuration with extensions
-	
-	create <name> [flags]
+
+  create <name> [flags]
     Create a new extension template
-	
-	download <extension> [flags]
+
+  download <extension> [flags]
     Download extensions from the registry
-	
-	clean [flags]
+
+  logs [flags]
+    Print the CLI logs
+
+  clean [flags]
     Clean cache directories
-	
-	logs [flags]
-	Print the CLI logs
 
   ui [flags]
     Start the web UI

--- a/cli/tools/gen-cli-docs/templates/command.mdx.tmpl
+++ b/cli/tools/gen-cli-docs/templates/command.mdx.tmpl
@@ -32,6 +32,6 @@ import Callout from '../../../components/Callout.astro';
 | Name | Description | Type | Default | Env Var | Required |
 |------|-------------|------|---------|-----|----------|
 {{- range .Flags}}
-| `--{{.Name}}`{{if .Short}} (`-{{.Short}}`){{end}} | {{.Help}} | `{{.Type}}` | {{if .Default}}`{{.Default}}`{{else}}-{{end}} | {{if .EnvVars}}`{{join .EnvVars ", "}}`{{else}}-{{end}} | {{if .Required}}Yes{{else}}No{{end}} |
+| {{if .Short}} `-{{.Short}}`, {{end}}`--{{.Name}}` | {{.Help}} | `{{.Type}}` | {{if .Default}}`{{.Default}}`{{else}}-{{end}} | {{if .EnvVars}}`{{join .EnvVars ", "}}`{{else}}-{{end}} | {{if .Required}}Yes{{else}}No{{end}} |
 {{- end}}
 {{end}}

--- a/website/src/pages/docs/cli/logs.mdx
+++ b/website/src/pages/docs/cli/logs.mdx
@@ -1,0 +1,59 @@
+---
+layout: ../../../layouts/DocsLayout.astro
+title: logs
+description: Print the CLI logs
+---
+
+import Callout from '../../../components/Callout.astro';
+
+# boe logs
+
+The logs command prints the Built On Envoy CLI logs to stdout.
+By default, it prints all log entries from the current session log file.
+
+Use `--follow` to continuously stream new log entries as they are written,
+similar to `tail -f`. Use `--tail` to limit output to the most recent N lines.
+
+## Examples
+
+Print all logs:
+
+    ```shell
+    boe logs
+    ```
+
+Print the last 50 log lines:
+
+    ```shell
+    boe logs --tail 50
+    ```
+
+Follow the log output in real time:
+
+    ```shell
+    boe logs --follow
+    ```
+
+Show the last 20 lines and continue following:
+
+    ```shell
+    boe logs --follow --tail 20
+    ```
+
+
+## Usage details
+
+```shell
+boe logs [flags]
+boe logs --help
+```
+
+
+
+## Flags
+
+| Name | Description | Type | Default | Env Var | Required |
+|------|-------------|------|---------|-----|----------|
+|  `-f`, `--follow` | Follow the log output (like tail -f). | `bool` | - | - | No |
+|  `-t`, `--tail` | Number of recent log lines to show. Defaults to 20 when --follow is set, 0 (all lines) otherwise. | `int` | - | - | No |
+

--- a/website/src/pages/docs/sidebar-cli.yaml
+++ b/website/src/pages/docs/sidebar-cli.yaml
@@ -14,6 +14,8 @@ sections:
         href: /docs/cli/gen-config
       - title: list
         href: /docs/cli/list
+      - title: logs
+        href: /docs/cli/logs
       - title: run
         href: /docs/cli/run
       - title: ui


### PR DESCRIPTION
Logs were written in the `~/.local/state/boe/boe.log` but were hard to follow for users. This PR adds the `boe logs` command, allowing users to tail and follow the logs more easily.