### PR TITLE
dns-gateway: bare "*" catch-all matcher + optional domain dynamic metadata

### DIFF
--- a/extensions/dns-gateway/README.md
+++ b/extensions/dns-gateway/README.md
@@ -81,6 +81,7 @@ See the [extension page](https://builtonenvoy.io/extensions/lookup) for the full
 
 - **Exact**: `"example.com"` — matches only `example.com`
 - **Wildcard**: `"*.aws.com"` — matches one subdomain level (e.g. `api.aws.com`) but not `aws.com` itself or nested subdomains like `sub.api.aws.com`
+- **Catch-all**: `"*"` — matches every queried domain, minting a virtual IP for each. Use it as a low-priority final matcher to intercept all DNS and defer routing/authorization to downstream filters (e.g. `tcp_proxy` route selection on the filter state, or an `ext_authz` check) instead of enumerating every domain
 
 ## Configuration
 
@@ -100,6 +101,7 @@ See the [extension page](https://builtonenvoy.io/extensions/lookup) for the full
 | Field                  | Type   | Description                                                                          |
 | ---------------------- | ------ | ------------------------------------------------------------------------------------ |
 | `filter_state_prefix`  | string | Prefix for filter state keys. Default: `io.builtonenvoy.dns_gateway`                |
+| `domain_metadata`      | object | Optional. If set (`{"namespace": "...", "key": "..."}`), also publish the resolved domain as connection **dynamic metadata** under that namespace/key, for consumers that read dynamic metadata rather than filter state (e.g. a network `ext_authz` filter with `metadata_context_namespaces`). |
 
 ## Building
 

--- a/extensions/dns-gateway/config.schema.json
+++ b/extensions/dns-gateway/config.schema.json
@@ -20,7 +20,7 @@
             "properties": {
               "domain": {
                 "type": "string",
-                "description": "Exact domain (\"example.com\") or single-level wildcard pattern (\"*.example.com\").",
+                "description": "Exact domain (\"example.com\"), single-level wildcard pattern (\"*.example.com\"), or a bare \"*\" catch-all that matches every queried domain.",
                 "minLength": 1
               },
               "base_ip": {
@@ -60,6 +60,24 @@
           "type": "string",
           "description": "Prefix for filter state keys written by the lookup filter. Downstream filters read domain and metadata under this prefix. Default: \"io.builtonenvoy.dns_gateway\".",
           "default": "io.builtonenvoy.dns_gateway"
+        },
+        "domain_metadata": {
+          "type": "object",
+          "description": "If set, also publish the resolved domain as Envoy connection dynamic metadata under the given namespace/key. Useful for consumers that read dynamic metadata rather than filter state (e.g. a network ext_authz filter with metadata_context_namespaces). Omit to publish filter state only.",
+          "additionalProperties": false,
+          "required": ["namespace", "key"],
+          "properties": {
+            "namespace": {
+              "type": "string",
+              "description": "Dynamic-metadata namespace to write under (e.g. \"io.builtonenvoy.dns_gateway\").",
+              "minLength": 1
+            },
+            "key": {
+              "type": "string",
+              "description": "Key within the namespace whose string value is the resolved domain (e.g. \"domain\").",
+              "minLength": 1
+            }
+          }
         }
       }
     }

--- a/extensions/dns-gateway/manifests/lookup/config.schema.json
+++ b/extensions/dns-gateway/manifests/lookup/config.schema.json
@@ -10,6 +10,24 @@
       "type": "string",
       "description": "Prefix for filter state keys written by the dns-gateway lookup filter. Downstream filters read domain and metadata under this prefix. Default: \"io.builtonenvoy.dns_gateway\".",
       "default": "io.builtonenvoy.dns_gateway"
+    },
+    "domain_metadata": {
+      "type": "object",
+      "description": "If set, also publish the resolved domain as Envoy connection dynamic metadata under the given namespace/key. Useful for consumers that read dynamic metadata rather than filter state (e.g. a network ext_authz filter with metadata_context_namespaces). Omit to publish filter state only.",
+      "additionalProperties": false,
+      "required": ["namespace", "key"],
+      "properties": {
+        "namespace": {
+          "type": "string",
+          "description": "Dynamic-metadata namespace to write under (e.g. \"io.builtonenvoy.dns_gateway\").",
+          "minLength": 1
+        },
+        "key": {
+          "type": "string",
+          "description": "Key within the namespace whose string value is the resolved domain (e.g. \"domain\").",
+          "minLength": 1
+        }
+      }
     }
   }
 }

--- a/extensions/dns-gateway/manifests/resolver/config.schema.json
+++ b/extensions/dns-gateway/manifests/resolver/config.schema.json
@@ -18,7 +18,7 @@
         "properties": {
           "domain": {
             "type": "string",
-            "description": "Exact domain (\"example.com\") or single-level wildcard pattern (\"*.example.com\").",
+            "description": "Exact domain (\"example.com\"), single-level wildcard pattern (\"*.example.com\"), or a bare \"*\" catch-all that matches every queried domain.",
             "minLength": 1
           },
           "base_ip": {

--- a/extensions/dns-gateway/src/cache_lookup.rs
+++ b/extensions/dns-gateway/src/cache_lookup.rs
@@ -19,24 +19,43 @@ const DEFAULT_FILTER_STATE_PREFIX: &str = "io.builtonenvoy.dns_gateway";
 #[derive(Deserialize, Default)]
 struct CacheLookupConfig {
     filter_state_prefix: Option<String>,
+    #[serde(default)]
+    domain_metadata: Option<DomainMetadata>,
+}
+
+/// Optional publication of the matched domain as Envoy **connection dynamic metadata**.
+///
+/// Filter state (which the cache-lookup filter always writes) is only reachable by other
+/// filters that read filter state directly. Some consumers instead read *dynamic metadata* —
+/// for example a network `ext_authz` filter with `metadata_context_namespaces` forwards the
+/// named namespace to the authorization service. When configured, the resolved domain is
+/// published as a string under `namespace`/`key` so those consumers can see it.
+#[derive(Deserialize, Clone)]
+struct DomainMetadata {
+    /// Dynamic-metadata namespace to write under (e.g. `io.builtonenvoy.dns_gateway`).
+    namespace: String,
+    /// Key within the namespace whose value is the resolved domain (e.g. `domain`).
+    key: String,
 }
 
 /// The filter configuration that implements
 /// [`envoy_proxy_dynamic_modules_rust_sdk::NetworkFilterConfig`].
 pub struct CacheLookupFilterConfig {
     filter_state_prefix: String,
+    domain_metadata: Option<DomainMetadata>,
 }
 
 impl CacheLookupFilterConfig {
     /// Creates a new cache lookup filter configuration.
     pub fn new(config: &[u8]) -> Self {
-        let prefix = serde_json::from_slice::<CacheLookupConfig>(config)
-            .ok()
-            .and_then(|c| c.filter_state_prefix)
+        let parsed = serde_json::from_slice::<CacheLookupConfig>(config).unwrap_or_default();
+        let prefix = parsed
+            .filter_state_prefix
             .unwrap_or_else(|| DEFAULT_FILTER_STATE_PREFIX.to_string());
         envoy_log_info!("Filter initialized");
         CacheLookupFilterConfig {
             filter_state_prefix: prefix,
+            domain_metadata: parsed.domain_metadata,
         }
     }
 }
@@ -45,6 +64,7 @@ impl<ENF: EnvoyNetworkFilter> NetworkFilterConfig<ENF> for CacheLookupFilterConf
     fn new_network_filter(&self, _envoy: &mut ENF) -> Box<dyn NetworkFilter<ENF>> {
         Box::new(CacheLookupFilter {
             filter_state_prefix: self.filter_state_prefix.clone(),
+            domain_metadata: self.domain_metadata.clone(),
         })
     }
 }
@@ -56,6 +76,7 @@ impl<ENF: EnvoyNetworkFilter> NetworkFilterConfig<ENF> for CacheLookupFilterConf
 /// with the matched domain and metadata.
 struct CacheLookupFilter {
     filter_state_prefix: String,
+    domain_metadata: Option<DomainMetadata>,
 }
 
 impl<ENF: EnvoyNetworkFilter> NetworkFilter<ENF> for CacheLookupFilter {
@@ -87,6 +108,12 @@ impl<ENF: EnvoyNetworkFilter> NetworkFilter<ENF> for CacheLookupFilter {
         for (key, value) in &metadata {
             let meta_key = format!("{}.metadata.{}", self.filter_state_prefix, key);
             envoy_filter.set_filter_state_bytes(meta_key.as_bytes(), value.as_bytes());
+        }
+
+        // If configured, also publish the resolved domain as connection dynamic metadata so
+        // consumers that read dynamic metadata (rather than filter state) can see it.
+        if let Some(dm) = &self.domain_metadata {
+            envoy_filter.set_dynamic_metadata_string(&dm.namespace, &dm.key, &domain);
         }
 
         abi::envoy_dynamic_module_type_on_network_filter_data_status::Continue
@@ -195,6 +222,70 @@ mod tests {
             .withf(|key, value| key == b"my.custom.prefix.metadata.env" && value == b"prod")
             .times(1)
             .returning(|_, _| true);
+
+        let status = filter.on_new_connection(&mut mock);
+        assert_eq!(
+            status,
+            abi::envoy_dynamic_module_type_on_network_filter_data_status::Continue
+        );
+    }
+
+    #[test]
+    fn test_on_new_connection_publishes_dynamic_metadata() {
+        let ip = get_cache()
+            .allocate(
+                "dyn-meta-test.example.com".into(),
+                HashMap::new(),
+                0x0D0D_0000, // 13.13.0.0
+                24,
+            )
+            .unwrap();
+
+        let config = CacheLookupFilterConfig::new(
+            br#"{"domain_metadata": {"namespace": "com.example.egress", "key": "fqdn"}}"#,
+        );
+        let mut mock = MockEnvoyNetworkFilter::new();
+        let mut filter = config.new_network_filter(&mut mock);
+
+        let mut mock = MockEnvoyNetworkFilter::new();
+        mock.expect_get_local_address()
+            .returning(move || (ip.to_string(), 8080));
+        mock.expect_set_filter_state_bytes().returning(|_, _| true);
+        mock.expect_set_dynamic_metadata_string()
+            .withf(|ns, key, value| {
+                ns == "com.example.egress" && key == "fqdn" && value == "dyn-meta-test.example.com"
+            })
+            .times(1)
+            .returning(|_, _, _| ());
+
+        let status = filter.on_new_connection(&mut mock);
+        assert_eq!(
+            status,
+            abi::envoy_dynamic_module_type_on_network_filter_data_status::Continue
+        );
+    }
+
+    #[test]
+    fn test_on_new_connection_no_dynamic_metadata_by_default() {
+        // Without domain_metadata configured, set_dynamic_metadata_string is never called.
+        // (mockall fails the test if an unexpected call is made.)
+        let ip = get_cache()
+            .allocate(
+                "no-dyn-meta-test.example.com".into(),
+                HashMap::new(),
+                0x0E0E_0000, // 14.14.0.0
+                24,
+            )
+            .unwrap();
+
+        let config = CacheLookupFilterConfig::new(b"{}");
+        let mut mock = MockEnvoyNetworkFilter::new();
+        let mut filter = config.new_network_filter(&mut mock);
+
+        let mut mock = MockEnvoyNetworkFilter::new();
+        mock.expect_get_local_address()
+            .returning(move || (ip.to_string(), 8080));
+        mock.expect_set_filter_state_bytes().returning(|_, _| true);
 
         let status = filter.on_new_connection(&mut mock);
         assert_eq!(

--- a/extensions/dns-gateway/src/dns_gateway.rs
+++ b/extensions/dns-gateway/src/dns_gateway.rs
@@ -19,10 +19,17 @@ use std::net::Ipv4Addr;
 use std::sync::Arc;
 
 /// Matches a domain against a pattern.
-/// Supports exact matches and wildcard patterns like "*.aws.com".
-/// Wildcard patterns match exactly one subdomain level, e.g. "*.aws.com"
+/// Supports exact matches, single-level wildcards like "*.aws.com", and a bare "*"
+/// catch-all. A "*.aws.com" wildcard matches exactly one subdomain level, e.g. it
 /// matches "api.aws.com" but not "sub.api.aws.com".
 fn matches_domain(pattern: &str, domain: &str) -> bool {
+    // A bare "*" is a catch-all that matches every queried domain, minting a virtual IP
+    // for each. Use it as a low-priority final matcher when you want to intercept all DNS
+    // and defer routing/authorization to downstream filters (e.g. tcp_proxy route selection
+    // on the filter state, or an ext_authz check) rather than enumerating every domain here.
+    if pattern == "*" {
+        return true;
+    }
     let Some(base) = pattern.strip_prefix("*.") else {
         return domain == pattern;
     };
@@ -52,15 +59,21 @@ impl DnsGatewayFilterConfig {
             .ok()?;
 
         for d in &gateway_config.domains {
-            let name = Name::from_utf8(&d.domain)
-                .map_err(|e| envoy_log_error!("Invalid domain '{}': {e}", d.domain))
-                .ok()?;
-            if name.is_wildcard() && name.num_labels() < 2 {
-                envoy_log_error!(
-                    "Bare wildcard '{}' is not allowed, use '*.example.com' instead",
-                    d.domain
-                );
-                return None;
+            // A bare "*" is an accepted catch-all (it matches every queried domain at runtime
+            // via matches_domain). Skip the DNS-name parse and the bare-wildcard rejection for
+            // it — those reject "*" as an invalid host — but still validate its base_ip and
+            // prefix_len below like any other matcher.
+            if d.domain != "*" {
+                let name = Name::from_utf8(&d.domain)
+                    .map_err(|e| envoy_log_error!("Invalid domain '{}': {e}", d.domain))
+                    .ok()?;
+                if name.is_wildcard() && name.num_labels() < 2 {
+                    envoy_log_error!(
+                        "Bare wildcard '{}' is not allowed, use '*.example.com' or a bare \"*\" catch-all instead",
+                        d.domain
+                    );
+                    return None;
+                }
             }
 
             d.base_ip
@@ -222,6 +235,16 @@ mod tests {
         assert!(!matches_domain("*.aws.com", "xaws.com"));
         assert!(!matches_domain("*.aws.com", "aws.com.evil.com"));
         assert!(!matches_domain("*.aws.com", "api.aws.org"));
+    }
+
+    #[test]
+    fn test_domain_matcher_catchall() {
+        // A bare "*" matches every queried domain, at any label depth.
+        assert!(matches_domain("*", "aws.com"));
+        assert!(matches_domain("*", "api.aws.com"));
+        assert!(matches_domain("*", "deep.sub.api.aws.com"));
+        assert!(matches_domain("*", "example.org"));
+        assert!(matches_domain("*", "localhost"));
     }
 
     #[test]
@@ -390,14 +413,51 @@ mod tests {
     }
 
     #[test]
-    fn test_config_parsing_rejects_bare_wildcard() {
+    fn test_config_parsing_accepts_catchall_wildcard() {
+        // A bare "*" is an accepted catch-all; its base_ip/prefix_len are still validated.
         let config = r#"{
             "domains": [
                 {"domain": "*", "base_ip": "10.0.0.0", "prefix_len": 24, "metadata": {}}
             ]
         }"#;
 
+        assert!(DnsGatewayFilterConfig::new(config.as_bytes()).is_some());
+    }
+
+    #[test]
+    fn test_config_parsing_catchall_still_validates_base_ip() {
+        // The name-parse is skipped for "*", but base_ip is still validated.
+        let config = r#"{
+            "domains": [
+                {"domain": "*", "base_ip": "not-an-ip", "prefix_len": 24, "metadata": {}}
+            ]
+        }"#;
+
         assert!(DnsGatewayFilterConfig::new(config.as_bytes()).is_none());
+    }
+
+    #[test]
+    fn test_process_dns_query_catchall_matches_any_domain() {
+        let filter = DnsGatewayFilter {
+            config: Arc::new(config::DnsGateway {
+                domains: vec![config::DomainMatcher {
+                    domain: "*".to_string(),
+                    base_ip: "10.123.0.0".to_string(),
+                    prefix_len: 24,
+                    metadata: HashMap::new(),
+                }],
+                fail_open: false,
+            }),
+        };
+
+        // An arbitrary domain not enumerated anywhere still resolves via the catch-all.
+        let query = make_dns_query("anything.example.net", RecordType::A);
+        let msg = parse_response(&filter.process_dns_query(&query).unwrap());
+        assert_eq!(msg.answers().len(), 1);
+        match msg.answers()[0].data() {
+            RData::A(ip) => assert_eq!(&ip.0.octets()[..3], &[10, 123, 0]),
+            other => panic!("expected A record from catch-all, got {:?}", other),
+        }
     }
 
     // ── process_dns_query tests ──────────────────────────────────────────────

--- a/ui/schemas/dns-gateway.json
+++ b/ui/schemas/dns-gateway.json
@@ -20,7 +20,7 @@
             "properties": {
               "domain": {
                 "type": "string",
-                "description": "Exact domain (\"example.com\") or single-level wildcard pattern (\"*.example.com\").",
+                "description": "Exact domain (\"example.com\"), single-level wildcard pattern (\"*.example.com\"), or a bare \"*\" catch-all that matches every queried domain.",
                 "minLength": 1
               },
               "base_ip": {
@@ -60,6 +60,24 @@
           "type": "string",
           "description": "Prefix for filter state keys written by the lookup filter. Downstream filters read domain and metadata under this prefix. Default: \"io.builtonenvoy.dns_gateway\".",
           "default": "io.builtonenvoy.dns_gateway"
+        },
+        "domain_metadata": {
+          "type": "object",
+          "description": "If set, also publish the resolved domain as Envoy connection dynamic metadata under the given namespace/key. Useful for consumers that read dynamic metadata rather than filter state (e.g. a network ext_authz filter with metadata_context_namespaces). Omit to publish filter state only.",
+          "additionalProperties": false,
+          "required": ["namespace", "key"],
+          "properties": {
+            "namespace": {
+              "type": "string",
+              "description": "Dynamic-metadata namespace to write under (e.g. \"io.builtonenvoy.dns_gateway\").",
+              "minLength": 1
+            },
+            "key": {
+              "type": "string",
+              "description": "Key within the namespace whose string value is the resolved domain (e.g. \"domain\").",
+              "minLength": 1
+            }
+          }
         }
       }
     }

--- a/ui/schemas/lookup.json
+++ b/ui/schemas/lookup.json
@@ -10,6 +10,24 @@
       "type": "string",
       "description": "Prefix for filter state keys written by the dns-gateway lookup filter. Downstream filters read domain and metadata under this prefix. Default: \"io.builtonenvoy.dns_gateway\".",
       "default": "io.builtonenvoy.dns_gateway"
+    },
+    "domain_metadata": {
+      "type": "object",
+      "description": "If set, also publish the resolved domain as Envoy connection dynamic metadata under the given namespace/key. Useful for consumers that read dynamic metadata rather than filter state (e.g. a network ext_authz filter with metadata_context_namespaces). Omit to publish filter state only.",
+      "additionalProperties": false,
+      "required": ["namespace", "key"],
+      "properties": {
+        "namespace": {
+          "type": "string",
+          "description": "Dynamic-metadata namespace to write under (e.g. \"io.builtonenvoy.dns_gateway\").",
+          "minLength": 1
+        },
+        "key": {
+          "type": "string",
+          "description": "Key within the namespace whose string value is the resolved domain (e.g. \"domain\").",
+          "minLength": 1
+        }
+      }
     }
   }
 }

--- a/ui/schemas/resolver.json
+++ b/ui/schemas/resolver.json
@@ -18,7 +18,7 @@
         "properties": {
           "domain": {
             "type": "string",
-            "description": "Exact domain (\"example.com\") or single-level wildcard pattern (\"*.example.com\").",
+            "description": "Exact domain (\"example.com\"), single-level wildcard pattern (\"*.example.com\"), or a bare \"*\" catch-all that matches every queried domain.",
             "minLength": 1
           },
           "base_ip": {

--- a/website/src/pages/docs/reference/extensions.mdx
+++ b/website/src/pages/docs/reference/extensions.mdx
@@ -698,6 +698,47 @@ WAF inspection mode. Defaults to "REQUEST_ONLY" if not set. "RESPONSE_ONLY" is d
 
 Configuration for the dns-gateway lookup network filter, the virtual-IP resolution half of the dns-gateway extension set.
 
+### domain_metadata
+
+If set, also publish the resolved domain as Envoy connection dynamic metadata under the given namespace/key. Useful for consumers that read dynamic metadata rather than filter state (e.g. a network ext_authz filter with metadata_context_namespaces). Omit to publish filter state only.
+
+| | |
+|---|---|
+| **Type** | `object` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ DNS Gateway Lookup Configuration](#lookup)
+
+
+
+#### domain_metadata.key
+
+Key within the namespace whose string value is the resolved domain (e.g. "domain").
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | Yes |
+| **Min length** | 1 |
+
+[↑ Top](#) | [↑ DNS Gateway Lookup Configuration](#lookup)
+
+
+
+#### domain_metadata.namespace
+
+Dynamic-metadata namespace to write under (e.g. "io.builtonenvoy.dns_gateway").
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | Yes |
+| **Min length** | 1 |
+
+[↑ Top](#) | [↑ DNS Gateway Lookup Configuration](#lookup)
+
+   {/* range .SubProperties */} {/* if .SubProperties */}
+
 ### filter_state_prefix
 
 Prefix for filter state keys written by the dns-gateway lookup filter. Downstream filters read domain and metadata under this prefix. Default: "io.builtonenvoy.dns_gateway".
@@ -747,7 +788,7 @@ Base IPv4 address for virtual IP allocation (e.g. "10.0.0.0").
 
 #### domains.domain
 
-Exact domain ("example.com") or single-level wildcard pattern ("*.example.com").
+Exact domain ("example.com"), single-level wildcard pattern ("*.example.com"), or a bare "*" catch-all that matches every queried domain.
 
 | | |
 |---|---|


### PR DESCRIPTION
## What

Two small, independently-useful additions for using the gateway as a universal DNS-takeover layer that defers routing/authorization to downstream filters.

### 1. Bare `*` catch-all matcher

`matches_domain` now treats a pattern of `"*"` as matching every queried domain, and the resolver config loader accepts a `"*"` matcher — skipping the DNS-name parse and the bare-wildcard rejection (which are meant for hostnames) while still validating its `base_ip`/`prefix_len`.

Use it as a low-priority final matcher to intercept all DNS and route/authorize downstream (e.g. `tcp_proxy` route selection on the filter state, or an `ext_authz` check) instead of enumerating every domain. Existing exact and `*.suffix` matching is unchanged; the previous "bare wildcard not allowed" rejection only applied to `*`-as-a-hostname and is now the catch-all.

### 2. Optional domain dynamic metadata on the `lookup` filter

The filter always writes the resolved domain to filter state; some consumers instead read Envoy **dynamic metadata** (e.g. a network `ext_authz` filter with `metadata_context_namespaces` forwards a namespace to the authz service). A new optional `domain_metadata: {namespace, key}` config publishes the resolved domain as a dynamic-metadata string under the operator-chosen namespace/key. Omitted by default, so existing behavior is unchanged.

## Testing

`cargo test`, `cargo fmt --check`, `cargo clippy --all-targets` all clean (45 tests). Adds tests for catch-all matching / config validation and for dynamic-metadata publication (present and absent). Schema + README updated for both.