### PR TITLE
Small fixes to test utility and Dockerfiles

### DIFF
--- a/cli/cmd/templates/create/go/Dockerfile.tmpl
+++ b/cli/cmd/templates/create/go/Dockerfile.tmpl
@@ -12,13 +12,13 @@ FROM golang:{{ .GoVersion }} AS builder
 
 ARG NAME
 
-WORKDIR /workspace
-COPY . .
-
 # Install necessary tools for cgo
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends \
     ca-certificates wget git ssh netcat-openbsd gcc build-essential binutils binutils-gold
+
+WORKDIR /workspace
+COPY . .
 
 RUN go mod download all
 

--- a/extensions/composer/Dockerfile
+++ b/extensions/composer/Dockerfile
@@ -7,13 +7,13 @@ ARG GO_VERSION
 
 FROM golang:${GO_VERSION} AS builder
 
-WORKDIR /workspace
-COPY . .
-
 # Install necessary tools for cgo
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends \
     ca-certificates wget git ssh netcat-openbsd gcc build-essential binutils binutils-gold
+
+WORKDIR /workspace
+COPY . .
 
 RUN go mod download all
 ARG BUILD_TAG=""

--- a/internal/testing/logging.go
+++ b/internal/testing/logging.go
@@ -79,11 +79,13 @@ func TeeOutput(t testing.TB, teeFile string, labels ...string) OutBuffers {
 	t.Cleanup(func() { _ = f.Close() })
 
 	buffers := CaptureOutput(labels...)
+	var fileMu sync.Mutex // shared across all teeBuffers writing to the same file
 	teeBuffers := make([]OutBuffer, len(labels))
 	for i, b := range buffers {
 		teeBuffers[i] = &teeBuffer{
 			outBuffer: b.(*outBuffer),
 			extra:     f,
+			fileMu:    &fileMu,
 		}
 	}
 
@@ -93,11 +95,16 @@ func TeeOutput(t testing.TB, teeFile string, labels ...string) OutBuffers {
 // teeBuffer writes to both an in-memory buffer and an extra writer (e.g. a file).
 type teeBuffer struct {
 	*outBuffer
-	extra io.Writer
+	extra  io.Writer
+	fileMu *sync.Mutex // shared among all teeBuffers writing to the same file
 }
 
 func (s *teeBuffer) Write(p []byte) (n int, err error) {
+	// s.extra is shared among all teeBuffers writing to the same file, so we need to lock it to
+	// avoid interleaved writes.
+	s.fileMu.Lock()
 	_, _ = s.extra.Write(p) // best-effort; don't let file errors mask buffer writes
+	s.fileMu.Unlock()
 	return s.outBuffer.Write(p)
 }
 


### PR DESCRIPTION
* Adds a fix to the test utility to avoid log interleaving issues when several buffers (stdout & stderr, for example) are tee'd to the same file.
* Updates Dockerfiles to improve caching by moving the `COPY . .` statements later in the file.