### PR TITLE
composer: make the composer lite an independent artifact

### DIFF
--- a/cli/cmd/genconfig.go
+++ b/cli/cmd/genconfig.go
@@ -197,9 +197,9 @@ func (g *GenConfig) writeConfig(
 				// since the config references that name directly.
 				dstExtensionFile = filepath.Join(g.Output, filepath.Base(srcExtensionFile))
 			} else {
-				// For Go plugins, we need to copy the composer shared bundle library (libcomposer.so)
-				// first.
-				composerFile := extensions.LocalCacheComposerLib(dirs, m.ComposerVersion)
+				// Standalone Go plugins are hosted by the composer-lite goplugin-loader, so copy
+				// libcomposer-lite.so first.
+				composerFile := extensions.LocalCacheComposerLiteLib(dirs, m.ComposerVersion)
 				dst := filepath.Join(g.Output, filepath.Base(composerFile))
 				if err := copyFile(composerFile, dst, logger); err != nil {
 					return nil, err

--- a/cli/cmd/genconfig_test.go
+++ b/cli/cmd/genconfig_test.go
@@ -346,7 +346,7 @@ func TestGenConfigWriteConfig(t *testing.T) {
 			mockLuaExtension          = &extensions.Manifest{Name: "test-lua", Type: extensions.TypeLua}
 			mockRustExtensionFile     = extensions.LocalCacheExtension(dirs, mockRustExtension)
 			mockGoExtensionFile       = extensions.LocalCacheExtension(dirs, mockGoExtension)
-			mockComposerExtensionFile = extensions.LocalCacheComposerLib(dirs, "1.0.0")
+			mockComposerExtensionFile = extensions.LocalCacheComposerLiteLib(dirs, "1.0.0")
 		)
 
 		// Create the mock extensions at the source
@@ -361,7 +361,7 @@ func TestGenConfigWriteConfig(t *testing.T) {
 		require.NoError(t, err)
 		require.FileExists(t, cmd.Output+"/envoy.yaml")
 		require.FileExists(t, cmd.Output+"/libtest-rust.so")
-		require.FileExists(t, cmd.Output+"/libcomposer.so")
+		require.FileExists(t, cmd.Output+"/libcomposer-lite.so")
 		require.FileExists(t, cmd.Output+"/test-go.so")
 	})
 
@@ -371,18 +371,18 @@ func TestGenConfigWriteConfig(t *testing.T) {
 			logger = internaltesting.NewTLogger(t)
 			dirs   = &xdg.Directories{DataHome: t.TempDir()}
 
-			gpl    = &extensions.Manifest{Name: extensions.GoPluginLoaderName, Type: extensions.TypeGo, CShared: true, Parent: extensions.ComposerBundle, Version: "1.0.0"}
-			gplLib = extensions.LocalCacheExtension(dirs, gpl) // resolves to dym/composer/1.0.0/libcomposer.so
+			gpl    = &extensions.Manifest{Name: extensions.GoPluginLoaderName, Type: extensions.TypeGo, CShared: true, Parent: extensions.ComposerLiteBundle, Version: "1.0.0"}
+			gplLib = extensions.LocalCacheExtension(dirs, gpl) // resolves to dym/composer-lite/1.0.0/libcomposer-lite.so
 		)
 		require.NoError(t, os.MkdirAll(filepath.Dir(gplLib), 0o750))
-		require.NoError(t, os.WriteFile(gplLib, []byte("fake libcomposer"), 0o600))
+		require.NoError(t, os.WriteFile(gplLib, []byte("fake libcomposer-lite"), 0o600))
 
 		// The user-supplied inner plugin url must be left untouched (not rewritten to file://).
 		inputConfig := `filter_config: {"name":"goplugin-loader","url":"oci://ex/p:v1"}`
 		_, err := cmd.writeConfig(inputConfig, []*extensions.Manifest{gpl}, dirs, logger)
 		require.NoError(t, err)
 
-		require.FileExists(t, cmd.Output+"/libcomposer.so")
+		require.FileExists(t, cmd.Output+"/libcomposer-lite.so")
 		// No per-extension goplugin-loader.so should be produced for a bundle-hosted extension.
 		require.NoFileExists(t, cmd.Output+"/goplugin-loader.so")
 

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -268,9 +268,10 @@ func downloadExtensions(ctx context.Context, downloader *extensions.Downloader, 
 		switch artifact.ArtifactType {
 		case extensions.ArtifactBinary:
 			if artifact.Manifest.Type == extensions.TypeGo && !artifact.Manifest.CShared {
-				// Ensure the composer is downloaded before running any extensions that may depend on it.
-				if err = extensions.CheckOrDownloadLibComposer(ctx, downloader, artifact.Manifest.ComposerVersion,
-					extensions.ComposerArtifactLite); err != nil {
+				// A standalone Go plugin is hosted by the independent composer-lite loader.
+				// Ensure composer-lite is downloaded before running any extensions that depend on it.
+				if err = extensions.CheckOrDownloadLibComposerLite(ctx, downloader,
+					artifact.Manifest.ComposerVersion); err != nil {
 					return nil, fmt.Errorf("failed to download libcomposer %s for extension %s: %w",
 						artifact.Manifest.ComposerVersion, name, err)
 				}
@@ -312,7 +313,7 @@ func resolveGoPluginLoader(ctx context.Context, downloader *extensions.Downloade
 	_, _ = fmt.Fprintf(os.Stderr, "→ %sPreparing %s (composer %s)...%s\n",
 		internal.ANSIBold, extensions.GoPluginLoaderName, version, internal.ANSIReset)
 
-	if err := extensions.CheckOrDownloadLibComposer(ctx, downloader, version, extensions.ComposerArtifactLite); err != nil {
+	if err := extensions.CheckOrDownloadLibComposerLite(ctx, downloader, version); err != nil {
 		return nil, fmt.Errorf("failed to download libcomposer %s for %s: %w", version, extensions.GoPluginLoaderName, err)
 	}
 
@@ -320,7 +321,7 @@ func resolveGoPluginLoader(ctx context.Context, downloader *extensions.Downloade
 		Name:            extensions.GoPluginLoaderName,
 		Type:            extensions.TypeGo,
 		CShared:         true,
-		Parent:          extensions.ComposerBundle,
+		Parent:          extensions.ComposerLiteBundle,
 		Version:         version,
 		ComposerVersion: version,
 	}
@@ -571,14 +572,15 @@ func handleExtensionSource(ctx context.Context, downloader *extensions.Downloade
 			return fmt.Errorf("failed to build local Go extension %s: %w", rootManifest.Name, err)
 		}
 		if !cshared {
-			// A locally-built old-style Go plugin is loaded via plugin.Open and must link against a
-			// libcomposer built from the same source with the same toolchain/deps; a prebuilt lite
+			// A locally-built old-style Go plugin is hosted by the composer-lite loader.
+			// It is loaded via plugin.Open and must link against a
+			// libcomposer-lite built from the same source with the same toolchain/deps; a prebuilt lite
 			// binary would be ABI-incompatible. Build from source unconditionally rather than via
-			// CheckOrDownloadLibComposer: that cache is keyed only by version and shares the
-			// dym/composer/<version>/libcomposer.so slot with the downloaded lite binary, so a cached
-			// binary (from goplugin-loader or a downloaded plugin) would otherwise be reused here and
-			// reintroduce the ABI mismatch.
-			if err = extensions.DownloadLibComposerAndBuildIfNeeded(ctx, downloader, rootManifest.ComposerVersion,
+			// CheckOrDownloadLibComposerLite: the composer-lite cache is keyed only by version, so a cached
+			// prebuilt binary (from goplugin-loader or a downloaded plugin) would otherwise be reused
+			// here and reintroduce the ABI mismatch. Building from source overwrites that slot with an
+			// ABI-matched libcomposer-lite.so.
+			if err = extensions.DownloadComposerLiteAndBuildIfNeeded(ctx, downloader, rootManifest.ComposerVersion,
 				extensions.ComposerArtifactSource); err != nil {
 				return fmt.Errorf("failed to build libcomposer %s for extension %s: %w",
 					rootManifest.ComposerVersion, rootManifest.Name, err)

--- a/cli/cmd/run_test.go
+++ b/cli/cmd/run_test.go
@@ -860,10 +860,10 @@ func TestDownloadExtensions(t *testing.T) {
 		dataHome := t.TempDir()
 		composerVersion := "0.1.0"
 
-		// Pre-create the libcomposer.so so CheckOrDownloadLibComposer succeeds without network.
-		composerDir := extensions.LocalCacheComposerDir(&xdg.Directories{DataHome: dataHome}, composerVersion)
-		require.NoError(t, os.MkdirAll(composerDir, 0o750))
-		require.NoError(t, os.WriteFile(filepath.Join(composerDir, "libcomposer.so"), []byte("fake"), 0o600))
+		// Pre-create libcomposer-lite.so so CheckOrDownloadLibComposerLite succeeds without network.
+		composerLiteLib := extensions.LocalCacheComposerLiteLib(&xdg.Directories{DataHome: dataHome}, composerVersion)
+		require.NoError(t, os.MkdirAll(filepath.Dir(composerLiteLib), 0o750))
+		require.NoError(t, os.WriteFile(composerLiteLib, []byte("fake"), 0o600))
 
 		mock := &mockOCIClient{
 			annotations: map[string]string{
@@ -1099,10 +1099,10 @@ func TestDownloadExtensions(t *testing.T) {
 
 	t.Run("goplugin-loader reserved name synthesizes a bundle manifest", func(t *testing.T) {
 		dataHome := t.TempDir()
-		// Pre-seed libcomposer.so so CheckOrDownloadLibComposer hits the cache and avoids network.
-		composerDir := extensions.LocalCacheComposerDir(&xdg.Directories{DataHome: dataHome}, "1.0.0")
-		require.NoError(t, os.MkdirAll(composerDir, 0o750))
-		require.NoError(t, os.WriteFile(filepath.Join(composerDir, "libcomposer.so"), []byte("fake"), 0o600))
+		// Pre-seed libcomposer-lite.so so CheckOrDownloadLibComposer hits the cache and avoids network.
+		composerLiteLib := extensions.LocalCacheComposerLiteLib(&xdg.Directories{DataHome: dataHome}, "1.0.0")
+		require.NoError(t, os.MkdirAll(filepath.Dir(composerLiteLib), 0o750))
+		require.NoError(t, os.WriteFile(composerLiteLib, []byte("fake"), 0o600))
 
 		d := &extensions.Downloader{Logger: internaltesting.NewTLogger(t), Dirs: &xdg.Directories{DataHome: dataHome}}
 
@@ -1114,7 +1114,7 @@ func TestDownloadExtensions(t *testing.T) {
 		require.Equal(t, extensions.GoPluginLoaderName, m.Name)
 		require.Equal(t, extensions.TypeGo, m.Type)
 		require.True(t, m.CShared, "goplugin-loader must be treated as a c-shared dynamic module")
-		require.Equal(t, extensions.ComposerBundle, m.Parent)
+		require.Equal(t, extensions.ComposerLiteBundle, m.Parent)
 		require.Equal(t, "1.0.0", m.Version)
 		require.Equal(t, "1.0.0", m.ComposerVersion)
 		require.True(t, m.Remote)
@@ -1123,8 +1123,8 @@ func TestDownloadExtensions(t *testing.T) {
 	})
 
 	t.Run("goplugin-loader missing composer cache fails without network", func(t *testing.T) {
-		// No libcomposer.so seeded and a concrete tag: CheckOrDownloadLibComposer must try to
-		// download via the (mock) client. A pull error surfaces as a wrapped error.
+		// No libcomposer-lite.so seeded and a concrete tag: CheckOrDownloadLibComposerLite must try
+		// to download via the (mock) client. A pull error surfaces as a wrapped error.
 		mock := &mockOCIClient{pullErr: errors.New("no network")}
 		d := newTestDownloader(t, t.TempDir(), mock)
 

--- a/cli/e2e/download_test.go
+++ b/cli/e2e/download_test.go
@@ -45,8 +45,9 @@ func TestDownloadComposer(t *testing.T) {
 			dirs := &xdg.Directories{DataHome: path}
 			manifest := &extensions.Manifest{Name: variant, Version: "0.6.0", Type: extensions.TypeComposer}
 
+			// composer → libcomposer.so, composer-lite → libcomposer-lite.so (independent artifacts).
 			requireDownloadHasFiles(t, manifest,
-				filepath.Base(extensions.LocalCacheComposerLib(dirs, "0.6.0")),
+				filepath.Base(extensions.LocalCacheExtension(dirs, manifest)),
 			)
 		})
 	}

--- a/cli/e2e/run_test.go
+++ b/cli/e2e/run_test.go
@@ -338,11 +338,11 @@ func dummy() string {
 // TestGoPluginLoaderRemoteExtension exercises the raw goplugin-loader extension end to end:
 //  1. build the example Go plugin image and push it to the local test registry;
 //  2. build the composer-lite image and push it to the local test registry, so boe downloads
-//     libcomposer.so from there into the local cache;
+//     libcomposer-lite.so from there into the local cache;
 //  3. run `boe run --extension goplugin-loader --config '{"name":...,"url":"oci://..."}'`
 //     and assert the dynamically loaded plugin processes responses.
 //
-// Both the plugin and libcomposer.so are built from the composer Dockerfiles, which pin the
+// Both the plugin and libcomposer-lite.so are built from the composer Dockerfiles, which pin the
 // same GO_VERSION from go.mod. This matters because plugin.Open requires the plugin and host
 // to share an identical Go toolchain and dependency set; strict_check=false only relaxes the
 // soft build-info checks, not the linker's hard ABI requirement.
@@ -365,8 +365,8 @@ func TestGoPluginLoaderRemoteExtension(t *testing.T) {
 	t.Setenv("BOE_REGISTRY", registryAddr)
 	t.Setenv("BOE_REGISTRY_INSECURE", "true")
 
-	// Dedicated data home so we can place libcomposer.so at the cache location the goplugin-loader
-	// extension expects, and so the plugin pull cache is isolated.
+	// Dedicated data home so we can place libcomposer-lite.so at the cache location the
+	// goplugin-loader extension expects, and so the plugin pull cache is isolated.
 	dataHome := t.TempDir()
 	t.Setenv("BOE_DATA_HOME", dataHome)
 
@@ -386,8 +386,9 @@ func TestGoPluginLoaderRemoteExtension(t *testing.T) {
 
 	// Step 2: build the composer-lite image and push it to the local registry (as
 	// <registry>/composer-lite:<version>). When the goplugin-loader runs in Step 3, boe downloads
-	// libcomposer.so from there into <dataHome>/extensions/dym/composer/<version>/libcomposer.so.
-	// This exercises the real composer download path instead of extracting the file manually.
+	// libcomposer-lite.so from there into
+	// <dataHome>/extensions/dym/composer-lite/<version>/libcomposer-lite.so.
+	// This exercises the real composer-lite download path instead of extracting the file manually.
 	runCmd(t, composerDir, "make", "push_image", "COMPOSER_LITE=true", "PLATFORMS=linux/"+runtime.GOARCH)
 
 	// Step 3: run the goplugin-loader extension, pointing it at the pushed plugin image via

--- a/cli/internal/envoy/extension.go
+++ b/cli/internal/envoy/extension.go
@@ -176,7 +176,8 @@ func (d DynamicModuleFilterGenerator) GenerateFilterConfig(manifest *extensions.
 	moduleName := extensions.ModuleName(manifest)
 	// The composer bundle must be loaded globally: it embeds a single Go runtime that
 	// has to be shared across all of its hosted filters. Other modules load per-filter.
-	loadGlobally := moduleName == extensions.ComposerBundle
+	// Both the full composer and the independent composer-lite host share this behavior.
+	loadGlobally := moduleName == extensions.ComposerBundle || moduleName == extensions.ComposerLiteBundle
 
 	moduleConfig := &dymv3.DynamicModuleConfig{
 		Name:             moduleName,
@@ -307,9 +308,13 @@ func (c ComposerFilterGenerator) GenerateFilterConfig(manifest *extensions.Manif
 	// Covert the StringValue to Any.
 	anyConfig, _ := anypb.New(configStringValue)
 
+	// Standalone Go plugins (CShared=false) are loaded dynamically via the goplugin-loader, which
+	// is hosted by the independent composer-lite module (libcomposer-lite.so). Bundle-hosted
+	// children are CShared=true and go through DynamicModuleFilterGenerator instead, so they never
+	// reach here.
 	protoConfig := &dymhttpv3.DynamicModuleFilter{
 		DynamicModuleConfig: &dymv3.DynamicModuleConfig{
-			Name:             extensions.ComposerBundle,
+			Name:             extensions.ComposerLiteBundle,
 			LoadGlobally:     true,
 			MetricsNamespace: "builtonenvoy",
 		},

--- a/cli/internal/envoy/extension_test.go
+++ b/cli/internal/envoy/extension_test.go
@@ -478,7 +478,7 @@ func TestComposerFilterGenerator(t *testing.T) {
 					TypedConfig: func() *anypb.Any {
 						dymConfig := &dymhttpv3.DynamicModuleFilter{
 							DynamicModuleConfig: &dymv3.DynamicModuleConfig{
-								Name:             "composer",
+								Name:             "composer-lite",
 								LoadGlobally:     true,
 								MetricsNamespace: "builtonenvoy",
 							},
@@ -527,7 +527,7 @@ func TestComposerFilterGenerator(t *testing.T) {
 
 						dymConfig := &dymhttpv3.DynamicModuleFilter{
 							DynamicModuleConfig: &dymv3.DynamicModuleConfig{
-								Name:             "composer",
+								Name:             "composer-lite",
 								LoadGlobally:     true,
 								MetricsNamespace: "builtonenvoy",
 							},
@@ -582,7 +582,7 @@ func TestComposerFilterGenerator(t *testing.T) {
 					TypedConfig: func() *anypb.Any {
 						dymConfig := &dymhttpv3.DynamicModuleFilter{
 							DynamicModuleConfig: &dymv3.DynamicModuleConfig{
-								Name:             "composer",
+								Name:             "composer-lite",
 								LoadGlobally:     true,
 								MetricsNamespace: "builtonenvoy",
 							},

--- a/cli/internal/envoy/runner.go
+++ b/cli/internal/envoy/runner.go
@@ -223,8 +223,8 @@ func setupDynamicModuleSearchPath(params *ConfigGenerationParams) (string, func(
 	for _, ext := range params.Extensions {
 		switch {
 		case ext.Type == extensions.TypeGo && !ext.CShared:
-			// Go plugin extensions are loaded by composer via goplugin-loader.
-			// At this point all Go plugin extensions are guaranteed to use the same version of composer.
+			// Standalone Go plugin extensions are loaded by the composer-lite goplugin-loader.
+			// At this point all Go plugin extensions are guaranteed to use the same composer version.
 			composerVersion = ext.ComposerVersion
 
 		case ext.Type == extensions.TypeRust || (ext.Type == extensions.TypeGo && ext.CShared):
@@ -249,20 +249,20 @@ func setupDynamicModuleSearchPath(params *ConfigGenerationParams) (string, func(
 		}
 	}
 
-	// If there are composer extensions, link libcomposer.so as well
+	// If there are standalone Go plugin extensions, link libcomposer-lite.so (their host loader).
 	if composerVersion != "" {
-		composerPath := extensions.LocalCacheComposerLib(params.Dirs, composerVersion)
+		composerPath := extensions.LocalCacheComposerLiteLib(params.Dirs, composerVersion)
 		linkPath := filepath.Join(tempDir, filepath.Base(composerPath))
-		// Skip if libcomposer.so was already linked above by a bundle-hosted extension
-		// (e.g. goplugin-loader), to avoid a "file exists" error.
+		// Skip if libcomposer-lite.so was already linked above by a c-shared bundle-hosted
+		// extension (e.g. goplugin-loader), to avoid a "file exists" error.
 		if _, err := os.Stat(linkPath); err == nil {
-			params.Logger.Debug("libcomposer already linked, skipping", "linkPath", linkPath)
+			params.Logger.Debug("libcomposer-lite already linked, skipping", "linkPath", linkPath)
 		} else if _, err := os.Stat(composerPath); err == nil {
-			params.Logger.Debug("linking libcomposer for composer extensions", "path", composerPath, "linkPath", linkPath)
+			params.Logger.Debug("linking libcomposer-lite for Go plugin extensions", "path", composerPath, "linkPath", linkPath)
 
 			if err := os.Symlink(composerPath, linkPath); err != nil {
 				cleanup()
-				return "", nil, fmt.Errorf("failed to create symlink for libcomposer: %w", err)
+				return "", nil, fmt.Errorf("failed to create symlink for libcomposer-lite: %w", err)
 			}
 		}
 	}

--- a/cli/internal/extensions/directories.go
+++ b/cli/internal/extensions/directories.go
@@ -80,7 +80,9 @@ func LocalCacheExtensionDir(dirs *xdg.Directories, manifest *Manifest) string {
 	case TypeExtProc:
 		return filepath.Join(dirs.DataHome, "extensions", "extproc", moduleName, manifest.Version)
 	case TypeComposer:
-		return LocalCacheComposerDir(dirs, manifest.Version)
+		// Keyed off the module name so the full composer (libcomposer.so) and the
+		// independent composer-lite (libcomposer-lite.so) live in separate slots.
+		return composerDir(dirs, moduleName, manifest.Version)
 	default:
 		return filepath.Join(dirs.DataHome, "extensions", moduleName, manifest.Version)
 	}
@@ -108,7 +110,8 @@ func LocalCacheExtension(dirs *xdg.Directories, manifest *Manifest) string {
 		// ext_proc extensions are not Go plugins, so we return the path to the ext_proc server binary instead
 		return filepath.Join(dir, "ext_proc-server")
 	case TypeComposer:
-		return LocalCacheComposerLib(dirs, manifest.Version)
+		// lib<module>.so: libcomposer.so for the full composer, libcomposer-lite.so for composer-lite.
+		return filepath.Join(dir, fmt.Sprintf("lib%s.so", ModuleName(manifest)))
 	default:
 		return filepath.Join(dir, "plugin.so")
 	}
@@ -130,14 +133,37 @@ func LocalCacheExtensionSourceDir(dirs *xdg.Directories, manifest *Manifest, nam
 	return path
 }
 
-// LocalCacheComposerDir returns the local cache directory for the composer.
+// LocalCacheComposerDir returns the local cache directory for the full composer.
 func LocalCacheComposerDir(dirs *xdg.Directories, version string) string {
-	return filepath.Join(dirs.DataHome, "extensions", "dym", "composer", version)
+	return composerDir(dirs, ComposerBundle, version)
 }
 
-// LocalCacheComposerLib returns the local cache path for the composer lib.
+// LocalCacheComposerLib returns the local cache path for the full composer lib (libcomposer.so).
 func LocalCacheComposerLib(dirs *xdg.Directories, version string) string {
-	return filepath.Join(LocalCacheComposerDir(dirs, version), "libcomposer.so")
+	return composerLib(dirs, ComposerBundle, version)
+}
+
+// LocalCacheComposerLiteDir returns the local cache directory for composer-lite, kept
+// independent from the full composer so the two libraries never share a cache slot.
+func LocalCacheComposerLiteDir(dirs *xdg.Directories, version string) string {
+	return composerDir(dirs, ComposerLiteBundle, version)
+}
+
+// LocalCacheComposerLiteLib returns the local cache path for the composer-lite lib
+// (libcomposer-lite.so).
+func LocalCacheComposerLiteLib(dirs *xdg.Directories, version string) string {
+	return composerLib(dirs, ComposerLiteBundle, version)
+}
+
+// composerDir returns the dynamic-module cache directory for a composer bundle (composer or
+// composer-lite) of the given version.
+func composerDir(dirs *xdg.Directories, name, version string) string {
+	return filepath.Join(dirs.DataHome, "extensions", "dym", name, version)
+}
+
+// composerLib returns the shared-library path (lib<name>.so) for a composer bundle.
+func composerLib(dirs *xdg.Directories, name, version string) string {
+	return filepath.Join(composerDir(dirs, name, version), fmt.Sprintf("lib%s.so", name))
 }
 
 // LocalCacheComposerSourceDir returns the local cache directory of the composer source artifact

--- a/cli/internal/extensions/downloader.go
+++ b/cli/internal/extensions/downloader.go
@@ -59,7 +59,7 @@ type DownloadedExtension struct {
 // DownloadComposer downloads the composer from the specified repository and version into the downloadDir.
 func (d *Downloader) DownloadComposer(ctx context.Context, version string, artifact string) (DownloadedExtension, error) {
 	d.Logger.Info("downloading composer", "repository", d.Registry, "artifact", artifact, "version", version)
-	return d.download(ctx, d.Registry+"/"+artifact, version, func(manifest *ocispec.Manifest) string {
+	ext, err := d.download(ctx, d.Registry+"/"+artifact, version, func(manifest *ocispec.Manifest) string {
 		extensionManifest := ManifestFromOCI(manifest)
 		if isSourceArtifact(manifest) {
 			return LocalCacheExtensionSourceArtifactDir(d.Dirs, extensionManifest)
@@ -74,6 +74,20 @@ func (d *Downloader) DownloadComposer(ctx context.Context, version string, artif
 		}
 		return LocalCacheComposerDir(d.Dirs, composerVersion)
 	})
+	if err != nil {
+		return DownloadedExtension{}, err
+	}
+
+	// For backwards compatibility.
+	if ext.ArtifactType == ArtifactBinary && artifact == ComposerArtifactLite {
+		// Normalize legacy composer-lite binary artifacts that ship the loader as libcomposer.so
+		// instead of libcomposer-lite.so.
+		if ensureErr := ensureComposerLiteLib(d.Dirs, ext.Manifest.ComposerVersion); ensureErr != nil {
+			return DownloadedExtension{}, ensureErr
+		}
+	}
+
+	return ext, nil
 }
 
 // DownloadExtension downloads the extension from the specified repository and tag into the downloadDir.

--- a/cli/internal/extensions/downloader.go
+++ b/cli/internal/extensions/downloader.go
@@ -67,6 +67,11 @@ func (d *Downloader) DownloadComposer(ctx context.Context, version string, artif
 		// use the composer version resolved from the manifest, as the input parameter one could be
 		// "latest" which needs to be resolved to a concrete version.
 		composerVersion := manifest.Annotations[OCIAnnotationComposerVersion]
+		// composer-lite is an independent artifact cached in its own slot
+		// (dym/composer-lite/<version>/libcomposer-lite.so).
+		if artifact == ComposerArtifactLite {
+			return LocalCacheComposerLiteDir(d.Dirs, composerVersion)
+		}
 		return LocalCacheComposerDir(d.Dirs, composerVersion)
 	})
 }

--- a/cli/internal/extensions/downloader_test.go
+++ b/cli/internal/extensions/downloader_test.go
@@ -322,11 +322,11 @@ func TestDownloadSourceFallbackDisabled(t *testing.T) {
 	require.ErrorIs(t, err, oci.ErrPlatformNotFound)
 }
 
-func TestCheckOrDownloadLibComposerCacheHit(t *testing.T) {
+func TestCheckOrDownloadLibComposerLiteCacheHit(t *testing.T) {
 	version := "0.5.0"
 	dirs := &xdg.Directories{DataHome: t.TempDir()}
-	require.NoError(t, os.MkdirAll(LocalCacheComposerDir(dirs, version), 0o750))
-	require.NoError(t, os.WriteFile(LocalCacheComposerLib(dirs, version), []byte("cached"), 0o600))
+	require.NoError(t, os.MkdirAll(LocalCacheComposerLiteDir(dirs, version), 0o750))
+	require.NoError(t, os.WriteFile(LocalCacheComposerLiteLib(dirs, version), []byte("cached"), 0o600))
 
 	d := &Downloader{
 		Logger:   internaltesting.NewTLogger(t),
@@ -338,7 +338,7 @@ func TestCheckOrDownloadLibComposerCacheHit(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, CheckOrDownloadLibComposer(t.Context(), d, version, ComposerArtifactLite))
+	require.NoError(t, CheckOrDownloadLibComposerLite(t.Context(), d, version))
 }
 
 func TestDownloadComposerExtensionLoadsParentManifest(t *testing.T) {
@@ -554,7 +554,7 @@ examples: []
 	})
 }
 
-func TestCheckOrDownloadLibComposerCacheMiss(t *testing.T) {
+func TestCheckOrDownloadLibComposerLiteCacheMiss(t *testing.T) {
 	version := "0.5.0"
 	dirs := &xdg.Directories{DataHome: t.TempDir()}
 
@@ -575,7 +575,7 @@ func TestCheckOrDownloadLibComposerCacheMiss(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, CheckOrDownloadLibComposer(t.Context(), d, version, ComposerArtifactLite))
+	require.NoError(t, CheckOrDownloadLibComposerLite(t.Context(), d, version))
 }
 
 func TestResolveLatestComposerVersion(t *testing.T) {

--- a/cli/internal/extensions/libcomposer.go
+++ b/cli/internal/extensions/libcomposer.go
@@ -48,12 +48,33 @@ func DownloadComposerLiteAndBuildIfNeeded(ctx context.Context, downloader *Downl
 		return fmt.Errorf("failed to download libcomposer: %w", err)
 	}
 
-	// If the downloaded artifact is a binary, we are done. If it's a source artifact, we need to build it.
+	// If the downloaded artifact is a binary, normalize it (legacy artifacts shipped the loader
+	// as libcomposer.so) and we are done. If it's a source artifact, we need to build it.
 	if artifact.ArtifactType == ArtifactBinary {
-		return nil
+		return ensureComposerLiteLib(downloader.Dirs, version)
 	}
 
 	return BuildLibComposer(downloader.Logger, downloader.Dirs, artifact.Path, version, true)
+}
+
+// ensureComposerLiteLib normalizes a downloaded composer-lite binary artifact. Legacy
+// composer-lite artifacts shipped the loader as libcomposer.so (the library was not renamed
+// when the lite build was split into its own artifact); the runtime now expects
+// libcomposer-lite.so. If only the legacy file is present, rename it into place so the rest
+// of the CLI can treat composer-lite uniformly.
+func ensureComposerLiteLib(dirs *xdg.Directories, version string) error {
+	liteLib := LocalCacheComposerLiteLib(dirs, version)
+	if _, err := os.Stat(liteLib); err == nil {
+		return nil
+	}
+	legacy := filepath.Join(LocalCacheComposerLiteDir(dirs, version), fmt.Sprintf("lib%s.so", ComposerBundle))
+	if _, err := os.Stat(legacy); err != nil {
+		return nil // nothing to normalize; let downstream surface any missing-file error
+	}
+	if err := os.Rename(legacy, liteLib); err != nil {
+		return fmt.Errorf("failed to normalize legacy composer-lite library: %w", err)
+	}
+	return nil
 }
 
 // HasCSharedMain checks if the extension at the given path has a main/ directory,

--- a/cli/internal/extensions/libcomposer.go
+++ b/cli/internal/extensions/libcomposer.go
@@ -48,10 +48,8 @@ func DownloadComposerLiteAndBuildIfNeeded(ctx context.Context, downloader *Downl
 		return fmt.Errorf("failed to download libcomposer: %w", err)
 	}
 
-	// If the downloaded artifact is a binary, normalize it (legacy artifacts shipped the loader
-	// as libcomposer.so) and we are done. If it's a source artifact, we need to build it.
 	if artifact.ArtifactType == ArtifactBinary {
-		return ensureComposerLiteLib(downloader.Dirs, version)
+		return nil
 	}
 
 	return BuildLibComposer(downloader.Logger, downloader.Dirs, artifact.Path, version, true)

--- a/cli/internal/extensions/libcomposer.go
+++ b/cli/internal/extensions/libcomposer.go
@@ -28,18 +28,21 @@ const (
 	ComposerArtifactSource = "composer-src"
 )
 
-// CheckOrDownloadLibComposer checks if the libcomposer.so exists in the local cache directory.
-// If not, it tries to download the pre-built libcomposer from OCI registry.
-func CheckOrDownloadLibComposer(ctx context.Context, downloader *Downloader, version string, artifact string) error {
-	if _, err := os.Stat(LocalCacheComposerLib(downloader.Dirs, version)); err == nil {
-		downloader.Logger.Debug("libcomposer already exists in local cache. skipping download", "version", version)
+// CheckOrDownloadLibComposerLite checks if libcomposer-lite.so exists in the local cache directory.
+// If not, it tries to download the pre-built composer-lite from the OCI registry (falling back to
+// building it from source). composer-lite is the loader used to host standalone Go plugins.
+func CheckOrDownloadLibComposerLite(ctx context.Context, downloader *Downloader, version string) error {
+	if _, err := os.Stat(LocalCacheComposerLiteLib(downloader.Dirs, version)); err == nil {
+		downloader.Logger.Debug("libcomposer-lite already exists in local cache. skipping download", "version", version)
 		return nil
 	}
-	return DownloadLibComposerAndBuildIfNeeded(ctx, downloader, version, artifact)
+	return DownloadComposerLiteAndBuildIfNeeded(ctx, downloader, version, ComposerArtifactLite)
 }
 
-// DownloadLibComposerAndBuildIfNeeded is a helper function that combines downloading and building the libcomposer.
-func DownloadLibComposerAndBuildIfNeeded(ctx context.Context, downloader *Downloader, version string, artifactName string) error {
+// DownloadComposerLiteAndBuildIfNeeded combines downloading and building composer-lite: it pulls the
+// given artifact (a prebuilt composer-lite binary, or composer-src) and, when source, builds
+// libcomposer-lite.so from it.
+func DownloadComposerLiteAndBuildIfNeeded(ctx context.Context, downloader *Downloader, version string, artifactName string) error {
 	artifact, err := downloader.DownloadComposer(ctx, version, artifactName)
 	if err != nil {
 		return fmt.Errorf("failed to download libcomposer: %w", err)
@@ -121,7 +124,15 @@ func buildExtensionPlugin(logger *slog.Logger, dirs *xdg.Directories, manifest *
 // to be at composerSrcPath. The built libcomposer.so will be saved in the local cache directory for
 // composer to load.
 func BuildLibComposer(logger *slog.Logger, dirs *xdg.Directories, composerSrcPath string, version string, lite bool) error {
+	// composer-lite is built into its own independent cache slot (libcomposer-lite.so) so it
+	// never collides with a full composer built from the same source for the same version.
 	dest := LocalCacheComposerLib(dirs, version)
+	if lite {
+		dest = LocalCacheComposerLiteLib(dirs, version)
+	}
+	if err := os.MkdirAll(filepath.Dir(dest), 0o750); err != nil {
+		return fmt.Errorf("failed to create composer cache directory: %w", err)
+	}
 	var buildTags string
 
 	commonEnvPath := filepath.Join(composerSrcPath, "Makefile.common")
@@ -174,15 +185,17 @@ func BuildLibComposer(logger *slog.Logger, dirs *xdg.Directories, composerSrcPat
 // preferring the source-artifact manifest and falling back to the installed dynamic-module
 // directory. It returns an error if no manifest is found for that version.
 func GetComposerManifest(dirs *xdg.Directories, version string) (*Manifest, error) {
-	sourceDir := LocalCacheComposerSourceDir(dirs, version)
-	manifestPath := filepath.Join(sourceDir, "manifest.yaml")
-	if _, err := os.Stat(manifestPath); err == nil {
-		return LoadLocalManifest(manifestPath)
-	}
-	extensionDir := LocalCacheComposerDir(dirs, version)
-	manifestPath = filepath.Join(extensionDir, "manifest.yaml")
-	if _, err := os.Stat(manifestPath); err == nil {
-		return LoadLocalManifest(manifestPath)
+	// Prefer the source-artifact manifest, then the installed lite and full dynamic-module
+	// directories (the runtime go-plugin host is composer-lite, so check it before composer).
+	for _, dir := range []string{
+		LocalCacheComposerSourceDir(dirs, version),
+		LocalCacheComposerDir(dirs, version),
+		LocalCacheComposerLiteDir(dirs, version),
+	} {
+		manifestPath := filepath.Join(dir, "manifest.yaml")
+		if _, err := os.Stat(manifestPath); err == nil {
+			return LoadLocalManifest(manifestPath)
+		}
 	}
 	return nil, fmt.Errorf("manifest.yaml not found for composer version %s", version)
 }

--- a/cli/internal/extensions/libcomposer_test.go
+++ b/cli/internal/extensions/libcomposer_test.go
@@ -35,6 +35,52 @@ func TestDownloadComposerLiteAndBuildIfNeeded_DownloadError(t *testing.T) {
 	require.ErrorContains(t, err, "failed to download libcomposer")
 }
 
+func TestEnsureComposerLiteLib(t *testing.T) {
+	const version = "0.1.0"
+
+	t.Run("renames legacy libcomposer.so", func(t *testing.T) {
+		dirs := &xdg.Directories{DataHome: t.TempDir()}
+		legacy := filepath.Join(LocalCacheComposerLiteDir(dirs, version), fmt.Sprintf("lib%s.so", ComposerBundle))
+		require.NoError(t, os.MkdirAll(filepath.Dir(legacy), 0o750))
+		require.NoError(t, os.WriteFile(legacy, []byte("legacy-lib"), 0o600))
+
+		require.NoError(t, ensureComposerLiteLib(dirs, version))
+
+		liteLib := LocalCacheComposerLiteLib(dirs, version)
+		content, err := os.ReadFile(liteLib)
+		require.NoError(t, err)
+		require.Equal(t, "legacy-lib", string(content))
+
+		_, err = os.Stat(legacy)
+		require.True(t, os.IsNotExist(err), "legacy libcomposer.so should have been renamed away")
+	})
+
+	t.Run("leaves existing libcomposer-lite.so untouched", func(t *testing.T) {
+		dirs := &xdg.Directories{DataHome: t.TempDir()}
+		liteLib := LocalCacheComposerLiteLib(dirs, version)
+		require.NoError(t, os.MkdirAll(filepath.Dir(liteLib), 0o750))
+		require.NoError(t, os.WriteFile(liteLib, []byte("lite-lib"), 0o600))
+		legacy := filepath.Join(LocalCacheComposerLiteDir(dirs, version), fmt.Sprintf("lib%s.so", ComposerBundle))
+		require.NoError(t, os.WriteFile(legacy, []byte("legacy-lib"), 0o600))
+
+		require.NoError(t, ensureComposerLiteLib(dirs, version))
+
+		content, err := os.ReadFile(liteLib)
+		require.NoError(t, err)
+		require.Equal(t, "lite-lib", string(content))
+		// The legacy file is left untouched when the lite lib already exists.
+		_, err = os.Stat(legacy)
+		require.NoError(t, err)
+	})
+
+	t.Run("no-op when neither file present", func(t *testing.T) {
+		dirs := &xdg.Directories{DataHome: t.TempDir()}
+		require.NoError(t, ensureComposerLiteLib(dirs, version))
+		_, err := os.Stat(LocalCacheComposerLiteLib(dirs, version))
+		require.True(t, os.IsNotExist(err))
+	})
+}
+
 func TestBuildLibComposer_InvalidPath(t *testing.T) {
 	logger := internaltesting.NewTLogger(t)
 	fakeDirs := &xdg.Directories{DataHome: t.TempDir()}

--- a/cli/internal/extensions/libcomposer_test.go
+++ b/cli/internal/extensions/libcomposer_test.go
@@ -47,6 +47,7 @@ func TestEnsureComposerLiteLib(t *testing.T) {
 		require.NoError(t, ensureComposerLiteLib(dirs, version))
 
 		liteLib := LocalCacheComposerLiteLib(dirs, version)
+		// #nosec G304
 		content, err := os.ReadFile(liteLib)
 		require.NoError(t, err)
 		require.Equal(t, "legacy-lib", string(content))
@@ -65,6 +66,7 @@ func TestEnsureComposerLiteLib(t *testing.T) {
 
 		require.NoError(t, ensureComposerLiteLib(dirs, version))
 
+		// #nosec G304
 		content, err := os.ReadFile(liteLib)
 		require.NoError(t, err)
 		require.Equal(t, "lite-lib", string(content))

--- a/cli/internal/extensions/libcomposer_test.go
+++ b/cli/internal/extensions/libcomposer_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/tetratelabs/built-on-envoy/cli/internal/xdg"
 )
 
-func TestDownloadLibComposerAndBuildIfNeeded_DownloadError(t *testing.T) {
+func TestDownloadComposerLiteAndBuildIfNeeded_DownloadError(t *testing.T) {
 	logger := internaltesting.NewTLogger(t)
 	fakeDirs := &xdg.Directories{DataHome: t.TempDir()}
 	d := &Downloader{
@@ -31,7 +31,7 @@ func TestDownloadLibComposerAndBuildIfNeeded_DownloadError(t *testing.T) {
 			return nil, fmt.Errorf("connection refused")
 		},
 	}
-	err := DownloadLibComposerAndBuildIfNeeded(t.Context(), d, "0.1.0", ComposerArtifactLite)
+	err := DownloadComposerLiteAndBuildIfNeeded(t.Context(), d, "0.1.0", ComposerArtifactLite)
 	require.ErrorContains(t, err, "failed to download libcomposer")
 }
 
@@ -54,8 +54,8 @@ func TestBuildLibComposerLite(t *testing.T) {
 	err = BuildLibComposer(logger, fakeDirs, composerPath, composerVersion, true)
 	require.NoError(t, err)
 
-	// Ensure the libcomposer.so is created.
-	out := LocalCacheComposerLib(fakeDirs, composerVersion)
+	// Ensure the libcomposer-lite.so is created in the independent composer-lite slot.
+	out := LocalCacheComposerLiteLib(fakeDirs, composerVersion)
 	_, err = os.Stat(out)
 	require.NoError(t, err)
 

--- a/extensions/composer/Dockerfile
+++ b/extensions/composer/Dockerfile
@@ -17,8 +17,10 @@ RUN apt-get install -y --no-install-recommends \
 
 RUN go mod download all
 ARG BUILD_TAG=""
+# Output library name: libcomposer.so for the full build, libcomposer-lite.so for the lite build.
+ARG LIB_NAME=libcomposer.so
 # Build go shared library
-RUN CGO_ENABLED=1 go build -trimpath -buildmode=c-shared ${BUILD_TAG} -o libcomposer.so ./main
+RUN CGO_ENABLED=1 go build -trimpath -buildmode=c-shared ${BUILD_TAG} -o ${LIB_NAME} ./main
 
 # Collect all sub-extension manifest.yaml and config.schema.json files preserving their directory structure.
 RUN mkdir -p /metadatas; find . -mindepth 2 \( -name 'manifest.yaml' -o -name 'config.schema.json' \) \

--- a/extensions/composer/Makefile
+++ b/extensions/composer/Makefile
@@ -24,7 +24,12 @@ endif
 BOE_DATA_HOME ?= $(HOME)/.local/share/boe
 
 # Labels for this plugin image.
-NAME             := $(shell $(GO_TOOL) yq '.name' manifest.yaml)
+ORIGIN_NAME      := $(shell $(GO_TOOL) yq '.name' manifest.yaml)
+# NAME is the published identity of the built artifact: the OCI image title, the shared library
+# name (lib$(NAME).so), the image repository and the local cache directory. It is the origin name
+# (composer) for the full build, and is overridden to composer-lite in the COMPOSER_LITE block
+# below so that composer-lite is an independent artifact.
+NAME             := $(ORIGIN_NAME)
 VERSION          := $(shell $(GO_TOOL) yq '.version' manifest.yaml)
 DESCRIPTION      := $(shell $(GO_TOOL) yq '.description' manifest.yaml)
 TIMESTAMP        := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
@@ -34,20 +39,23 @@ COMPOSER_VERSION := $(VERSION)
 LICENSE          := Apache-2.0
 
 HUB        := $(or $(BOE_REGISTRY),$(OCI_REGISTRY)/built-on-envoy)
-IMAGE      := $(HUB)/$(NAME):$(VERSION)$(IMAGE_NONCE)
 SOURCE     := https://$(subst ghcr.io,github.com,$(HUB))
 
 comma := ,
 
 # Shared variables used by both this Makefile and the main Makefile.
 include Makefile.common
-# Option to build lite version of the loader.
+# Option to build lite version of the loader. Overriding NAME to composer-lite makes the image
+# repository, OCI title, library name and cache directory all follow automatically.
 ifeq ($(strip $(COMPOSER_LITE)),true)
+	NAME := $(ORIGIN_NAME)-lite
 	DESCRIPTION := Go plugin loader.
-	IMAGE := $(HUB)/$(NAME)-lite:$(VERSION)$(IMAGE_NONCE)
 	BUILD_TAGS := $(if $(BUILD_TAGS),$(BUILD_TAGS)$(comma))lite
 endif
 COMPOSER_BUILD_TAG := $(if $(BUILD_TAGS),-tags $(BUILD_TAGS))
+
+# Defined after the COMPOSER_LITE block so it picks up the final NAME (composer or composer-lite).
+IMAGE      := $(HUB)/$(NAME):$(VERSION)$(IMAGE_NONCE)
 
 # If the version of the image is a development one (ends with '-dev'), we will
 # add an additional 'dev' tag (without the version number) to make it easier to reference the
@@ -139,7 +147,7 @@ create_builder:
 
 # Cross-build through Docker only when a target overrides force_target_os.
 build_cmd_native = CGO_ENABLED=1 go build -trimpath -buildmode=c-shared $(COMPOSER_BUILD_TAG) -o lib$(NAME).so ./main
-build_cmd_cross  = docker buildx build --platform=$(force_target_os)/$(ARCH) --output type=local,dest=. --build-arg BUILD_TAG="$(COMPOSER_BUILD_TAG)" -f ./Dockerfile .
+build_cmd_cross  = docker buildx build --platform=$(force_target_os)/$(ARCH) --output type=local,dest=. --build-arg BUILD_TAG="$(COMPOSER_BUILD_TAG)" --build-arg LIB_NAME="lib$(NAME).so" -f ./Dockerfile .
 
 .PHONY: build
 build:
@@ -167,6 +175,7 @@ build_image:
 		$(CSHARED_ARTIFACT) \
 		$(BINARY_ARTIFACT) \
 		--build-arg BUILD_TAG="$(COMPOSER_BUILD_TAG)" \
+		--build-arg LIB_NAME="lib$(NAME).so" \
 		--build-arg GO_VERSION="$(GO_VERSION)" \
 		-t $(IMAGE)-$(OS)-$(ARCH) \
 		-f ./Dockerfile .
@@ -189,6 +198,7 @@ push_image: create_builder  ## Build and push docker image for the plugin for cr
 		--provenance=false \
 		$(PUSH_ANNOTATIONS) \
 		--build-arg BUILD_TAG="$(COMPOSER_BUILD_TAG)" \
+		--build-arg LIB_NAME="lib$(NAME).so" \
 		--build-arg GO_VERSION="$(GO_VERSION)" \
 		--tag $(IMAGE) $(DEV_TAG) \
 		-f ./Dockerfile .


### PR DESCRIPTION
- Now the composer-lite is independent lib and the composer-lite and composer won't affect each others' local cache.