### PR TITLE
composer: add manifest for goplugin-loader

### DIFF
--- a/cli/cmd/genconfig_test.go
+++ b/cli/cmd/genconfig_test.go
@@ -371,18 +371,18 @@ func TestGenConfigWriteConfig(t *testing.T) {
 			logger = internaltesting.NewTLogger(t)
 			dirs   = &xdg.Directories{DataHome: t.TempDir()}
 
-			gpl    = &extensions.Manifest{Name: extensions.GoPluginLoaderName, Type: extensions.TypeGo, CShared: true, Parent: extensions.ComposerLiteBundle, Version: "1.0.0"}
-			gplLib = extensions.LocalCacheExtension(dirs, gpl) // resolves to dym/composer-lite/1.0.0/libcomposer-lite.so
+			gpl    = &extensions.Manifest{Name: extensions.GoPluginLoaderName, Type: extensions.TypeGo, CShared: true, Parent: extensions.ComposerBundle, Version: "1.0.0"}
+			gplLib = extensions.LocalCacheExtension(dirs, gpl) // resolves to dym/composer/1.0.0/libcomposer.so
 		)
 		require.NoError(t, os.MkdirAll(filepath.Dir(gplLib), 0o750))
-		require.NoError(t, os.WriteFile(gplLib, []byte("fake libcomposer-lite"), 0o600))
+		require.NoError(t, os.WriteFile(gplLib, []byte("fake libcomposer"), 0o600))
 
 		// The user-supplied inner plugin url must be left untouched (not rewritten to file://).
 		inputConfig := `filter_config: {"name":"goplugin-loader","url":"oci://ex/p:v1"}`
 		_, err := cmd.writeConfig(inputConfig, []*extensions.Manifest{gpl}, dirs, logger)
 		require.NoError(t, err)
 
-		require.FileExists(t, cmd.Output+"/libcomposer-lite.so")
+		require.FileExists(t, cmd.Output+"/libcomposer.so")
 		// No per-extension goplugin-loader.so should be produced for a bundle-hosted extension.
 		require.NoFileExists(t, cmd.Output+"/goplugin-loader.so")
 

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -242,19 +242,14 @@ func downloadExtensions(ctx context.Context, downloader *extensions.Downloader, 
 	for _, ext := range refs {
 		bundle, name, tag := splitRef(ext)
 
-		// The reserved name "goplugin-loader" is not a downloadable extension: it drives
-		// the composer's goplugin-loader filter directly from the user-supplied --config.
-		// Resolve the composer version, ensure libcomposer is available, and synthesize a
-		// manifest so the rest of the pipeline treats it like a dynamic-module extension.
+		// The reserved name "goplugin-loader" is the built-in loader compiled into the composer
+		// bundle; it has no standalone artifact of its own. Always resolve it from the composer
+		// bundle (libcomposer.so), whether referenced bare as "goplugin-loader" or fully as
+		// "composer/goplugin-loader". The bundle's embedded goplugin-loader/manifest.yaml is then
+		// resolved by the normal bundled-extension path below, yielding a c-shared, composer-hosted
+		// dynamic-module extension.
 		if name == extensions.GoPluginLoaderName {
-			manifest, err := resolveGoPluginLoader(ctx, downloader, tag)
-			if err != nil {
-				return nil, err
-			}
-			manifest.Remote = true
-			manifest.RemoteRef = ext
-			downloaded = append(downloaded, manifest)
-			continue
+			bundle = extensions.ComposerBundle
 		}
 
 		_, _ = fmt.Fprintf(os.Stderr, "→ %sFetching %s...%s\n", internal.ANSIBold, name, internal.ANSIReset)
@@ -295,38 +290,6 @@ func downloadExtensions(ctx context.Context, downloader *extensions.Downloader, 
 	}
 
 	return downloaded, nil
-}
-
-// resolveGoPluginLoader resolves the composer-lite version for the raw goplugin-loader
-// extension, ensures libcomposer.so is present in the local cache, and returns a synthetic
-// manifest describing it. The tag (if not "latest") is interpreted as the composer version.
-func resolveGoPluginLoader(ctx context.Context, downloader *extensions.Downloader, tag string) (*extensions.Manifest, error) {
-	version := tag
-	if version == "" || version == "latest" {
-		resolved, err := extensions.ResolveLatestComposerVersion(ctx, downloader.Logger)
-		if err != nil {
-			return nil, fmt.Errorf("failed to resolve composer version for %s: %w", extensions.GoPluginLoaderName, err)
-		}
-		version = resolved
-	}
-
-	_, _ = fmt.Fprintf(os.Stderr, "→ %sPreparing %s (composer %s)...%s\n",
-		internal.ANSIBold, extensions.GoPluginLoaderName, version, internal.ANSIReset)
-
-	if err := extensions.CheckOrDownloadLibComposerLite(ctx, downloader, version); err != nil {
-		return nil, fmt.Errorf("failed to download libcomposer %s for %s: %w", version, extensions.GoPluginLoaderName, err)
-	}
-
-	manifest := &extensions.Manifest{
-		Name:            extensions.GoPluginLoaderName,
-		Type:            extensions.TypeGo,
-		CShared:         true,
-		Parent:          extensions.ComposerLiteBundle,
-		Version:         version,
-		ComposerVersion: version,
-	}
-	manifest.ApplyDefaults()
-	return manifest, nil
 }
 
 // parseLogLevels parses a log level string in the format "component:level,component2:level".

--- a/cli/cmd/run_test.go
+++ b/cli/cmd/run_test.go
@@ -1097,14 +1097,56 @@ func TestDownloadExtensions(t *testing.T) {
 		require.ErrorIs(t, err, errFail)
 	})
 
-	t.Run("goplugin-loader reserved name synthesizes a bundle manifest", func(t *testing.T) {
+	t.Run("goplugin-loader resolves from the composer bundle", func(t *testing.T) {
 		dataHome := t.TempDir()
-		// Pre-seed libcomposer-lite.so so CheckOrDownloadLibComposer hits the cache and avoids network.
-		composerLiteLib := extensions.LocalCacheComposerLiteLib(&xdg.Directories{DataHome: dataHome}, "1.0.0")
-		require.NoError(t, os.MkdirAll(filepath.Dir(composerLiteLib), 0o750))
-		require.NoError(t, os.WriteFile(composerLiteLib, []byte("fake"), 0o600))
+		dirs := &xdg.Directories{DataHome: dataHome}
 
-		d := &extensions.Downloader{Logger: internaltesting.NewTLogger(t), Dirs: &xdg.Directories{DataHome: dataHome}}
+		// The bare "goplugin-loader" reference is remapped to the composer bundle, which is
+		// downloaded and then walked for the embedded goplugin-loader child manifest. Pre-stage the
+		// composer bundle cache (root manifest + embedded child) so the mock Pull (a no-op) leaves
+		// the resolver real files to read.
+		composerCacheDir := extensions.LocalCacheComposerDir(dirs, "1.0.0")
+		require.NoError(t, os.MkdirAll(filepath.Join(composerCacheDir, "metadatas", "goplugin-loader"), 0o750))
+		require.NoError(t, os.WriteFile(filepath.Join(composerCacheDir, "manifest.yaml"), []byte(`name: composer
+version: 1.0.0
+composerVersion: 1.0.0
+categories:
+  - Misc
+author: Test
+description: test composer
+longDescription: |
+  test composer
+type: composer
+tags:
+  - go
+license: Apache-2.0
+examples: []
+extensionSet: true
+`), 0o600))
+		require.NoError(t, os.WriteFile(filepath.Join(composerCacheDir, "metadatas", "goplugin-loader", "manifest.yaml"), []byte(`name: goplugin-loader
+parent: composer
+categories:
+  - Misc
+author: Test
+description: built-in go plugin loader
+longDescription: |
+  built-in go plugin loader
+type: go
+tags:
+  - go
+license: Apache-2.0
+examples: []
+`), 0o600))
+
+		mock := &mockOCIClient{annotations: map[string]string{
+			ocispec.AnnotationTitle:                 extensions.ComposerBundle,
+			ocispec.AnnotationVersion:               "1.0.0",
+			extensions.OCIAnnotationExtensionType:   string(extensions.TypeComposer),
+			extensions.OCIAnnotationComposerVersion: "1.0.0",
+			extensions.OCIAnnotationCShared:         "true",
+			extensions.OCIAnnotationArtifact:        extensions.ArtifactBinary,
+		}}
+		d := newTestDownloader(t, dataHome, mock)
 
 		manifests, err := downloadExtensions(t.Context(), d, []string{extensions.GoPluginLoaderName + ":1.0.0"}, false)
 		require.NoError(t, err)
@@ -1114,7 +1156,8 @@ func TestDownloadExtensions(t *testing.T) {
 		require.Equal(t, extensions.GoPluginLoaderName, m.Name)
 		require.Equal(t, extensions.TypeGo, m.Type)
 		require.True(t, m.CShared, "goplugin-loader must be treated as a c-shared dynamic module")
-		require.Equal(t, extensions.ComposerLiteBundle, m.Parent)
+		// Hosted by the full composer bundle, not composer-lite.
+		require.Equal(t, extensions.ComposerBundle, m.Parent)
 		require.Equal(t, "1.0.0", m.Version)
 		require.Equal(t, "1.0.0", m.ComposerVersion)
 		require.True(t, m.Remote)
@@ -1122,15 +1165,15 @@ func TestDownloadExtensions(t *testing.T) {
 		require.Equal(t, []extensions.FilterType{extensions.FilterTypeHTTP}, m.FilterTypes)
 	})
 
-	t.Run("goplugin-loader missing composer cache fails without network", func(t *testing.T) {
-		// No libcomposer-lite.so seeded and a concrete tag: CheckOrDownloadLibComposerLite must try
-		// to download via the (mock) client. A pull error surfaces as a wrapped error.
+	t.Run("goplugin-loader fails when the composer bundle cannot be pulled", func(t *testing.T) {
+		// A concrete tag with no cached bundle: the composer bundle download must hit the (mock)
+		// client, and a pull error surfaces as a wrapped error.
 		mock := &mockOCIClient{pullErr: errors.New("no network")}
 		d := newTestDownloader(t, t.TempDir(), mock)
 
 		_, err := downloadExtensions(t.Context(), d, []string{extensions.GoPluginLoaderName + ":9.9.9"}, false)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), extensions.GoPluginLoaderName)
+		require.Contains(t, err.Error(), extensions.ComposerBundle)
 	})
 }
 

--- a/cli/e2e/run_test.go
+++ b/cli/e2e/run_test.go
@@ -334,15 +334,15 @@ func dummy() string {
 	require.NoError(t, err, string(output))
 }
 
-// corazaBuildTags mirrors BUILD_TAGS in extensions/composer/Makefile.common; the composer and its
 // TestGoPluginLoaderRemoteExtension exercises the raw goplugin-loader extension end to end:
 //  1. build the example Go plugin image and push it to the local test registry;
-//  2. build the composer-lite image and push it to the local test registry, so boe downloads
-//     libcomposer-lite.so from there into the local cache;
+//  2. build the full composer image and push it to the local test registry, so boe downloads
+//     libcomposer.so (the composer bundle that hosts the built-in goplugin-loader) from there
+//     into the local cache and resolves the embedded goplugin-loader manifest;
 //  3. run `boe run --extension goplugin-loader --config '{"name":...,"url":"oci://..."}'`
 //     and assert the dynamically loaded plugin processes responses.
 //
-// Both the plugin and libcomposer-lite.so are built from the composer Dockerfiles, which pin the
+// Both the plugin and libcomposer.so are built from the composer Dockerfiles, which pin the
 // same GO_VERSION from go.mod. This matters because plugin.Open requires the plugin and host
 // to share an identical Go toolchain and dependency set; strict_check=false only relaxes the
 // soft build-info checks, not the linker's hard ABI requirement.
@@ -365,8 +365,7 @@ func TestGoPluginLoaderRemoteExtension(t *testing.T) {
 	t.Setenv("BOE_REGISTRY", registryAddr)
 	t.Setenv("BOE_REGISTRY_INSECURE", "true")
 
-	// Dedicated data home so we can place libcomposer-lite.so at the cache location the
-	// goplugin-loader extension expects, and so the plugin pull cache is isolated.
+	// Dedicated data home so the composer bundle download and the plugin pull cache are isolated.
 	dataHome := t.TempDir()
 	t.Setenv("BOE_DATA_HOME", dataHome)
 
@@ -384,12 +383,14 @@ func TestGoPluginLoaderRemoteExtension(t *testing.T) {
 	)
 	pluginURL := "oci://" + pluginRef
 
-	// Step 2: build the composer-lite image and push it to the local registry (as
-	// <registry>/composer-lite:<version>). When the goplugin-loader runs in Step 3, boe downloads
-	// libcomposer-lite.so from there into
-	// <dataHome>/extensions/dym/composer-lite/<version>/libcomposer-lite.so.
-	// This exercises the real composer-lite download path instead of extracting the file manually.
-	runCmd(t, composerDir, "make", "push_image", "COMPOSER_LITE=true", "PLATFORMS=linux/"+runtime.GOARCH)
+	// Step 2: build the full composer image and push it to the local registry (as
+	// <registry>/composer:<version>). When the goplugin-loader runs in Step 3, boe downloads
+	// libcomposer.so from there into <dataHome>/extensions/dym/composer/<version>/libcomposer.so
+	// and resolves the embedded goplugin-loader manifest from the bundle's /metadatas.
+	runCmd(t, composerDir, "make", "push_image",
+		"PLATFORMS=linux/"+runtime.GOARCH,
+		"OCI_REGISTRY="+registryAddr,
+	)
 
 	// Step 3: run the goplugin-loader extension, pointing it at the pushed plugin image via
 	// the user-supplied URL.

--- a/cli/internal/envoy/runner.go
+++ b/cli/internal/envoy/runner.go
@@ -253,8 +253,7 @@ func setupDynamicModuleSearchPath(params *ConfigGenerationParams) (string, func(
 	if composerVersion != "" {
 		composerPath := extensions.LocalCacheComposerLiteLib(params.Dirs, composerVersion)
 		linkPath := filepath.Join(tempDir, filepath.Base(composerPath))
-		// Skip if libcomposer-lite.so was already linked above by a c-shared bundle-hosted
-		// extension (e.g. goplugin-loader), to avoid a "file exists" error.
+		// Skip if libcomposer-lite.so was already linked above, to avoid a "file exists" error.
 		if _, err := os.Stat(linkPath); err == nil {
 			params.Logger.Debug("libcomposer-lite already linked, skipping", "linkPath", linkPath)
 		} else if _, err := os.Stat(composerPath); err == nil {

--- a/extensions/composer/Makefile
+++ b/extensions/composer/Makefile
@@ -218,10 +218,16 @@ push_code: create_builder  ## Build and push source code image
 		--tag $(CODE_IMAGE) \
 		-f ./Dockerfile.code .
 
+# The goplugin-loader is the built-in loader that hosts standalone Go plugins. It is always
+# compiled into composer/composer-lite and, being the loader itself, can never be built as an
+# independent Go plugin, so it is excluded from the standalone plugin build/install/release targets.
+# Its manifest.yaml exists only for catalog/metadata purposes.
+BUILTIN_PLUGIN_DIRS := goplugin-loader
+
 # Find all sub-directories containing a manifest.yaml file and get their names.
-# Ignore current directory.
+# Ignore current directory and the always-built-in loader.
 PLUGIN_DIRS := $(shell find . -mindepth 2 -maxdepth 2 -type f -name 'manifest.yaml' -exec dirname {} \; | sort)
-PLUGIN_CLEAN_DIRS := $(notdir $(PLUGIN_DIRS))
+PLUGIN_CLEAN_DIRS := $(filter-out $(BUILTIN_PLUGIN_DIRS),$(notdir $(PLUGIN_DIRS)))
 
 push_plugins: ## Push all plugin images
 	@for dir in $(PLUGIN_CLEAN_DIRS); do \

--- a/extensions/composer/goplugin-loader/config.schema.json
+++ b/extensions/composer/goplugin-loader/config.schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/tetratelabs/built-on-envoy/extensions/composer/goplugin-loader/config.schema.json",
+  "title": "Go Plugin Loader Configuration",
+  "description": "Configuration for the built-in Go plugin loader. Identifies a standalone Go plugin to load at runtime and the configuration to pass to it.",
+  "type": "object",
+  "required": ["name", "url"],
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Name of the Go plugin to load.",
+      "minLength": 1
+    },
+    "url": {
+      "type": "string",
+      "description": "Location of the plugin binary. Supports \"file://\" URLs for local paths and \"oci://\" URLs for plugins fetched from an OCI registry at runtime.",
+      "minLength": 1
+    },
+    "config": {
+      "type": "object",
+      "description": "Plugin-specific configuration passed through verbatim to the loaded plugin.",
+      "additionalProperties": true
+    },
+    "strict_check": {
+      "type": "boolean",
+      "description": "Whether to enforce strict host/plugin compatibility checks (Go version, build flags, and shared dependency versions/checksums) before loading. Defaults to true."
+    }
+  }
+}

--- a/extensions/composer/goplugin-loader/manifest.yaml
+++ b/extensions/composer/goplugin-loader/manifest.yaml
@@ -48,10 +48,7 @@ longDescription: |
   - `GOPLUGIN_INSECURE` — set to `true` to allow insecure (HTTP) registry connections
 type: go
 tags:
-  - go
   - plugin-loader
-  - dynamic-module
-  - built-in
 license: Apache-2.0
 examples:
   - title: Load a local Go plugin

--- a/extensions/composer/goplugin-loader/manifest.yaml
+++ b/extensions/composer/goplugin-loader/manifest.yaml
@@ -1,0 +1,77 @@
+# Copyright Built On Envoy
+# SPDX-License-Identifier: Apache-2.0
+# The full text of the Apache license is available in the LICENSE file at
+# the root of the repo.
+
+# NOTE: The goplugin-loader is always built into the composer (and composer-lite)
+# dynamic module. Unlike the sibling extensions in this directory, it has no
+# `standalone/` package and is deliberately excluded from the standalone Go plugin
+# build/install/release targets in ../Makefile, because it is the loader that hosts
+# other Go plugins and therefore can never be compiled or shipped as an independent
+# Go plugin itself. This manifest exists only to document and catalog the loader.
+name: goplugin-loader
+parent: composer
+categories:
+  - Misc
+author: Tetrate
+description: Built-in loader that hosts standalone Go plugins at runtime; always compiled into composer
+longDescription: |
+  The Go Plugin Loader is a built-in Envoy dynamic module filter that loads standalone
+  Go plugins (`.so` files built with `-buildmode=plugin`) at runtime, without recompiling
+  the host binary. It is registered as the well-known HTTP filter config factory named
+  `goplugin-loader`.
+
+  ## Always built-in
+
+  The loader is **always** compiled into the Composer (`libcomposer.so`) and Composer Lite
+  (`libcomposer-lite.so`) dynamic modules. It is **not** a standalone, independently
+  installable or releasable Go plugin: because it is the component that loads other Go
+  plugins, it can never itself be compiled as an independent Go plugin.
+
+  Users reference it directly via `--extension goplugin-loader` or
+  `--extension composer/goplugin-loader`, which drives the loader to fetch and load the
+  configured plugin at runtime.
+
+  ## Configuration
+
+  The loader is configured with the `GoPlugin` message:
+
+  - `name`: the plugin name to load
+  - `url`: where to fetch the plugin binary (`file://` for local paths, `oci://` for OCI registries)
+  - `config`: optional plugin-specific configuration passed through to the loaded plugin
+  - `strict_check`: whether to enforce strict host/plugin compatibility checks (defaults to `true`)
+
+  ## Runtime environment variables
+
+  - `GOPLUGIN_CACHE_DIR` — directory to cache downloaded plugin binaries
+  - `GOPLUGIN_PULL_SECRET` — credentials for authenticating to the OCI registry
+  - `GOPLUGIN_INSECURE` — set to `true` to allow insecure (HTTP) registry connections
+type: go
+tags:
+  - go
+  - plugin-loader
+  - dynamic-module
+  - built-in
+license: Apache-2.0
+examples:
+  - title: Load a local Go plugin
+    description: |
+      Drive the built-in goplugin-loader directly to load a locally-built plugin `.so`
+      from a `file://` URL.
+    code: |
+      boe run --extension goplugin-loader \
+        --config '{
+          "name": "my-plugin",
+          "url": "file:///path/to/myplugin.so",
+          "config": {}
+        }'
+  - title: Load a Go plugin from an OCI registry
+    description: |
+      Fetch and load a plugin binary directly from an OCI registry at runtime using an
+      `oci://` URL.
+    code: |
+      boe run --extension goplugin-loader \
+        --config '{
+          "name": "my-plugin",
+          "url": "oci://ghcr.io/tetratelabs/built-on-envoy/extension-my-plugin:v1.0.0"
+        }'

--- a/ui/schemas/goplugin-loader.json
+++ b/ui/schemas/goplugin-loader.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/tetratelabs/built-on-envoy/extensions/composer/goplugin-loader/config.schema.json",
+  "title": "Go Plugin Loader Configuration",
+  "description": "Configuration for the built-in Go plugin loader. Identifies a standalone Go plugin to load at runtime and the configuration to pass to it.",
+  "type": "object",
+  "required": ["name", "url"],
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Name of the Go plugin to load.",
+      "minLength": 1
+    },
+    "url": {
+      "type": "string",
+      "description": "Location of the plugin binary. Supports \"file://\" URLs for local paths and \"oci://\" URLs for plugins fetched from an OCI registry at runtime.",
+      "minLength": 1
+    },
+    "config": {
+      "type": "object",
+      "description": "Plugin-specific configuration passed through verbatim to the loaded plugin.",
+      "additionalProperties": true
+    },
+    "strict_check": {
+      "type": "boolean",
+      "description": "Whether to enforce strict host/plugin compatibility checks (Go version, build flags, and shared dependency versions/checksums) before loading. Defaults to true."
+    }
+  }
+}

--- a/website/public/extensions.json
+++ b/website/public/extensions.json
@@ -548,6 +548,44 @@
     "configReferencePath": "/docs/reference/extensions#file-server"
   },
   {
+    "name": "goplugin-loader",
+    "version": "0.8.0-dev",
+    "parent": "composer",
+    "categories": [
+      "Misc"
+    ],
+    "author": "Tetrate",
+    "description": "Built-in loader that hosts standalone Go plugins at runtime; always compiled into composer",
+    "longDescription": "The Go Plugin Loader is a built-in Envoy dynamic module filter that loads standalone\nGo plugins (`.so` files built with `-buildmode=plugin`) at runtime, without recompiling\nthe host binary. It is registered as the well-known HTTP filter config factory named\n`goplugin-loader`.\n\n## Always built-in\n\nThe loader is **always** compiled into the Composer (`libcomposer.so`) and Composer Lite\n(`libcomposer-lite.so`) dynamic modules. It is **not** a standalone, independently\ninstallable or releasable Go plugin: because it is the component that loads other Go\nplugins, it can never itself be compiled as an independent Go plugin.\n\nUsers reference it directly via `--extension goplugin-loader` or\n`--extension composer/goplugin-loader`, which drives the loader to fetch and load the\nconfigured plugin at runtime.\n\n## Configuration\n\nThe loader is configured with the `GoPlugin` message:\n\n- `name`: the plugin name to load\n- `url`: where to fetch the plugin binary (`file://` for local paths, `oci://` for OCI registries)\n- `config`: optional plugin-specific configuration passed through to the loaded plugin\n- `strict_check`: whether to enforce strict host/plugin compatibility checks (defaults to `true`)\n\n## Runtime environment variables\n\n- `GOPLUGIN_CACHE_DIR` — directory to cache downloaded plugin binaries\n- `GOPLUGIN_PULL_SECRET` — credentials for authenticating to the OCI registry\n- `GOPLUGIN_INSECURE` — set to `true` to allow insecure (HTTP) registry connections\n",
+    "type": "go",
+    "filterType": [
+      "http"
+    ],
+    "tags": [
+      "go",
+      "plugin-loader",
+      "dynamic-module",
+      "built-in"
+    ],
+    "license": "Apache-2.0",
+    "examples": [
+      {
+        "title": "Load a local Go plugin",
+        "description": "Drive the built-in goplugin-loader directly to load a locally-built plugin `.so`\nfrom a `file://` URL.\n",
+        "code": "boe run --extension goplugin-loader \\\n  --config '{\n    \"name\": \"my-plugin\",\n    \"url\": \"file:///path/to/myplugin.so\",\n    \"config\": {}\n  }'\n"
+      },
+      {
+        "title": "Load a Go plugin from an OCI registry",
+        "description": "Fetch and load a plugin binary directly from an OCI registry at runtime using an\n`oci://` URL.\n",
+        "code": "boe run --extension goplugin-loader \\\n  --config '{\n    \"name\": \"my-plugin\",\n    \"url\": \"oci://ghcr.io/tetratelabs/built-on-envoy/extension-my-plugin:v1.0.0\"\n  }'\n"
+      }
+    ],
+    "minEnvoyVersion": "1.38.0",
+    "maxEnvoyVersion": "1.39.0",
+    "composerVersion": "0.8.0-dev",
+    "sourcePath": "composer/goplugin-loader"
+  },
+  {
     "name": "ip-restriction",
     "version": "0.2.0",
     "categories": [

--- a/website/public/extensions.json
+++ b/website/public/extensions.json
@@ -562,10 +562,7 @@
       "http"
     ],
     "tags": [
-      "go",
-      "plugin-loader",
-      "dynamic-module",
-      "built-in"
+      "plugin-loader"
     ],
     "license": "Apache-2.0",
     "examples": [
@@ -583,7 +580,8 @@
     "minEnvoyVersion": "1.38.0",
     "maxEnvoyVersion": "1.39.0",
     "composerVersion": "0.8.0-dev",
-    "sourcePath": "composer/goplugin-loader"
+    "sourcePath": "composer/goplugin-loader",
+    "configReferencePath": "/docs/reference/extensions#goplugin-loader"
   },
   {
     "name": "ip-restriction",

--- a/website/src/pages/docs/reference/extensions.mdx
+++ b/website/src/pages/docs/reference/extensions.mdx
@@ -666,6 +666,60 @@ URL path prefix to match (e.g. "/static/").
 
 
 
+<a id="goplugin-loader"></a>
+## Go Plugin Loader Configuration
+
+Configuration for the built-in Go plugin loader. Identifies a standalone Go plugin to load at runtime and the configuration to pass to it.
+
+### config
+
+Plugin-specific configuration passed through verbatim to the loaded plugin.
+
+| | |
+|---|---|
+| **Type** | `object` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ Go Plugin Loader Configuration](#goplugin-loader) {/* if .SubProperties */}
+
+### name
+
+Name of the Go plugin to load.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | Yes |
+| **Min length** | 1 |
+
+[↑ Top](#) | [↑ Go Plugin Loader Configuration](#goplugin-loader) {/* if .SubProperties */}
+
+### strict_check
+
+Whether to enforce strict host/plugin compatibility checks (Go version, build flags, and shared dependency versions/checksums) before loading. Defaults to true.
+
+| | |
+|---|---|
+| **Type** | `boolean` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ Go Plugin Loader Configuration](#goplugin-loader) {/* if .SubProperties */}
+
+### url
+
+Location of the plugin binary. Supports "file://" URLs for local paths and "oci://" URLs for plugins fetched from an OCI registry at runtime.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | Yes |
+| **Min length** | 1 |
+
+[↑ Top](#) | [↑ Go Plugin Loader Configuration](#goplugin-loader) {/* if .SubProperties */} {/* range .Properties */} {/* if .CustomTypes */}
+
+
+
+
 <a id="ip-restriction"></a>
 ## IP Restriction Configuration
 


### PR DESCRIPTION
We added the goplugin-loader support before to allow the users could run the goplugin-loader directly.
In this pull request, we added a manifest to expose it in the UI/document.

Note, when goplugin-loader is ran explicitly, now the full composer will be used. This is deliberate change, because the target of the goplugin-loader support here is to make testing the out-of-tree go plugin easily. And full composer has much higher ratio to be used in practice. I hope it could reflect the actual case.