### PR TITLE
make boe fips compliant

### DIFF
--- a/cli/cmd/testdata/output_full_config.yaml
+++ b/cli/cmd/testdata/output_full_config.yaml
@@ -28,6 +28,10 @@ static_resources:
       name: envoy.transport_sockets.tls
       typed_config:
         '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        common_tls_context:
+          tls_params:
+            compliance_policies:
+            - FIPS_202205
         sni: httpbin.org
     type: STRICT_DNS
   listeners:

--- a/cli/cmd/testdata/output_full_config_with_cluster.yaml
+++ b/cli/cmd/testdata/output_full_config_with_cluster.yaml
@@ -28,6 +28,10 @@ static_resources:
       name: envoy.transport_sockets.tls
       typed_config:
         '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        common_tls_context:
+          tls_params:
+            compliance_policies:
+            - FIPS_202205
         sni: httpbin.org
     type: STRICT_DNS
   - load_assignment:

--- a/cli/cmd/testdata/output_full_config_with_native.yaml
+++ b/cli/cmd/testdata/output_full_config_with_native.yaml
@@ -28,6 +28,10 @@ static_resources:
       name: envoy.transport_sockets.tls
       typed_config:
         '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        common_tls_context:
+          tls_params:
+            compliance_policies:
+            - FIPS_202205
         sni: httpbin.org
     type: STRICT_DNS
   listeners:

--- a/cli/cmd/testdata/output_full_config_with_native_after.yaml
+++ b/cli/cmd/testdata/output_full_config_with_native_after.yaml
@@ -28,6 +28,10 @@ static_resources:
       name: envoy.transport_sockets.tls
       typed_config:
         '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        common_tls_context:
+          tls_params:
+            compliance_policies:
+            - FIPS_202205
         sni: httpbin.org
     type: STRICT_DNS
   listeners:

--- a/cli/cmd/testdata/output_full_config_with_shorthand_cluster.yaml
+++ b/cli/cmd/testdata/output_full_config_with_shorthand_cluster.yaml
@@ -28,6 +28,10 @@ static_resources:
       name: envoy.transport_sockets.tls
       typed_config:
         '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        common_tls_context:
+          tls_params:
+            compliance_policies:
+            - FIPS_202205
         sni: httpbin.org
     type: STRICT_DNS
   - dns_lookup_family: V4_ONLY
@@ -45,6 +49,10 @@ static_resources:
       name: envoy.transport_sockets.tls
       typed_config:
         '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        common_tls_context:
+          tls_params:
+            compliance_policies:
+            - FIPS_202205
         sni: example.com
     type: STRICT_DNS
   listeners:

--- a/cli/cmd/testdata/output_full_config_with_shorthand_cluster_and_insecure_cluster.yaml
+++ b/cli/cmd/testdata/output_full_config_with_shorthand_cluster_and_insecure_cluster.yaml
@@ -28,6 +28,10 @@ static_resources:
       name: envoy.transport_sockets.tls
       typed_config:
         '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        common_tls_context:
+          tls_params:
+            compliance_policies:
+            - FIPS_202205
         sni: httpbin.org
     type: STRICT_DNS
   - dns_lookup_family: V4_ONLY
@@ -45,6 +49,10 @@ static_resources:
       name: envoy.transport_sockets.tls
       typed_config:
         '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        common_tls_context:
+          tls_params:
+            compliance_policies:
+            - FIPS_202205
         sni: example.com
     type: STRICT_DNS
   - dns_lookup_family: V4_ONLY

--- a/cli/cmd/testdata/output_full_config_with_shorthand_insecure_cluster.yaml
+++ b/cli/cmd/testdata/output_full_config_with_shorthand_insecure_cluster.yaml
@@ -28,6 +28,10 @@ static_resources:
       name: envoy.transport_sockets.tls
       typed_config:
         '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        common_tls_context:
+          tls_params:
+            compliance_policies:
+            - FIPS_202205
         sni: httpbin.org
     type: STRICT_DNS
   - dns_lookup_family: V4_ONLY

--- a/cli/cmd/testdata/output_full_config_with_test_upstream_cluster.yaml
+++ b/cli/cmd/testdata/output_full_config_with_test_upstream_cluster.yaml
@@ -28,6 +28,10 @@ static_resources:
       name: envoy.transport_sockets.tls
       typed_config:
         '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        common_tls_context:
+          tls_params:
+            compliance_policies:
+            - FIPS_202205
         sni: example.com
     type: STRICT_DNS
   listeners:

--- a/cli/cmd/testdata/output_only_filters_with_shorthand_cluster.yaml
+++ b/cli/cmd/testdata/output_only_filters_with_shorthand_cluster.yaml
@@ -19,6 +19,10 @@ clusters:
     name: envoy.transport_sockets.tls
     typed_config:
       '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+      common_tls_context:
+        tls_params:
+          compliance_policies:
+          - FIPS_202205
       sni: example.com
   type: STRICT_DNS
 http_filters:

--- a/cli/cmd/testdata/output_only_filters_with_shorthand_cluster_and_insecure_cluster.yaml
+++ b/cli/cmd/testdata/output_only_filters_with_shorthand_cluster_and_insecure_cluster.yaml
@@ -19,6 +19,10 @@ clusters:
     name: envoy.transport_sockets.tls
     typed_config:
       '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+      common_tls_context:
+        tls_params:
+          compliance_policies:
+          - FIPS_202205
       sni: example.com
   type: STRICT_DNS
 - dns_lookup_family: V4_ONLY

--- a/cli/internal/envoy/config.go
+++ b/cli/internal/envoy/config.go
@@ -687,8 +687,18 @@ func buildTestUpstreamCluster(name string, hostname string, port uint32, tls boo
 		return cluster, nil
 	}
 
-	// Add TLS context
-	tlsContext := &tlsv3.UpstreamTlsContext{Sni: hostname}
+	// Add TLS context with FIPS 140-3 (FIPS_202205) compliance policy, which restricts
+	// Envoy to FIPS-approved cipher suites and curves for both TLS 1.2 and 1.3.
+	tlsContext := &tlsv3.UpstreamTlsContext{
+		Sni: hostname,
+		CommonTlsContext: &tlsv3.CommonTlsContext{
+			TlsParams: &tlsv3.TlsParameters{
+				CompliancePolicies: []tlsv3.TlsParameters_CompliancePolicy{
+					tlsv3.TlsParameters_FIPS_202205,
+				},
+			},
+		},
+	}
 	tlsContextAny, err := anypb.New(tlsContext)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal TLS context to Any: %w", err)

--- a/cli/internal/envoy/testdata/output_config.yaml
+++ b/cli/internal/envoy/testdata/output_config.yaml
@@ -62,4 +62,8 @@ static_resources:
         name: envoy.transport_sockets.tls
         typed_config:
           "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+          common_tls_context:
+            tls_params:
+              compliance_policies:
+              - FIPS_202205
           sni: httpbin.org

--- a/cli/internal/envoy/testdata/output_config_admin_all_interfaces.yaml
+++ b/cli/internal/envoy/testdata/output_config_admin_all_interfaces.yaml
@@ -62,4 +62,8 @@ static_resources:
         name: envoy.transport_sockets.tls
         typed_config:
           "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+          common_tls_context:
+            tls_params:
+              compliance_policies:
+              - FIPS_202205
           sni: httpbin.org

--- a/cli/internal/envoy/testdata/output_config_with_extensions.yaml
+++ b/cli/internal/envoy/testdata/output_config_with_extensions.yaml
@@ -28,6 +28,10 @@ static_resources:
       name: envoy.transport_sockets.tls
       typed_config:
         '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        common_tls_context:
+          tls_params:
+            compliance_policies:
+            - FIPS_202205
         sni: httpbin.org
     type: STRICT_DNS
   listeners:

--- a/cli/internal/envoy/testdata/output_config_with_test_upstream_cluster.yaml
+++ b/cli/internal/envoy/testdata/output_config_with_test_upstream_cluster.yaml
@@ -61,4 +61,8 @@ static_resources:
         name: envoy.transport_sockets.tls
         typed_config:
           "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+          common_tls_context:
+            tls_params:
+              compliance_policies:
+              - FIPS_202205
           sni: example.com

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/tetratelabs/built-on-envoy
 
 go 1.26.4
 
+godebug fips140=only
+
 require (
 	github.com/alecthomas/kong v1.15.0
 	github.com/envoyproxy/go-control-plane/envoy v1.37.1-0.20260427194735-8b4b133fe2a5


### PR DESCRIPTION

-  Since we are using go1.26, it includes  native FIPS 140-3 validated cryptographic module.Binary is built with this mode as the default — no BoringCrypto fork or external crypto library required. At runtime, Go's crypto stack automatically restricts all TLS connections to FIPS-approved cipher suites and curves for both TLS 1.2 and 1.3. This covers any Go-originated TLS connections made by the CLI 
- Setting compliance_policies: [FIPS_202205] on the CommonTlsContext of all generated upstream clusters instructs Envoy to restrict its TLS stack (backed by BoringSSL) to FIPS-approved cipher suites and curves (P-256, P-384) for both TLS 1.2 and 1.3. This is enforced at the Envoy config level — no changes to the Envoy binary are required beyond using a FIPS-enabled build.

We also need to make sure that FuncE is running fips compliant envoy build.

```
➜  boe curl -s localhost:9901/server_info | grep -i "fips\|boring"
 "version": "f387231af8dd7274e37c5ae2cc797cb09a948818/1.38.2/Clean/RELEASE/BoringSSL",
```


tried building cli using these changes

GO -->

```
➜  cli git:(mega) ✗ go version -m out/boe-darwin-arm64 | grep -i GODEBUG
        build   DefaultGODEBUG=fips140=only
```



ENVOY -->
```
curl http://localhost:10000/get

s_server -accept 14443 -cert /tmp/cert.pem -key /tmp/key.pem -www 
This TLS version forbids renegotiation.
Ciphers supported in s_server binary
TLSv1.3    :TLS_AES_256_GCM_SHA384    TLSv1.3    :TLS_CHACHA20_POLY1305_SHA256 
TLSv1.3    :TLS_AES_128_GCM_SHA256    TLSv1.2    :ECDHE-ECDSA-AES256-GCM-SHA384 
TLSv1.2    :ECDHE-RSA-AES256-GCM-SHA384 TLSv1.2    :DHE-RSA-AES256-GCM-SHA384 
TLSv1.2    :ECDHE-ECDSA-CHACHA20-POLY1305 TLSv1.2    :ECDHE-RSA-CHACHA20-POLY1305 
TLSv1.2    :DHE-RSA-CHACHA20-POLY1305 TLSv1.2    :ECDHE-ECDSA-AES128-GCM-SHA256 
TLSv1.2    :ECDHE-RSA-AES128-GCM-SHA256 TLSv1.2    :DHE-RSA-AES128-GCM-SHA256 
TLSv1.2    :ECDHE-ECDSA-AES256-SHA384 TLSv1.2    :ECDHE-RSA-AES256-SHA384   
TLSv1.2    :DHE-RSA-AES256-SHA256     TLSv1.2    :ECDHE-ECDSA-AES128-SHA256 
TLSv1.2    :ECDHE-RSA-AES128-SHA256   TLSv1.2    :DHE-RSA-AES128-SHA256     
TLSv1.0    :ECDHE-ECDSA-AES256-SHA    TLSv1.0    :ECDHE-RSA-AES256-SHA      
SSLv3      :DHE-RSA-AES256-SHA        TLSv1.0    :ECDHE-ECDSA-AES128-SHA    
TLSv1.0    :ECDHE-RSA-AES128-SHA      SSLv3      :DHE-RSA-AES128-SHA        
TLSv1.2    :RSA-PSK-AES256-GCM-SHA384 TLSv1.2    :DHE-PSK-AES256-GCM-SHA384 
TLSv1.2    :RSA-PSK-CHACHA20-POLY1305 TLSv1.2    :DHE-PSK-CHACHA20-POLY1305 
TLSv1.2    :ECDHE-PSK-CHACHA20-POLY1305 TLSv1.2    :AES256-GCM-SHA384         
TLSv1.2    :PSK-AES256-GCM-SHA384     TLSv1.2    :PSK-CHACHA20-POLY1305     
TLSv1.2    :RSA-PSK-AES128-GCM-SHA256 TLSv1.2    :DHE-PSK-AES128-GCM-SHA256 
TLSv1.2    :AES128-GCM-SHA256         TLSv1.2    :PSK-AES128-GCM-SHA256     
TLSv1.2    :AES256-SHA256             TLSv1.2    :AES128-SHA256             
TLSv1.0    :ECDHE-PSK-AES256-CBC-SHA384 TLSv1.0    :ECDHE-PSK-AES256-CBC-SHA  
SSLv3      :SRP-RSA-AES-256-CBC-SHA   SSLv3      :SRP-AES-256-CBC-SHA       
TLSv1.0    :RSA-PSK-AES256-CBC-SHA384 TLSv1.0    :DHE-PSK-AES256-CBC-SHA384 
SSLv3      :RSA-PSK-AES256-CBC-SHA    SSLv3      :DHE-PSK-AES256-CBC-SHA    
SSLv3      :AES256-SHA                TLSv1.0    :PSK-AES256-CBC-SHA384     
SSLv3      :PSK-AES256-CBC-SHA        TLSv1.0    :ECDHE-PSK-AES128-CBC-SHA256 
TLSv1.0    :ECDHE-PSK-AES128-CBC-SHA  SSLv3      :SRP-RSA-AES-128-CBC-SHA   
SSLv3      :SRP-AES-128-CBC-SHA       TLSv1.0    :RSA-PSK-AES128-CBC-SHA256 
TLSv1.0    :DHE-PSK-AES128-CBC-SHA256 SSLv3      :RSA-PSK-AES128-CBC-SHA    
SSLv3      :DHE-PSK-AES128-CBC-SHA    SSLv3      :AES128-SHA                
TLSv1.0    :PSK-AES128-CBC-SHA256     SSLv3      :PSK-AES128-CBC-SHA        
---
Ciphers common between both SSL end points:
TLS_AES_128_GCM_SHA256     TLS_AES_256_GCM_SHA384     ECDHE-ECDSA-AES128-GCM-SHA256
ECDHE-RSA-AES128-GCM-SHA256 ECDHE-ECDSA-AES256-GCM-SHA384 ECDHE-RSA-AES256-GCM-SHA384
Signature Algorithms: RSA+SHA256:RSA+SHA384:RSA+SHA512:ECDSA+SHA256:ECDSA+SHA384:RSA-PSS+SHA256:RSA-PSS+SHA384:RSA-PSS+SHA512
Shared Signature Algorithms: RSA+SHA256:RSA+SHA384:RSA+SHA512:ECDSA+SHA256:ECDSA+SHA384:RSA-PSS+SHA256:RSA-PSS+SHA384:RSA-PSS+SHA512
Supported groups: secp256r1:secp384r1
Shared groups: secp256r1:secp384r1
---
New, TLSv1.3, Cipher is TLS_AES_128_GCM_SHA256
SSL-Session:
    Protocol  : TLSv1.3
    Cipher    : TLS_AES_128_GCM_SHA256
    Session-ID: C6B8D6294C8EE133FE3E0CD4D5E744E862E4F78B5B4228800C33B16F4B701DCD
    Session-ID-ctx: 01000000
    Resumption PSK: 392CE52F34EA33821134FC309FA064E99F215E0F9BD26380EE7EC925F8A0EE32
    PSK identity: None
    PSK identity hint: None
    SRP username: None
    Start Time: 1781561743
    Timeout   : 7200 (sec)
    Verify return code: 0 (ok)
    Extended master secret: no
    Max Early Data: 0
---
   0 items in the session cache
   0 client connects (SSL_connect())
   0 client renegotiates (SSL_connect())
   0 client connects that finished
   1 server accepts (SSL_accept())
   0 server renegotiates (SSL_accept())
   1 server accepts that finished
   0 session cache hits
   0 session cache misses
   0 session cache timeouts
   0 callback cache hits
   0 cache full overflows (128 allowed)

```