### PR TITLE
extension: udp multicast relay

### DIFF
--- a/cli/cmd/flags.go
+++ b/cli/cmd/flags.go
@@ -42,6 +42,7 @@ type DockerFlags struct {
 	Enabled      bool   `name:"docker" help:"Run Envoy as a Docker container instead of using func-e." default:"false" env:"BOE_RUN_DOCKER"`
 	Pull         string `name:"pull" help:"Pull policy for the BOE Docker image (missing, always, never). Only applicable when running with --docker." enum:"missing,always,never" default:"missing"`
 	ImageVersion string `name:"docker-image-version" help:"Override the BOE Docker image tag to use when running with --docker. By default, the image version matches the BOE version."`
+	Network      string `name:"docker-network" help:"Container network mode when running with --docker. With 'host' the container shares the host network namespace and no ports are published, which removes container network isolation." enum:"bridge,host" default:"bridge"`
 }
 
 // extensionPositions keeps track of the original position of extensions specified via --extension and --local flags.

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -103,6 +103,7 @@ func (r *Run) Run(ctx context.Context, dirs *xdg.Directories, logger *slog.Logge
 			LocalExtensions: r.Local,
 			Pull:            r.Docker.Pull,
 			ImageVersion:    r.Docker.ImageVersion,
+			DockerNetwork:   r.Docker.Network,
 		}
 		return runner.Run(ctx)
 	}

--- a/cli/cmd/run_test.go
+++ b/cli/cmd/run_test.go
@@ -112,6 +112,11 @@ Flags:
                                    Override the BOE Docker image tag to use
                                    when running with --docker. By default,
                                    the image version matches the BOE version.
+      --docker-network="bridge"    Container network mode when running with
+                                   --docker. With 'host' the container shares
+                                   the host network namespace and no ports are
+                                   published, which removes container network
+                                   isolation.
       --registry="%s"
                                    OCI registry URL for the extensions
                                    ($BOE_REGISTRY).

--- a/cli/cmd/ui_test.go
+++ b/cli/cmd/ui_test.go
@@ -42,48 +42,53 @@ Start the web UI
 
 %s
 Flags:
-  -h, --help                     Show context-sensitive help.
+  -h, --help                       Show context-sensitive help.
 
-      --port=18000               HTTP server port.
-      --log-level="all:error"    Envoy component log level ($ENVOY_LOG_LEVEL).
-      --envoy-version=STRING     Envoy version to use (e.g., 1.31.0, dev,
-                                 dev-latest) ($ENVOY_VERSION)
-      --envoy-path=STRING        Path to a custom Envoy binary. Skips Envoy
-                                 download and version selection ($ENVOY_PATH).
-      --local=LOCAL              Path to a directory containing a local
-                                 Extension to enable.
-      --dev                      Whether to allow downloading dev versions of
-                                 extensions (with -dev suffix). By default,
-                                 only stable versions are allowed.
-      --cluster=CLUSTER,...      Optional additional Envoy cluster provided in
-                                 the host:tlsPort pattern.
+      --port=18000                 HTTP server port.
+      --log-level="all:error"      Envoy component log level ($ENVOY_LOG_LEVEL).
+      --envoy-version=STRING       Envoy version to use (e.g., 1.31.0, dev,
+                                   dev-latest) ($ENVOY_VERSION)
+      --envoy-path=STRING          Path to a custom Envoy binary. Skips Envoy
+                                   download and version selection ($ENVOY_PATH).
+      --local=LOCAL                Path to a directory containing a local
+                                   Extension to enable.
+      --dev                        Whether to allow downloading dev versions of
+                                   extensions (with -dev suffix). By default,
+                                   only stable versions are allowed.
+      --cluster=CLUSTER,...        Optional additional Envoy cluster provided in
+                                   the host:tlsPort pattern.
       --cluster-insecure=CLUSTER-INSECURE,...
-                                 Optional additional Envoy cluster (with TLS
-                                 transport disabled) provided in the host:port
-                                 pattern.
+                                   Optional additional Envoy cluster (with TLS
+                                   transport disabled) provided in the host:port
+                                   pattern.
       --cluster-json=CLUSTER-JSON
-                                 Optional additional Envoy cluster providing the
-                                 complete cluster config in JSON format.
+                                   Optional additional Envoy cluster providing
+                                   the complete cluster config in JSON format.
       --test-upstream-host=STRING
-                                 Hostname for the test upstream
-                                 cluster. Mutually exclusive with
-                                 --test-upstream-cluster. Defaults to
-                                 "httpbin.org".
+                                   Hostname for the test upstream
+                                   cluster. Mutually exclusive with
+                                   --test-upstream-cluster. Defaults to
+                                   "httpbin.org".
       --test-upstream-cluster=STRING
-                                 Name of an existing configured cluster to
-                                 use as the test upstream. The cluster must be
-                                 configured via --cluster, --cluster-insecure,
-                                 or --cluster-json. Mutually exclusive with
-                                 --test-upstream-host.
-      --docker                   Run Envoy as a Docker container instead of
-                                 using func-e ($BOE_RUN_DOCKER).
-      --pull="missing"           Pull policy for the BOE Docker image (missing,
-                                 always, never). Only applicable when running
-                                 with --docker.
+                                   Name of an existing configured cluster to
+                                   use as the test upstream. The cluster must be
+                                   configured via --cluster, --cluster-insecure,
+                                   or --cluster-json. Mutually exclusive with
+                                   --test-upstream-host.
+      --docker                     Run Envoy as a Docker container instead of
+                                   using func-e ($BOE_RUN_DOCKER).
+      --pull="missing"             Pull policy for the BOE Docker image
+                                   (missing, always, never). Only applicable
+                                   when running with --docker.
       --docker-image-version=STRING
-                                 Override the BOE Docker image tag to use when
-                                 running with --docker. By default, the image
-                                 version matches the BOE version.
+                                   Override the BOE Docker image tag to use
+                                   when running with --docker. By default,
+                                   the image version matches the BOE version.
+      --docker-network="bridge"    Container network mode when running with
+                                   --docker. With 'host' the container shares
+                                   the host network namespace and no ports are
+                                   published, which removes container network
+                                   isolation.
 `, wrapHelp(uiHelp))
 
 	require.Equal(t, expected, buf.String())

--- a/cli/internal/envoy/runner.go
+++ b/cli/internal/envoy/runner.go
@@ -377,6 +377,8 @@ const (
 	containerRuntimeDir = containerVolumeDir + "/run"
 	// containerLocalExtensionsDir is the directory inside the container where local extensions are mounted.
 	containerLocalExtensionsDir = containerRuntimeDir + "/extensions"
+	// dockerNetworkBridge is Docker's default network mode, in which ports are published.
+	dockerNetworkBridge = "bridge"
 )
 
 // RunnerDocker handles running Envoy as a Docker container.
@@ -391,6 +393,9 @@ type RunnerDocker struct {
 	LocalExtensions []string
 	Pull            string
 	ImageVersion    string
+	// DockerNetwork is the container network mode. Anything other than the default
+	// bridge is passed to `docker run --network` and suppresses port publishing.
+	DockerNetwork string
 }
 
 // Run starts Envoy in a Docker container.
@@ -434,16 +439,26 @@ func (r *RunnerDocker) dockerRunArgs(image string, localExtArgs []string) []stri
 		"run", "--rm",
 		"--pull", r.Pull,
 		"--platform", "linux/" + r.Arch,
-		"-p", fmt.Sprintf("%d:%d/tcp", r.ListenPort, r.ListenPort),
-		"-p", fmt.Sprintf("%d:%d/udp", r.ListenPort, r.ListenPort),
-		"-p", adminPort + ":" + adminPort,
-		"-v", ContainerCacheVolumeName + ":" + containerVolumeDir,
-		"-e", "BOE_ADMIN_ADDRESS=" + containerAdminAddress,
-		"-e", "BOE_CONFIG_HOME=" + containerConfigHome,
-		"-e", "BOE_DATA_HOME=" + containerDataHome,
-		"-e", "BOE_STATE_HOME=" + containerStateHome,
-		"-e", "BOE_RUNTIME_DIR=" + containerRuntimeDir,
 	}
+	// Publishing ports is meaningless, and rejected by Docker, when the container
+	// shares the host network namespace.
+	if r.DockerNetwork != "" && r.DockerNetwork != dockerNetworkBridge {
+		args = append(args, "--network", r.DockerNetwork)
+	} else {
+		args = append(args,
+			"-p", fmt.Sprintf("%d:%d/tcp", r.ListenPort, r.ListenPort),
+			"-p", fmt.Sprintf("%d:%d/udp", r.ListenPort, r.ListenPort),
+			"-p", adminPort+":"+adminPort,
+		)
+	}
+	args = append(args,
+		"-v", ContainerCacheVolumeName+":"+containerVolumeDir,
+		"-e", "BOE_ADMIN_ADDRESS="+containerAdminAddress,
+		"-e", "BOE_CONFIG_HOME="+containerConfigHome,
+		"-e", "BOE_DATA_HOME="+containerDataHome,
+		"-e", "BOE_STATE_HOME="+containerStateHome,
+		"-e", "BOE_RUNTIME_DIR="+containerRuntimeDir,
+	)
 	if r.RunID != "" {
 		args = append(args, "-e", "BOE_RUN_ID="+r.RunID)
 	}
@@ -529,9 +544,11 @@ func (r *RunnerDocker) processCommandArgs(args []string) []string {
 		// and should not be passed to the container.
 		// Need to do prefix match not equality because flags could be in the form of --docker=true or --pull=always.
 
-		// Handle --docker-image-version value
-		if arg == "--docker-image-version" && i+1 < len(args) {
-			i++ // skip next arg (the value for --docker-image-version)
+		// Handle the space-separated form of --docker flags that take a value. The
+		// --docker prefix check below drops the flag itself, so without this the value
+		// would survive as a stray positional argument to the container's boe.
+		if slices.Contains([]string{"--docker-image-version", "--docker-network"}, arg) && i+1 < len(args) {
+			i++ // skip next arg (the flag's value)
 			continue
 		}
 		if strings.HasPrefix(arg, "--docker") {

--- a/cli/internal/envoy/runner_test.go
+++ b/cli/internal/envoy/runner_test.go
@@ -305,6 +305,78 @@ func TestDockerRunArgs_RunID(t *testing.T) {
 	}
 }
 
+func TestDockerRunArgs_Network(t *testing.T) {
+	originalArgs := os.Args
+	os.Args = []string{"boe", "run", "--docker"}
+	t.Cleanup(func() { os.Args = originalArgs })
+
+	// -p is rejected alongside --network host.
+	r := &RunnerDocker{
+		Logger:        internaltesting.NewTLogger(t),
+		ListenPort:    10000,
+		AdminPort:     9901,
+		Arch:          "arm64",
+		Pull:          "missing",
+		DockerNetwork: "host",
+	}
+	require.Equal(t, []string{
+		"run", "--rm",
+		"--pull", "missing",
+		"--platform", "linux/arm64",
+		"--network", "host",
+		"-v", "boe-cache:" + containerVolumeDir,
+		"-e", "BOE_ADMIN_ADDRESS=0.0.0.0:9901",
+		"-e", "BOE_CONFIG_HOME=" + containerConfigHome,
+		"-e", "BOE_DATA_HOME=" + containerDataHome,
+		"-e", "BOE_STATE_HOME=" + containerStateHome,
+		"-e", "BOE_RUNTIME_DIR=" + containerRuntimeDir,
+		"ghcr.io/test/boe:latest", "/boe",
+		"run",
+	}, r.dockerRunArgs("ghcr.io/test/boe:latest", nil))
+}
+
+func TestDockerRunArgs_BridgePublishesPorts(t *testing.T) {
+	originalArgs := os.Args
+	os.Args = []string{"boe", "run", "--docker"}
+	t.Cleanup(func() { os.Args = originalArgs })
+
+	// An explicit "bridge" must behave exactly like the unset default.
+	r := &RunnerDocker{
+		Logger:        internaltesting.NewTLogger(t),
+		ListenPort:    10000,
+		AdminPort:     9901,
+		Arch:          "arm64",
+		Pull:          "missing",
+		DockerNetwork: "bridge",
+	}
+	args := r.dockerRunArgs("ghcr.io/test/boe:latest", nil)
+	require.Contains(t, strings.Join(args, " "), "-p 10000:10000/udp")
+	require.NotContains(t, strings.Join(args, " "), "--network")
+}
+
+// The --docker prefix filter drops the flag name, so a space-separated value would
+// otherwise survive as a stray positional argument to the container's boe.
+func TestProcessCommandArgsStripsDockerFlagValues(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{{
+		name: "docker-network space separated",
+		args: []string{"boe", "run", "--docker", "--docker-network", "host", "--listen-port", "10000"},
+	}, {
+		name: "docker-network equals form",
+		args: []string{"boe", "run", "--docker", "--docker-network=host", "--listen-port", "10000"},
+	}, {
+		name: "docker-image-version space separated",
+		args: []string{"boe", "run", "--docker", "--docker-image-version", "latest", "--listen-port", "10000"},
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &RunnerDocker{Logger: internaltesting.NewTLogger(t)}
+			require.Equal(t, []string{"run", "--listen-port", "10000"}, r.processCommandArgs(tc.args))
+		})
+	}
+}
+
 func TestPassthroughEnvVars(t *testing.T) {
 	// Save and restore the original environment.
 	originalEnv := os.Environ()

--- a/extensions/composer/go.mod
+++ b/extensions/composer/go.mod
@@ -30,6 +30,8 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 )
 
+require golang.org/x/net v0.55.0
+
 require (
 	github.com/agnivade/levenshtein v1.2.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
@@ -84,7 +86,6 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/exp v0.0.0-20260212183809-81e46e3db34a // indirect
-	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/text v0.38.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect

--- a/extensions/composer/multicast-relay/config.schema.json
+++ b/extensions/composer/multicast-relay/config.schema.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/tetratelabs/built-on-envoy/extensions/multicast-relay/config.schema.json",
+  "title": "Multicast Relay Configuration",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["groups", "target"],
+  "properties": {
+    "groups": {
+      "type": "array",
+      "description": "IPv4 multicast groups to join. Groups sharing a port share one socket.",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["address", "port"],
+        "properties": {
+          "address": {
+            "type": "string",
+            "description": "IPv4 multicast group address, e.g. 239.1.1.1.",
+            "minLength": 1
+          },
+          "port": {
+            "type": "integer",
+            "description": "UDP port the group sends on.",
+            "minimum": 1,
+            "maximum": 65535
+          },
+          "interface": {
+            "type": "string",
+            "description": "Interface name to join on, e.g. en0 or lo0. Pin this explicitly; leaving it empty lets the routing table choose, which is rarely what you want on a multi-homed host."
+          }
+        }
+      }
+    },
+    "target": {
+      "type": "object",
+      "description": "The local Envoy UDP listener that relayed datagrams are sent to.",
+      "additionalProperties": false,
+      "required": ["port"],
+      "properties": {
+        "address": {
+          "type": "string",
+          "description": "Unicast address to forward to. Keep this on loopback: a unicast source address is what makes udp_proxy's reply path valid.",
+          "default": "127.0.0.1"
+        },
+        "port": {
+          "type": "integer",
+          "description": "Port of Envoy's UDP listener. With BOE this is the same port number as the main TCP listener.",
+          "minimum": 1,
+          "maximum": 65535
+        }
+      }
+    },
+    "read_buffer_size": {
+      "type": "integer",
+      "description": "Receive buffer and maximum datagram size in bytes.",
+      "minimum": 512,
+      "maximum": 65536,
+      "default": 65535
+    }
+  }
+}

--- a/extensions/composer/multicast-relay/embedded/host.go
+++ b/extensions/composer/multicast-relay/embedded/host.go
@@ -1,0 +1,18 @@
+// Copyright Built On Envoy
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+// Package host registers the multicast-relay plugin into the composer host
+// binary so it can be used without loading a shared library.
+package host
+
+import (
+	sdk "github.com/envoyproxy/envoy/source/extensions/dynamic_modules/sdk/go"
+
+	impl "github.com/tetratelabs/built-on-envoy/extensions/composer/multicast-relay"
+)
+
+func init() {
+	sdk.RegisterHttpFilterConfigFactories(impl.WellKnownHttpFilterConfigFactories())
+}

--- a/extensions/composer/multicast-relay/manifest.yaml
+++ b/extensions/composer/multicast-relay/manifest.yaml
@@ -1,0 +1,117 @@
+# Copyright Built On Envoy
+# SPDX-License-Identifier: Apache-2.0
+# The full text of the Apache license is available in the LICENSE file at
+# the root of the repo.
+
+name: multicast-relay
+parent: composer
+categories:
+  - Network
+author: Anton Kanugalawattage
+description: Join IPv4 multicast groups and relay the traffic through Envoy
+longDescription: |
+  Envoy cannot receive multicast traffic. Nothing in Envoy joins an IGMP group, so a UDP
+  listener bound to a `239.0.0.0/8` address receives nothing, and the UDP dynamic-module
+  ABI exposes no socket, file descriptor, or `setsockopt` callback an extension could use
+  to join one.
+
+  This extension joins the configured groups on sockets it owns and re-emits every
+  datagram as unicast UDP to Envoy's own UDP listener, where a `udp_proxy` filter forwards
+  it to an upstream cluster.
+
+  ## Configuration
+
+  | Field | Type | Required | Description |
+  |-------|------|----------|-------------|
+  | `groups` | array | yes | Multicast groups to join |
+  | `groups[].address` | string | yes | IPv4 multicast group address (e.g. `239.1.1.1`) |
+  | `groups[].port` | integer | yes | UDP port the group sends on. Groups sharing a port share one socket |
+  | `groups[].interface` | string | no | Interface name to join on (e.g. `en0`). Pin this explicitly; leaving it empty lets the routing table choose, which is rarely correct on a multi-homed host |
+  | `target` | object | yes | The local Envoy UDP listener that relayed datagrams are sent to |
+  | `target.address` | string | no | Unicast address to forward to. Keep this on loopback: a unicast source is what makes `udp_proxy`'s reply path valid. Default: `127.0.0.1` |
+  | `target.port` | integer | yes | Port of Envoy's UDP listener. Under BOE this is the same port number as the main TCP listener |
+  | `read_buffer_size` | integer | no | Receive buffer and maximum datagram size in bytes. Default: `65535` |
+
+  ## Wiring the UDP listener
+
+  Add a `udp_proxy` as the upstream for multicast relay filter:
+
+  ```yaml
+  static_resources:
+    listeners:
+      - name: udp
+        address:
+          socket_address: { protocol: UDP, address: 0.0.0.0, port_value: 10000 }
+        udp_listener_config: {}
+        listener_filters:
+          - name: envoy.filters.udp_listener.udp_proxy
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.udp.udp_proxy.v3.UdpProxyConfig
+              stat_prefix: multicast_relay
+              cluster: multicast_upstream
+    clusters:
+      - name: multicast_upstream
+        type: STATIC
+        load_assignment:
+          cluster_name: multicast_upstream
+          endpoints:
+            - lb_endpoints:
+                - endpoint:
+                    address:
+                      socket_address: { protocol: UDP, address: 127.0.0.1, port_value: 19999 }
+  ```
+  `target.port` must match that listener's `port_value`. A UDP listener may share a port
+  number with the TCP listener; they are distinct sockets.
+
+  ## Prerequisites
+
+  Joining a group needs no elevated privileges, but it does need access to a network that
+  carries the traffic. Run with host networking (`--docker-network host` under `--docker`).
+
+  > On Docker Desktop for macOS, host networking binds inside the Linux VM rather than on
+  > the macOS host, so host-LAN multicast will not arrive. Use a local `boe run` there.
+tags:
+  - go
+  - igmp
+  - multicast
+  - networking
+  - udp
+license: Apache-2.0
+type: go
+examples:
+  - title: Single Group
+    description: |
+      Join `239.1.1.1:5000` on `en0` and forward each datagram to Envoy's UDP listener on
+      port 10000, where `udp_proxy` carries it upstream.
+    code: |
+      boe run \
+        --extension multicast-relay --config '
+          {
+            "groups": [
+              {
+                "address": "239.1.1.1",
+                "port": 5000,
+                "interface": "en0"
+              }
+            ],
+            "target": {
+              "port": 10000
+            }
+          }'
+  - title: One Instance Per Group
+    description: |
+      Two groups that must reach different upstreams need one instance each, so every group
+      gets its own `target.port`, its own `udp_proxy` listener, and its own cluster. Groups
+      listed together in a single instance all share one target.
+    code: |
+      boe run \
+        --extension multicast-relay --config '
+          {
+            "groups": [{ "address": "239.1.1.1", "port": 5000, "interface": "en0" }],
+            "target": { "port": 10001 }
+          }' \
+        --extension multicast-relay --config '
+          {
+            "groups": [{ "address": "239.1.1.2", "port": 5000, "interface": "en0" }],
+            "target": { "port": 10002 }
+          }'

--- a/extensions/composer/multicast-relay/multicast_relay.go
+++ b/extensions/composer/multicast-relay/multicast_relay.go
@@ -1,0 +1,99 @@
+// Copyright Built On Envoy
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+// Package multicastrelay is a composer plugin that brings IPv4 multicast traffic into
+// Envoy. It joins the configured groups on sockets it owns and re-emits each datagram as
+// unicast UDP to Envoy's UDP listener, where udp_proxy forwards it upstream.
+//
+// The HTTP filter it registers does nothing on the request path; the filter config
+// factory is simply the lifecycle hook for the background relay.
+package multicastrelay
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/envoyproxy/envoy/source/extensions/dynamic_modules/sdk/go/shared"
+
+	"github.com/tetratelabs/built-on-envoy/extensions/composer/multicast-relay/relay"
+)
+
+// ExtensionName is the filter name composer registers this plugin under.
+const ExtensionName = "multicast-relay"
+
+func parseConfig(raw []byte) (*relay.Config, error) {
+	if len(raw) == 0 {
+		return nil, fmt.Errorf("empty config")
+	}
+	var c relay.Config
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&c); err != nil {
+		return nil, fmt.Errorf("parse config: %w", err)
+	}
+	return &c, c.Validate()
+}
+
+// Plugin is the per-stream filter instance, deliberately inert: the work happens in the
+// background relay.
+type Plugin struct {
+	shared.EmptyHttpFilter
+}
+
+// pluginInstance is shared across streams because Plugin holds no per-stream state.
+var pluginInstance = &Plugin{}
+
+// PluginFactory creates Plugin instances and holds this config's relay reference.
+type PluginFactory struct {
+	key string
+}
+
+// Create returns the shared, stateless filter instance.
+func (f *PluginFactory) Create(_ shared.HttpFilterHandle) shared.HttpFilter {
+	return pluginInstance
+}
+
+// OnDestroy releases this holder's reference, stopping the relay once it was the last.
+func (f *PluginFactory) OnDestroy() {
+	if f.key != "" {
+		relay.Release(f.key)
+		f.key = ""
+	}
+}
+
+// PluginConfigFactory parses the plugin config and starts the relay.
+type PluginConfigFactory struct {
+	shared.EmptyHttpFilterConfigFactory
+}
+
+// Create validates the config and acquires a relay. A bad config or failed group join is
+// returned as an error so Envoy rejects the filter config rather than receiving nothing.
+func (f *PluginConfigFactory) Create(handle shared.HttpFilterConfigHandle, unparsed []byte) (shared.HttpFilterFactory, error) {
+	cfg, err := parseConfig(unparsed)
+	if err != nil {
+		handle.Log(shared.LogLevelError, "multicast-relay: %v", err)
+		return nil, err
+	}
+	cfg.Logger = handle.Log
+
+	_, key, err := relay.Acquire(context.Background(), cfg)
+	if err != nil {
+		handle.Log(shared.LogLevelError, "multicast-relay: start: %v", err)
+		return nil, err
+	}
+	return &PluginFactory{key: key}, nil
+}
+
+// CreatePerRoute is a no-op; the plugin has no per-route config.
+func (f *PluginConfigFactory) CreatePerRoute(_ []byte) (any, error) { return nil, nil }
+
+// WellKnownHttpFilterConfigFactories returns the factories this plugin registers with the composer host.
+func WellKnownHttpFilterConfigFactories() map[string]shared.HttpFilterConfigFactory { //nolint:revive
+	return map[string]shared.HttpFilterConfigFactory{
+		ExtensionName: &PluginConfigFactory{},
+	}
+}

--- a/extensions/composer/multicast-relay/multicast_relay_test.go
+++ b/extensions/composer/multicast-relay/multicast_relay_test.go
@@ -1,0 +1,141 @@
+// Copyright Built On Envoy
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package multicastrelay
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/envoyproxy/envoy/source/extensions/dynamic_modules/sdk/go/shared/mocks"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/tetratelabs/built-on-envoy/extensions/composer/multicast-relay/relay"
+)
+
+func TestParseConfigErrors(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		raw          string
+		errorMessage string
+	}{{
+		name:         "empty",
+		raw:          "",
+		errorMessage: "empty config",
+	}, {
+		name:         "not JSON",
+		raw:          "foo",
+		errorMessage: "parse config: invalid character 'o' in literal false (expecting 'a')",
+	}, {
+		name:         "unknown field",
+		raw:          `{"groups":[{"address":"239.1.1.1","port":5000}],"target":{"port":1},"bogus":true}`,
+		errorMessage: `parse config: json: unknown field "bogus"`,
+	}, {
+		name:         "fails validation",
+		raw:          `{"groups":[],"target":{"port":10000}}`,
+		errorMessage: "groups must contain at least one entry",
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := parseConfig([]byte(tc.raw))
+			require.EqualError(t, err, tc.errorMessage)
+			_ = cfg
+		})
+	}
+}
+
+func TestParseConfigAppliesDefaults(t *testing.T) {
+	cfg, err := parseConfig([]byte(`{
+		"groups":[{"address":"239.1.1.1","port":5000,"interface":"lo0"}],
+		"target":{"port":10000}
+	}`))
+	require.NoError(t, err)
+	require.Equal(t, &relay.Config{
+		Groups:         []relay.GroupSpec{{Address: "239.1.1.1", Port: 5000, Interface: "lo0"}},
+		Target:         relay.Target{Address: "127.0.0.1", Port: 10000},
+		ReadBufferSize: 65535,
+	}, cfg)
+}
+
+func TestPluginConfigFactoryCreateRejectsBadConfig(t *testing.T) {
+	handle := mocks.NewMockHttpFilterConfigHandle(gomock.NewController(t))
+	handle.EXPECT().Log(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
+	factory, err := (&PluginConfigFactory{}).Create(handle, []byte(`{"groups":[]}`))
+	require.Error(t, err)
+	require.Nil(t, factory)
+}
+
+// A group join that cannot succeed must fail the filter config, so Envoy rejects it
+// rather than running a relay that silently receives nothing.
+func TestPluginConfigFactoryCreateRejectsUnknownInterface(t *testing.T) {
+	handle := mocks.NewMockHttpFilterConfigHandle(gomock.NewController(t))
+	handle.EXPECT().Log(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
+	factory, err := (&PluginConfigFactory{}).Create(handle, []byte(
+		`{"groups":[{"address":"239.1.1.1","port":5000,"interface":"nope0"}],"target":{"port":10000}}`))
+	require.ErrorContains(t, err, `interface "nope0"`)
+	require.Nil(t, factory)
+}
+
+func TestPluginConfigFactoryCreatePerRouteIsNoOp(t *testing.T) {
+	perRoute, err := (&PluginConfigFactory{}).CreatePerRoute([]byte(`{"any":"thing"}`))
+	require.NoError(t, err)
+	require.Nil(t, perRoute)
+}
+
+func TestPluginConfigFactoryCreateStartsAndStopsTheRelay(t *testing.T) {
+	handle := mocks.NewMockHttpFilterConfigHandle(gomock.NewController(t))
+	handle.EXPECT().Log(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
+	factory, err := (&PluginConfigFactory{}).Create(handle, []byte(fmt.Sprintf(
+		`{"groups":[{"address":"239.77.77.90","port":%d,"interface":%q}],"target":{"port":%d}}`,
+		freePort(t), loopbackInterface(t), freePort(t))))
+	require.NoError(t, err)
+
+	pluginFactory, ok := factory.(*PluginFactory)
+	require.True(t, ok)
+	require.NotEmpty(t, pluginFactory.key)
+
+	// The filter itself is inert and shared across streams.
+	require.Same(t, pluginInstance, pluginFactory.Create(nil))
+
+	pluginFactory.OnDestroy()
+	require.Empty(t, pluginFactory.key, "OnDestroy must clear the key so a second call cannot double-release")
+	pluginFactory.OnDestroy()
+}
+
+func TestWellKnownHttpFilterConfigFactories(t *testing.T) {
+	factories := WellKnownHttpFilterConfigFactories()
+	require.Len(t, factories, 1)
+	require.Contains(t, factories, ExtensionName)
+	require.NotNil(t, factories[ExtensionName])
+}
+
+func loopbackInterface(t *testing.T) string {
+	t.Helper()
+
+	ifaces, err := net.Interfaces()
+	require.NoError(t, err)
+	for _, ifi := range ifaces {
+		if ifi.Flags&net.FlagLoopback != 0 && ifi.Flags&net.FlagUp != 0 && ifi.Flags&net.FlagMulticast != 0 {
+			return ifi.Name
+		}
+	}
+	t.Skip("no multicast-capable loopback interface available")
+	return ""
+}
+
+func freePort(t *testing.T) int {
+	t.Helper()
+
+	conn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	require.NoError(t, err)
+	addr, ok := conn.LocalAddr().(*net.UDPAddr)
+	require.True(t, ok)
+	require.NoError(t, conn.Close())
+	return addr.Port
+}

--- a/extensions/composer/multicast-relay/relay/registry.go
+++ b/extensions/composer/multicast-relay/relay/registry.go
@@ -1,0 +1,76 @@
+// Copyright Built On Envoy
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package relay
+
+import (
+	"context"
+	"sync"
+)
+
+// The composer host may build a filter config factory more than once for the same
+// configuration, and two relays on one group would double every datagram. Relays are
+// therefore interned by canonical config and reference counted.
+var (
+	registryMu sync.Mutex
+	registry   = map[string]*entry{}
+)
+
+type entry struct {
+	relay *Relay
+	refs  int
+}
+
+// Acquire returns a running relay for cfg, starting one if this is the first
+// holder. The returned key must be passed to Release when the holder is destroyed.
+func Acquire(ctx context.Context, cfg *Config) (*Relay, string, error) {
+	key := cfg.key()
+
+	registryMu.Lock()
+	defer registryMu.Unlock()
+
+	if e, ok := registry[key]; ok {
+		e.refs++
+		return e.relay, key, nil
+	}
+
+	r := New(cfg)
+	if err := r.Start(ctx); err != nil {
+		return nil, "", err
+	}
+	registry[key] = &entry{relay: r, refs: 1}
+	return r, key, nil
+}
+
+// Release drops one reference and stops the relay once none remain.
+func Release(key string) {
+	registryMu.Lock()
+	e, ok := registry[key]
+	if !ok {
+		registryMu.Unlock()
+		return
+	}
+	e.refs--
+	last := e.refs <= 0
+	if last {
+		delete(registry, key)
+	}
+	registryMu.Unlock()
+
+	// Outside the lock: Stop waits on the forwarding goroutines.
+	if last {
+		e.relay.Stop()
+	}
+}
+
+// refs reports the current reference count for a key, for tests.
+func refs(key string) int {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	if e, ok := registry[key]; ok {
+		return e.refs
+	}
+	return 0
+}

--- a/extensions/composer/multicast-relay/relay/registry_test.go
+++ b/extensions/composer/multicast-relay/relay/registry_test.go
@@ -1,0 +1,116 @@
+// Copyright Built On Envoy
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package relay
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The composer host can build a filter config factory more than once for the same
+// config. Without interning, each one would join the group again and every datagram
+// would be delivered N times, so this is the test that guards against duplication.
+func TestRegistrySharesOneRelayPerConfig(t *testing.T) {
+	ifi := multicastInterface(t)
+	cfg := Config{
+		Groups: []GroupSpec{{Address: "239.77.77.82", Port: freeUDPPort(t), Interface: ifi.Name}},
+		Target: Target{Port: freeUDPPort(t)},
+	}
+	require.NoError(t, cfg.Validate())
+
+	first, key, err := Acquire(context.Background(), &cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { first.Stop() })
+
+	second, secondKey, err := Acquire(context.Background(), &cfg)
+	require.NoError(t, err)
+
+	require.Equal(t, key, secondKey)
+	require.Same(t, first, second, "identical configs must share one relay")
+	require.Equal(t, 2, refs(key))
+	require.Len(t, first.LocalAddrs(), 1, "one socket, not one per holder")
+
+	Release(key)
+	require.Equal(t, 1, refs(key))
+	require.False(t, first.stopped.Load(), "relay must survive while a holder remains")
+
+	Release(key)
+	require.Equal(t, 0, refs(key))
+	require.True(t, first.stopped.Load(), "relay must stop once the last holder releases")
+}
+
+// Groups listing the same set in a different order describe the same relay. Keying them
+// differently would start two, both would join, and every datagram would be delivered twice
+// -- so this asserts the delivered count, not just pointer identity.
+func TestRegistryInternsPermutedGroups(t *testing.T) {
+	ifi := multicastInterface(t)
+	sink := udpSink(t)
+	port := freeUDPPort(t)
+	first := GroupSpec{Address: "239.77.77.89", Port: port, Interface: ifi.Name}
+	second := GroupSpec{Address: "239.77.77.90", Port: port, Interface: ifi.Name}
+
+	forward := Config{Groups: []GroupSpec{first, second}, Target: Target{Port: sinkPort(t, sink)}}
+	require.NoError(t, forward.Validate())
+	reversed := Config{Groups: []GroupSpec{second, first}, Target: Target{Port: sinkPort(t, sink)}}
+	require.NoError(t, reversed.Validate())
+
+	relay, key, err := Acquire(context.Background(), &forward)
+	require.NoError(t, err)
+	defer Release(key)
+
+	permuted, permutedKey, err := Acquire(context.Background(), &reversed)
+	require.NoError(t, err)
+	defer Release(permutedKey)
+
+	require.Equal(t, key, permutedKey, "permuted groups must produce the same key")
+	require.Same(t, relay, permuted)
+	require.Equal(t, 2, refs(key))
+
+	sendMulticast(t, ifi, first.Address, port, "solo")
+	payload, _ := readSink(t, sink)
+	require.Equal(t, "solo", payload)
+
+	// A second relay would have joined the same group and delivered a duplicate.
+	require.NoError(t, sink.SetReadDeadline(time.Now().Add(300*time.Millisecond)))
+	buf := make([]byte, 128)
+	_, _, err = sink.ReadFromUDP(buf)
+	require.ErrorIs(t, err, os.ErrDeadlineExceeded, "one send must deliver exactly one datagram")
+}
+
+func TestRegistryDistinctConfigsGetDistinctRelays(t *testing.T) {
+	ifi := multicastInterface(t)
+	target := freeUDPPort(t)
+
+	first := Config{
+		Groups: []GroupSpec{{Address: "239.77.77.83", Port: freeUDPPort(t), Interface: ifi.Name}},
+		Target: Target{Port: target},
+	}
+	require.NoError(t, first.Validate())
+	second := Config{
+		Groups: []GroupSpec{{Address: "239.77.77.84", Port: freeUDPPort(t), Interface: ifi.Name}},
+		Target: Target{Port: target},
+	}
+	require.NoError(t, second.Validate())
+
+	firstRelay, firstKey, err := Acquire(context.Background(), &first)
+	require.NoError(t, err)
+	defer Release(firstKey)
+
+	secondRelay, secondKey, err := Acquire(context.Background(), &second)
+	require.NoError(t, err)
+	defer Release(secondKey)
+
+	require.NotEqual(t, firstKey, secondKey)
+	require.NotSame(t, firstRelay, secondRelay)
+}
+
+func TestReleaseUnknownKeyIsNoop(_ *testing.T) {
+	Release("not-a-key")
+}

--- a/extensions/composer/multicast-relay/relay/relay.go
+++ b/extensions/composer/multicast-relay/relay/relay.go
@@ -1,0 +1,399 @@
+// Copyright Built On Envoy
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+// Package relay joins IPv4 multicast groups on sockets it owns and re-emits each
+// received datagram as unicast UDP to a local Envoy UDP listener.
+//
+// The join cannot happen inside Envoy: nothing in Envoy joins an IGMP group, and the UDP
+// dynamic-module ABI exposes no socket, fd, or setsockopt callback.
+//
+// Forwarding to loopback also fixes udp_proxy's reply path. udp_proxy uses the received
+// datagram's header destination as the reply source IP, which the kernel rejects with
+// EINVAL for a multicast group but accepts for a unicast loopback address.
+package relay
+
+import (
+	"cmp"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"slices"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"syscall"
+
+	"github.com/envoyproxy/envoy/source/extensions/dynamic_modules/sdk/go/shared"
+	"golang.org/x/net/ipv4"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	defaultTargetAddress  = "127.0.0.1"
+	defaultReadBufferSize = 65535
+
+	minReadBufferSize = 512
+	maxReadBufferSize = 1 << 16
+
+	// Rate-limits forward failure logs so an unreachable target cannot flood the log.
+	forwardErrorLogEvery = 1000
+)
+
+// Logger matches the composer SDK's logging signature.
+type Logger func(level shared.LogLevel, format string, args ...any)
+
+// GroupSpec is one multicast group to join.
+type GroupSpec struct {
+	Address   string `json:"address"`
+	Port      int    `json:"port"`
+	Interface string `json:"interface,omitempty"`
+}
+
+// Target is the local Envoy UDP listener that relayed datagrams are sent to.
+type Target struct {
+	Address string `json:"address,omitempty"`
+	Port    int    `json:"port"`
+}
+
+// Config is the relay configuration, deserialized from the extension's config JSON.
+type Config struct {
+	Groups         []GroupSpec `json:"groups"`
+	Target         Target      `json:"target"`
+	ReadBufferSize int         `json:"read_buffer_size,omitempty"`
+
+	// Logger is not part of the config JSON; the plugin sets it.
+	Logger Logger `json:"-"`
+}
+
+// Validate applies defaults and reports every problem at once.
+func (c *Config) Validate() error {
+	if c.Target.Address == "" {
+		c.Target.Address = defaultTargetAddress
+	}
+	if c.ReadBufferSize == 0 {
+		c.ReadBufferSize = defaultReadBufferSize
+	}
+
+	var errs []error
+	if len(c.Groups) == 0 {
+		errs = append(errs, errors.New("groups must contain at least one entry"))
+	}
+
+	seen := map[string]bool{}
+	for i, g := range c.Groups {
+		switch ip := net.ParseIP(g.Address); {
+		case g.Address == "":
+			errs = append(errs, fmt.Errorf("groups[%d]: address is required", i))
+		case ip == nil:
+			errs = append(errs, fmt.Errorf("groups[%d]: address %q is not a valid IP", i, g.Address))
+		case ip.To4() == nil:
+			errs = append(errs, fmt.Errorf("groups[%d]: address %q must be IPv4", i, g.Address))
+		case !ip.IsMulticast():
+			errs = append(errs, fmt.Errorf("groups[%d]: address %q is not a multicast address", i, g.Address))
+		}
+		if g.Port <= 0 || g.Port > 65535 {
+			errs = append(errs, fmt.Errorf("groups[%d]: port %d out of range 1-65535", i, g.Port))
+		}
+		key := fmt.Sprintf("%s:%d@%s", g.Address, g.Port, g.Interface)
+		if seen[key] {
+			errs = append(errs, fmt.Errorf("groups[%d]: duplicate group %s", i, key))
+		}
+		seen[key] = true
+	}
+
+	if c.Target.Port <= 0 || c.Target.Port > 65535 {
+		errs = append(errs, fmt.Errorf("target.port %d out of range 1-65535", c.Target.Port))
+	}
+	if c.ReadBufferSize < minReadBufferSize || c.ReadBufferSize > maxReadBufferSize {
+		errs = append(errs, fmt.Errorf("read_buffer_size %d out of range %d-%d",
+			c.ReadBufferSize, minReadBufferSize, maxReadBufferSize))
+	}
+
+	return errors.Join(errs...)
+}
+
+// key canonicalizes the config so the registry can dedupe identical relays.
+func (c *Config) key() string {
+	groups := slices.Clone(c.Groups)
+	slices.SortFunc(groups, func(a, b GroupSpec) int {
+		return cmp.Or(
+			strings.Compare(a.Address, b.Address),
+			cmp.Compare(a.Port, b.Port),
+			strings.Compare(a.Interface, b.Interface),
+		)
+	})
+
+	b, _ := json.Marshal(struct {
+		Groups         []GroupSpec `json:"groups"`
+		Target         Target      `json:"target"`
+		ReadBufferSize int         `json:"read_buffer_size"`
+	}{groups, c.Target, c.ReadBufferSize})
+	return string(b)
+}
+
+// Stats is a point-in-time snapshot of relay counters.
+type Stats struct {
+	Received  uint64
+	Forwarded uint64
+	Dropped   uint64
+	Bytes     uint64
+	Foreign   uint64
+}
+
+// socket is one wildcard-bound UDP socket serving every group on a single port.
+type socket struct {
+	port   int
+	pc     *ipv4.PacketConn
+	groups map[string]bool
+}
+
+// Relay owns the multicast sockets and the forwarding goroutines.
+type Relay struct {
+	cfg     *Config
+	sockets []*socket
+	target  *net.UDPAddr
+
+	cancel  context.CancelFunc
+	wg      sync.WaitGroup
+	stopped atomic.Bool
+
+	received  atomic.Uint64
+	forwarded atomic.Uint64
+	dropped   atomic.Uint64
+	bytes     atomic.Uint64
+	foreign   atomic.Uint64
+
+	// sender is the single socket every relayed datagram is written from, so udp_proxy
+	// sees one source 4-tuple and keeps one session for the group. Safe to read without a
+	// lock: Stop closes the multicast sockets and waits for the read loops before closing
+	// it, so no forward can be in flight.
+	sender *net.UDPConn
+}
+
+// New returns a Relay ready to Start. cfg must already have passed Validate, and is
+// retained rather than copied, so callers must not mutate it afterwards.
+func New(cfg *Config) *Relay {
+	return &Relay{cfg: cfg}
+}
+
+func (r *Relay) logf(level shared.LogLevel, format string, args ...any) {
+	if r.cfg.Logger != nil {
+		r.cfg.Logger(level, format, args...)
+	}
+}
+
+// Start binds one socket per distinct group port, joins every group on it, and launches
+// a forwarding goroutine per socket. Closes anything already opened if it fails.
+func (r *Relay) Start(ctx context.Context) (err error) {
+	target, err := net.ResolveUDPAddr("udp4", net.JoinHostPort(
+		r.cfg.Target.Address, fmt.Sprint(r.cfg.Target.Port)))
+	if err != nil {
+		return fmt.Errorf("resolve target: %w", err)
+	}
+	r.target = target
+
+	sharedConn, err := net.DialUDP("udp4", nil, target)
+	if err != nil {
+		return fmt.Errorf("dial target %s: %w", target, err)
+	}
+	r.sender = sharedConn
+
+	defer func() {
+		if err != nil {
+			// Sockets opened before the failure hold fds and group memberships, so a
+			// rejected config must not leave them behind.
+			r.closeSockets()
+			r.closeSender()
+		}
+	}()
+
+	byPort := map[int][]GroupSpec{}
+	var ports []int
+	for _, g := range r.cfg.Groups {
+		if _, ok := byPort[g.Port]; !ok {
+			ports = append(ports, g.Port)
+		}
+		byPort[g.Port] = append(byPort[g.Port], g)
+	}
+
+	for _, port := range ports {
+		s, err := r.openSocket(ctx, port, byPort[port])
+		if err != nil {
+			return err
+		}
+		r.sockets = append(r.sockets, s)
+	}
+
+	loopCtx, cancel := context.WithCancel(ctx)
+	r.cancel = cancel
+	for _, s := range r.sockets {
+		r.wg.Add(1)
+		go func(s *socket) {
+			defer r.wg.Done()
+			r.readLoop(loopCtx, s)
+		}(s)
+	}
+
+	r.logf(shared.LogLevelInfo, "multicast-relay: joined %d group(s) on %d socket(s), forwarding to %s",
+		len(r.cfg.Groups), len(r.sockets), target)
+	return nil
+}
+
+// openSocket binds the wildcard address on port and joins each group on it, so groups
+// sharing a port share a socket.
+func (r *Relay) openSocket(ctx context.Context, port int, groups []GroupSpec) (*socket, error) {
+	lc := net.ListenConfig{Control: setSocketReuse}
+	conn, err := lc.ListenPacket(ctx, "udp4", fmt.Sprintf(":%d", port))
+	if err != nil {
+		return nil, fmt.Errorf("listen udp4 :%d: %w", port, err)
+	}
+	udp, ok := conn.(*net.UDPConn)
+	if !ok {
+		_ = conn.Close()
+		return nil, fmt.Errorf("listen udp4 :%d: unexpected conn type %T", port, conn)
+	}
+	if bufErr := udp.SetReadBuffer(r.cfg.ReadBufferSize); bufErr != nil {
+		// Not fatal; the kernel default still works, just with a smaller queue.
+		r.logf(shared.LogLevelWarn, "multicast-relay: set read buffer on :%d: %v", port, bufErr)
+	}
+
+	pc := ipv4.NewPacketConn(udp)
+	// The destination address is how readLoop tells joined-group traffic apart from
+	// anything else arriving on this wildcard-bound port.
+	if err = pc.SetControlMessage(ipv4.FlagDst, true); err != nil {
+		_ = pc.Close()
+		return nil, fmt.Errorf("enable destination control message on :%d: %w", port, err)
+	}
+
+	s := &socket{port: port, pc: pc, groups: map[string]bool{}}
+	for _, g := range groups {
+		var ifi *net.Interface
+		if g.Interface != "" {
+			ifi, err = net.InterfaceByName(g.Interface)
+			if err != nil {
+				_ = pc.Close()
+				return nil, fmt.Errorf("group %s:%d: interface %q: %w", g.Address, g.Port, g.Interface, err)
+			}
+		}
+		ip := net.ParseIP(g.Address)
+		if err := pc.JoinGroup(ifi, &net.UDPAddr{IP: ip}); err != nil {
+			_ = pc.Close()
+			return nil, fmt.Errorf("join group %s:%d on %q: %w", g.Address, g.Port, g.Interface, err)
+		}
+		s.groups[ip.String()] = true
+		r.logf(shared.LogLevelInfo, "multicast-relay: joined %s:%d on interface %q",
+			g.Address, g.Port, g.Interface)
+	}
+	return s, nil
+}
+
+// setSocketReuse allows an old and new relay to briefly overlap on the same port
+// during a config reload.
+func setSocketReuse(_, _ string, c syscall.RawConn) error {
+	var setErr error
+	if err := c.Control(func(fd uintptr) {
+		if setErr = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEADDR, 1); setErr != nil {
+			return
+		}
+		setErr = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEPORT, 1)
+	}); err != nil {
+		return err
+	}
+	return setErr
+}
+
+func (r *Relay) readLoop(ctx context.Context, s *socket) {
+	buf := make([]byte, r.cfg.ReadBufferSize)
+	for {
+		n, cm, _, err := s.pc.ReadFrom(buf)
+		if err != nil {
+			if ctx.Err() != nil || r.stopped.Load() || errors.Is(err, net.ErrClosed) {
+				return
+			}
+			r.logf(shared.LogLevelWarn, "multicast-relay: read on :%d: %v", s.port, err)
+			continue
+		}
+		r.received.Add(1)
+
+		// A wildcard bind also receives unicast and other groups on this port.
+		if cm != nil && cm.Dst != nil && !s.groups[cm.Dst.String()] {
+			r.foreign.Add(1)
+			continue
+		}
+		r.forward(buf[:n])
+	}
+}
+
+func (r *Relay) forward(payload []byte) {
+	if _, err := r.sender.Write(payload); err != nil {
+		n := r.dropped.Add(1)
+		if n == 1 || n%forwardErrorLogEvery == 0 {
+			r.logf(shared.LogLevelWarn, "multicast-relay: forward to %s failed (%d dropped): %v",
+				r.target, n, err)
+		}
+		return
+	}
+	r.forwarded.Add(1)
+	r.bytes.Add(uint64(len(payload)))
+}
+
+// Stop closes the sockets, which implicitly leaves the groups, and waits for the
+// forwarding goroutines. Safe to call twice.
+func (r *Relay) Stop() {
+	if !r.stopped.CompareAndSwap(false, true) {
+		return
+	}
+	if r.cancel != nil {
+		r.cancel()
+	}
+	// Close first so a blocked ReadFrom returns.
+	r.closeSockets()
+	r.wg.Wait()
+	r.closeSender()
+
+	st := r.Stats()
+	r.logf(shared.LogLevelInfo,
+		"multicast-relay: stopped; received=%d forwarded=%d dropped=%d foreign=%d bytes=%d",
+		st.Received, st.Forwarded, st.Dropped, st.Foreign, st.Bytes)
+}
+
+// closeSockets closes the multicast sockets, which also drops the group memberships.
+// Kept separate from closeAll because Stop must close these before waiting on the
+// forwarding goroutines, so a blocked ReadFrom returns.
+func (r *Relay) closeSockets() {
+	for _, s := range r.sockets {
+		_ = s.pc.Close()
+	}
+	r.sockets = nil
+}
+
+func (r *Relay) closeSender() {
+	if r.sender != nil {
+		_ = r.sender.Close()
+		r.sender = nil
+	}
+}
+
+// Stats returns a snapshot of the relay counters.
+func (r *Relay) Stats() Stats {
+	return Stats{
+		Received:  r.received.Load(),
+		Forwarded: r.forwarded.Load(),
+		Dropped:   r.dropped.Load(),
+		Bytes:     r.bytes.Load(),
+		Foreign:   r.foreign.Load(),
+	}
+}
+
+// LocalAddrs reports the bound address of each multicast socket.
+func (r *Relay) LocalAddrs() []string {
+	out := make([]string, 0, len(r.sockets))
+	for _, s := range r.sockets {
+		out = append(out, s.pc.LocalAddr().String())
+	}
+	return out
+}

--- a/extensions/composer/multicast-relay/relay/relay_test.go
+++ b/extensions/composer/multicast-relay/relay/relay_test.go
@@ -1,0 +1,387 @@
+// Copyright Built On Envoy
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+package relay
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/envoyproxy/envoy/source/extensions/dynamic_modules/sdk/go/shared"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/ipv4"
+)
+
+func TestConfigValidateErrors(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		cfg          Config
+		errorMessage string
+	}{{
+		name:         "no groups",
+		cfg:          Config{Target: Target{Port: 10000}},
+		errorMessage: "groups must contain at least one entry",
+	}, {
+		name: "address missing",
+		cfg: Config{
+			Groups: []GroupSpec{{Port: 5000}},
+			Target: Target{Port: 10000},
+		},
+		errorMessage: "groups[0]: address is required",
+	}, {
+		name: "address not an IP",
+		cfg: Config{
+			Groups: []GroupSpec{{Address: "foo", Port: 5000}},
+			Target: Target{Port: 10000},
+		},
+		errorMessage: `groups[0]: address "foo" is not a valid IP`,
+	}, {
+		name: "address is IPv6",
+		cfg: Config{
+			Groups: []GroupSpec{{Address: "ff02::1", Port: 5000}},
+			Target: Target{Port: 10000},
+		},
+		errorMessage: `groups[0]: address "ff02::1" must be IPv4`,
+	}, {
+		name: "address is not multicast",
+		cfg: Config{
+			Groups: []GroupSpec{{Address: "10.0.0.1", Port: 5000}},
+			Target: Target{Port: 10000},
+		},
+		errorMessage: `groups[0]: address "10.0.0.1" is not a multicast address`,
+	}, {
+		name: "group port out of range",
+		cfg: Config{
+			Groups: []GroupSpec{{Address: "239.1.1.1", Port: 70000}},
+			Target: Target{Port: 10000},
+		},
+		errorMessage: "groups[0]: port 70000 out of range 1-65535",
+	}, {
+		name: "duplicate group",
+		cfg: Config{
+			Groups: []GroupSpec{
+				{Address: "239.1.1.1", Port: 5000, Interface: "lo0"},
+				{Address: "239.1.1.1", Port: 5000, Interface: "lo0"},
+			},
+			Target: Target{Port: 10000},
+		},
+		errorMessage: "groups[1]: duplicate group 239.1.1.1:5000@lo0",
+	}, {
+		name: "target port missing",
+		cfg: Config{
+			Groups: []GroupSpec{{Address: "239.1.1.1", Port: 5000}},
+		},
+		errorMessage: "target.port 0 out of range 1-65535",
+	}, {
+		name: "read buffer too small",
+		cfg: Config{
+			Groups:         []GroupSpec{{Address: "239.1.1.1", Port: 5000}},
+			Target:         Target{Port: 10000},
+			ReadBufferSize: 8,
+		},
+		errorMessage: "read_buffer_size 8 out of range 512-65536",
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := tc.cfg
+			require.EqualError(t, cfg.Validate(), tc.errorMessage)
+		})
+	}
+}
+
+func TestConfigValidateAppliesDefaults(t *testing.T) {
+	cfg := Config{
+		Groups: []GroupSpec{{Address: "239.1.1.1", Port: 5000}},
+		Target: Target{Port: 10000},
+	}
+	require.NoError(t, cfg.Validate())
+	require.Equal(t, Config{
+		Groups:         []GroupSpec{{Address: "239.1.1.1", Port: 5000}},
+		Target:         Target{Address: "127.0.0.1", Port: 10000},
+		ReadBufferSize: 65535,
+	}, cfg)
+}
+
+func TestRelayStartRejectsUnknownInterface(t *testing.T) {
+	cfg := Config{
+		Groups: []GroupSpec{{Address: "239.77.77.77", Port: freeUDPPort(t), Interface: "nope0"}},
+		Target: Target{Port: freeUDPPort(t)},
+	}
+	require.NoError(t, cfg.Validate())
+
+	r := New(&cfg)
+	require.ErrorContains(t, r.Start(context.Background()), `interface "nope0"`)
+}
+
+// A partially-started relay must not keep the sockets it already opened: each one holds
+// an fd and a group membership, so a config that Envoy rejects would otherwise leak both
+// on every reload attempt.
+func TestRelayStartClosesSocketsOnFailure(t *testing.T) {
+	ifi := multicastInterface(t)
+	cfg := Config{
+		Groups: []GroupSpec{
+			{Address: "239.77.77.85", Port: freeUDPPort(t), Interface: ifi.Name},
+			{Address: "239.77.77.86", Port: freeUDPPort(t), Interface: "nope0"},
+		},
+		Target: Target{Port: freeUDPPort(t)},
+	}
+	require.NoError(t, cfg.Validate())
+
+	r := New(&cfg)
+	require.ErrorContains(t, r.Start(context.Background()), `interface "nope0"`)
+	require.Empty(t, r.sockets, "the socket opened for the first group must be closed and dropped")
+	require.Empty(t, r.LocalAddrs())
+}
+
+// TestRelayForwardsToTarget is the load-bearing test: it proves a real IGMP join
+// receives real multicast traffic and that the payload lands on the unicast target
+// with a unicast source address, which is the whole reason for the loopback hop.
+func TestRelayForwardsToTarget(t *testing.T) {
+	ifi := multicastInterface(t)
+	sink := udpSink(t)
+	group, port := "239.77.77.78", freeUDPPort(t)
+
+	cfg := Config{
+		Groups: []GroupSpec{{Address: group, Port: port, Interface: ifi.Name}},
+		Target: Target{Port: sinkPort(t, sink)},
+	}
+	require.NoError(t, cfg.Validate())
+
+	r := New(&cfg)
+	require.NoError(t, r.Start(context.Background()))
+	defer r.Stop()
+
+	sendMulticast(t, ifi, group, port, "🍎", "🧨")
+
+	payload, src := readSink(t, sink)
+	require.Equal(t, "🍎", payload)
+	require.True(t, src.IP.IsLoopback(),
+		"forwarded source must be unicast loopback so udp_proxy's reply path is valid, got %s", src.IP)
+
+	payload, _ = readSink(t, sink)
+	require.Equal(t, "🧨", payload)
+
+	require.Equal(t, Stats{Received: 2, Forwarded: 2, Bytes: 8}, r.Stats())
+}
+
+// TestRelayIgnoresTrafficForOtherDestinations covers the wildcard bind: the socket
+// also receives unicast on the group's port, which must not be relayed.
+func TestRelayIgnoresTrafficForOtherDestinations(t *testing.T) {
+	ifi := multicastInterface(t)
+	sink := udpSink(t)
+	group, port := "239.77.77.79", freeUDPPort(t)
+
+	cfg := Config{
+		Groups: []GroupSpec{{Address: group, Port: port, Interface: ifi.Name}},
+		Target: Target{Port: sinkPort(t, sink)},
+	}
+	require.NoError(t, cfg.Validate())
+
+	r := New(&cfg)
+	require.NoError(t, r.Start(context.Background()))
+	defer r.Stop()
+
+	conn, err := net.DialUDP("udp4", nil, &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: port})
+	require.NoError(t, err)
+	defer func() { _ = conn.Close() }()
+	_, err = conn.Write([]byte("bar"))
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool { return r.Stats().Foreign == 1 }, 2*time.Second, 10*time.Millisecond,
+		"unicast datagram on the group port should be counted foreign, stats: %+v", r.Stats())
+	require.Equal(t, Stats{Received: 1, Foreign: 1}, r.Stats())
+}
+
+func TestRelayCountsDropsWhenTargetIsUnwritable(t *testing.T) {
+	ifi := multicastInterface(t)
+	group, port := "239.77.77.87", freeUDPPort(t)
+
+	cfg := Config{
+		Groups: []GroupSpec{{Address: group, Port: port, Interface: ifi.Name}},
+		Target: Target{Port: freeUDPPort(t)},
+	}
+	require.NoError(t, cfg.Validate())
+
+	r := New(&cfg)
+	require.NoError(t, r.Start(context.Background()))
+	defer r.Stop()
+
+	// Closing the sender is what an unwritable target looks like from the relay's side.
+	require.NoError(t, r.sender.Close())
+
+	sendMulticast(t, ifi, group, port, "foo")
+
+	require.Eventually(t, func() bool { return r.Stats().Dropped == 1 }, 2*time.Second, 10*time.Millisecond,
+		"a failed write must be counted, stats: %+v", r.Stats())
+	require.Zero(t, r.Stats().Forwarded, "a dropped datagram must not also count as forwarded")
+	require.Zero(t, r.Stats().Bytes)
+}
+
+// Start must fail loudly on an unresolvable target rather than come up and drop everything.
+func TestRelayStartRejectsUnresolvableTarget(t *testing.T) {
+	cfg := Config{
+		Groups: []GroupSpec{{Address: "239.77.77.92", Port: freeUDPPort(t)}},
+		// A host containing a colon cannot resolve, so this fails before any socket is opened.
+		Target: Target{Address: "1.2.3.4:5", Port: freeUDPPort(t)},
+	}
+	require.NoError(t, cfg.Validate())
+
+	r := New(&cfg)
+	require.ErrorContains(t, r.Start(context.Background()), "resolve target")
+	require.Empty(t, r.sockets)
+}
+
+// Two entries for one group on one port differ only by interface, so Validate allows them,
+// but they share a socket and the second join is rejected by the kernel. Start must surface
+// that instead of reporting a relay that joined less than it was asked to.
+func TestRelayStartRejectsDuplicateJoinOnOneSocket(t *testing.T) {
+	ifi := multicastInterface(t)
+	group, port := "239.77.77.93", freeUDPPort(t)
+
+	cfg := Config{
+		Groups: []GroupSpec{
+			{Address: group, Port: port, Interface: ifi.Name},
+			{Address: group, Port: port},
+		},
+		Target: Target{Port: freeUDPPort(t)},
+	}
+	require.NoError(t, cfg.Validate())
+
+	r := New(&cfg)
+	require.ErrorContains(t, r.Start(context.Background()), "join group "+group)
+	require.Empty(t, r.sockets, "the socket must not be retained after a failed join")
+}
+
+// The plugin passes Envoy's log handle through Config.Logger; this proves the relay actually
+// calls it, so join and drop diagnostics reach Envoy's log.
+func TestRelayLogsThroughConfiguredLogger(t *testing.T) {
+	ifi := multicastInterface(t)
+	group, port := "239.77.77.94", freeUDPPort(t)
+
+	var mu sync.Mutex
+	var lines []string
+	cfg := Config{
+		Groups: []GroupSpec{{Address: group, Port: port, Interface: ifi.Name}},
+		Target: Target{Port: freeUDPPort(t)},
+		Logger: func(_ shared.LogLevel, format string, args ...any) {
+			mu.Lock()
+			defer mu.Unlock()
+			lines = append(lines, fmt.Sprintf(format, args...))
+		},
+	}
+	require.NoError(t, cfg.Validate())
+
+	r := New(&cfg)
+	require.NoError(t, r.Start(context.Background()))
+	r.Stop()
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.NotEmpty(t, lines, "the relay must log through the configured logger")
+	require.Contains(t, strings.Join(lines, "\n"), "joined "+group)
+}
+
+func TestRelayStopIsIdempotent(t *testing.T) {
+	ifi := multicastInterface(t)
+	cfg := Config{
+		Groups: []GroupSpec{{Address: "239.77.77.81", Port: freeUDPPort(t), Interface: ifi.Name}},
+		Target: Target{Port: freeUDPPort(t)},
+	}
+	require.NoError(t, cfg.Validate())
+
+	r := New(&cfg)
+	require.NoError(t, r.Start(context.Background()))
+	r.Stop()
+	r.Stop()
+}
+
+// multicastInterface prefers loopback so the test needs no real network, falling
+// back to any multicast-capable interface.
+func multicastInterface(t *testing.T) *net.Interface {
+	t.Helper()
+
+	ifaces, err := net.Interfaces()
+	require.NoError(t, err)
+
+	var fallback *net.Interface
+	for i := range ifaces {
+		ifi := &ifaces[i]
+		if ifi.Flags&net.FlagUp == 0 || ifi.Flags&net.FlagMulticast == 0 {
+			continue
+		}
+		if ifi.Flags&net.FlagLoopback != 0 {
+			return ifi
+		}
+		if fallback == nil {
+			fallback = ifi
+		}
+	}
+	if fallback == nil {
+		t.Skip("no multicast-capable interface available")
+	}
+	return fallback
+}
+
+func udpSink(t *testing.T) *net.UDPConn {
+	t.Helper()
+
+	sink, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sink.Close() })
+	return sink
+}
+
+func sinkPort(t *testing.T, sink *net.UDPConn) int {
+	t.Helper()
+
+	addr, ok := sink.LocalAddr().(*net.UDPAddr)
+	require.True(t, ok)
+	return addr.Port
+}
+
+func readSink(t *testing.T, sink *net.UDPConn) (string, *net.UDPAddr) {
+	t.Helper()
+
+	require.NoError(t, sink.SetReadDeadline(time.Now().Add(3*time.Second)))
+	buf := make([]byte, 2048)
+	n, src, err := sink.ReadFromUDP(buf)
+	require.NoError(t, err, "no datagram reached the target")
+	return string(buf[:n]), src
+}
+
+// sendMulticast sends from a fresh socket, so each call is a distinct source.
+func sendMulticast(t *testing.T, ifi *net.Interface, group string, port int, payloads ...string) {
+	t.Helper()
+
+	conn, err := net.ListenPacket("udp4", "0.0.0.0:0")
+	require.NoError(t, err)
+	defer func() { _ = conn.Close() }()
+
+	pc := ipv4.NewPacketConn(conn)
+	require.NoError(t, pc.SetMulticastInterface(ifi))
+	require.NoError(t, pc.SetMulticastLoopback(true))
+	require.NoError(t, pc.SetMulticastTTL(1))
+
+	dst := &net.UDPAddr{IP: net.ParseIP(group), Port: port}
+	for _, p := range payloads {
+		_, err := pc.WriteTo([]byte(p), nil, dst)
+		require.NoError(t, err)
+	}
+}
+
+func freeUDPPort(t *testing.T) int {
+	t.Helper()
+
+	conn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	require.NoError(t, err)
+	addr, ok := conn.LocalAddr().(*net.UDPAddr)
+	require.True(t, ok)
+	require.NoError(t, conn.Close())
+	return addr.Port
+}

--- a/extensions/composer/multicast-relay/standalone/main.go
+++ b/extensions/composer/multicast-relay/standalone/main.go
@@ -1,0 +1,18 @@
+// Copyright Built On Envoy
+// SPDX-License-Identifier: Apache-2.0
+// The full text of the Apache license is available in the LICENSE file at
+// the root of the repo.
+
+// Package main builds the multicast-relay as a standalone Go plugin loadable
+// by the composer dynamic module.
+package main
+
+import (
+	shared "github.com/envoyproxy/envoy/source/extensions/dynamic_modules/sdk/go/shared"
+
+	impl "github.com/tetratelabs/built-on-envoy/extensions/composer/multicast-relay"
+)
+
+func WellKnownHttpFilterConfigFactories() map[string]shared.HttpFilterConfigFactory { //nolint:revive
+	return impl.WellKnownHttpFilterConfigFactories()
+}

--- a/extensions/composer/plugins.go
+++ b/extensions/composer/plugins.go
@@ -19,6 +19,7 @@ import (
 	_ "github.com/tetratelabs/built-on-envoy/extensions/composer/goplugin-loader"
 	_ "github.com/tetratelabs/built-on-envoy/extensions/composer/jwe-decrypt/embedded"       // JWE decryption plugin.
 	_ "github.com/tetratelabs/built-on-envoy/extensions/composer/llm-proxy/embedded"         // LLM Proxy plugin.
+	_ "github.com/tetratelabs/built-on-envoy/extensions/composer/multicast-relay/embedded"   // Multicast Relay plugin.
 	_ "github.com/tetratelabs/built-on-envoy/extensions/composer/opa/embedded"               // OPA authorization plugin.
 	_ "github.com/tetratelabs/built-on-envoy/extensions/composer/openapi-validator/embedded" // OpenAPI validator plugin.
 	_ "github.com/tetratelabs/built-on-envoy/extensions/composer/openfga/embedded"           // OpenFGA authorization plugin.

--- a/ui/schemas/multicast-relay.json
+++ b/ui/schemas/multicast-relay.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/tetratelabs/built-on-envoy/extensions/multicast-relay/config.schema.json",
+  "title": "Multicast Relay Configuration",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["groups", "target"],
+  "properties": {
+    "groups": {
+      "type": "array",
+      "description": "IPv4 multicast groups to join. Groups sharing a port share one socket.",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["address", "port"],
+        "properties": {
+          "address": {
+            "type": "string",
+            "description": "IPv4 multicast group address, e.g. 239.1.1.1.",
+            "minLength": 1
+          },
+          "port": {
+            "type": "integer",
+            "description": "UDP port the group sends on.",
+            "minimum": 1,
+            "maximum": 65535
+          },
+          "interface": {
+            "type": "string",
+            "description": "Interface name to join on, e.g. en0 or lo0. Pin this explicitly; leaving it empty lets the routing table choose, which is rarely what you want on a multi-homed host."
+          }
+        }
+      }
+    },
+    "target": {
+      "type": "object",
+      "description": "The local Envoy UDP listener that relayed datagrams are sent to.",
+      "additionalProperties": false,
+      "required": ["port"],
+      "properties": {
+        "address": {
+          "type": "string",
+          "description": "Unicast address to forward to. Keep this on loopback: a unicast source address is what makes udp_proxy's reply path valid.",
+          "default": "127.0.0.1"
+        },
+        "port": {
+          "type": "integer",
+          "description": "Port of Envoy's UDP listener. With BOE this is the same port number as the main TCP listener.",
+          "minimum": 1,
+          "maximum": 65535
+        }
+      }
+    },
+    "read_buffer_size": {
+      "type": "integer",
+      "description": "Receive buffer and maximum datagram size in bytes.",
+      "minimum": 512,
+      "maximum": 65536,
+      "default": 65535
+    }
+  }
+}

--- a/website/public/extensions.json
+++ b/website/public/extensions.json
@@ -829,6 +829,46 @@
     "configReferencePath": "/docs/reference/extensions#lookup"
   },
   {
+    "name": "multicast-relay",
+    "version": "0.11.0-dev",
+    "parent": "composer",
+    "categories": [
+      "Network"
+    ],
+    "author": "Anton Kanugalawattage",
+    "description": "Join IPv4 multicast groups and relay the traffic through Envoy",
+    "longDescription": "Envoy cannot receive multicast traffic. Nothing in Envoy joins an IGMP group, so a UDP\nlistener bound to a `239.0.0.0/8` address receives nothing, and the UDP dynamic-module\nABI exposes no socket, file descriptor, or `setsockopt` callback an extension could use\nto join one.\n\nThis extension joins the configured groups on sockets it owns and re-emits every\ndatagram as unicast UDP to Envoy's own UDP listener, where a `udp_proxy` filter forwards\nit to an upstream cluster.\n\n## Configuration\n\n| Field | Type | Required | Description |\n|-------|------|----------|-------------|\n| `groups` | array | yes | Multicast groups to join |\n| `groups[].address` | string | yes | IPv4 multicast group address (e.g. `239.1.1.1`) |\n| `groups[].port` | integer | yes | UDP port the group sends on. Groups sharing a port share one socket |\n| `groups[].interface` | string | no | Interface name to join on (e.g. `en0`). Pin this explicitly; leaving it empty lets the routing table choose, which is rarely correct on a multi-homed host |\n| `target` | object | yes | The local Envoy UDP listener that relayed datagrams are sent to |\n| `target.address` | string | no | Unicast address to forward to. Keep this on loopback: a unicast source is what makes `udp_proxy`'s reply path valid. Default: `127.0.0.1` |\n| `target.port` | integer | yes | Port of Envoy's UDP listener. Under BOE this is the same port number as the main TCP listener |\n| `read_buffer_size` | integer | no | Receive buffer and maximum datagram size in bytes. Default: `65535` |\n\n## Wiring the UDP listener\n\nAdd a `udp_proxy` as the upstream for multicast relay filter:\n\n```yaml\nstatic_resources:\n  listeners:\n    - name: udp\n      address:\n        socket_address: { protocol: UDP, address: 0.0.0.0, port_value: 10000 }\n      udp_listener_config: {}\n      listener_filters:\n        - name: envoy.filters.udp_listener.udp_proxy\n          typed_config:\n            \"@type\": type.googleapis.com/envoy.extensions.filters.udp.udp_proxy.v3.UdpProxyConfig\n            stat_prefix: multicast_relay\n            cluster: multicast_upstream\n  clusters:\n    - name: multicast_upstream\n      type: STATIC\n      load_assignment:\n        cluster_name: multicast_upstream\n        endpoints:\n          - lb_endpoints:\n              - endpoint:\n                  address:\n                    socket_address: { protocol: UDP, address: 127.0.0.1, port_value: 19999 }\n```\n`target.port` must match that listener's `port_value`. A UDP listener may share a port\nnumber with the TCP listener; they are distinct sockets.\n\n## Prerequisites\n\nJoining a group needs no elevated privileges, but it does need access to a network that\ncarries the traffic. Run with host networking (`--docker-network host` under `--docker`).\n\n\u003e On Docker Desktop for macOS, host networking binds inside the Linux VM rather than on\n\u003e the macOS host, so host-LAN multicast will not arrive. Use a local `boe run` there.\n",
+    "type": "go",
+    "filterType": [
+      "http"
+    ],
+    "tags": [
+      "go",
+      "igmp",
+      "multicast",
+      "networking",
+      "udp"
+    ],
+    "license": "Apache-2.0",
+    "examples": [
+      {
+        "title": "Single Group",
+        "description": "Join `239.1.1.1:5000` on `en0` and forward each datagram to Envoy's UDP listener on\nport 10000, where `udp_proxy` carries it upstream.\n",
+        "code": "boe run \\\n  --extension multicast-relay --config '\n    {\n      \"groups\": [\n        {\n          \"address\": \"239.1.1.1\",\n          \"port\": 5000,\n          \"interface\": \"en0\"\n        }\n      ],\n      \"target\": {\n        \"port\": 10000\n      }\n    }'\n"
+      },
+      {
+        "title": "One Instance Per Group",
+        "description": "Two groups that must reach different upstreams need one instance each, so every group\ngets its own `target.port`, its own `udp_proxy` listener, and its own cluster. Groups\nlisted together in a single instance all share one target.\n",
+        "code": "boe run \\\n  --extension multicast-relay --config '\n    {\n      \"groups\": [{ \"address\": \"239.1.1.1\", \"port\": 5000, \"interface\": \"en0\" }],\n      \"target\": { \"port\": 10001 }\n    }' \\\n  --extension multicast-relay --config '\n    {\n      \"groups\": [{ \"address\": \"239.1.1.2\", \"port\": 5000, \"interface\": \"en0\" }],\n      \"target\": { \"port\": 10002 }\n    }'\n"
+      }
+    ],
+    "minEnvoyVersion": "1.38.0",
+    "maxEnvoyVersion": "1.39.0",
+    "composerVersion": "0.11.0-dev",
+    "sourcePath": "composer/multicast-relay",
+    "configReferencePath": "/docs/reference/extensions#multicast-relay"
+  },
+  {
     "name": "opa",
     "version": "0.11.0-dev",
     "parent": "composer",

--- a/website/src/pages/docs/cli/run.mdx
+++ b/website/src/pages/docs/cli/run.mdx
@@ -117,6 +117,7 @@ boe run --help
 | `--docker` | Run Envoy as a Docker container instead of using func-e. | `bool` | `false` | `BOE_RUN_DOCKER` | No |
 | `--pull` | Pull policy for the BOE Docker image (missing, always, never). Only applicable when running with --docker. | `string` | `missing` | - | No |
 | `--docker-image-version` | Override the BOE Docker image tag to use when running with --docker. By default, the image version matches the BOE version. | `string` | - | - | No |
+| `--docker-network` | Container network mode when running with --docker. With 'host' the container shares the host network namespace and no ports are published, which removes container network isolation. | `string` | `bridge` | - | No |
 | `--registry` | OCI registry URL for the extensions. | `string` | `ghcr.io/tetratelabs/built-on-envoy` | `BOE_REGISTRY` | No |
 | `--insecure` | Allow connecting to an insecure (HTTP) registry. | `bool` | `false` | `BOE_REGISTRY_INSECURE` | No |
 | `--username` | Username for the OCI registry. | `string` | - | `BOE_REGISTRY_USERNAME` | No |

--- a/website/src/pages/docs/cli/ui.mdx
+++ b/website/src/pages/docs/cli/ui.mdx
@@ -72,4 +72,5 @@ boe ui --help
 | `--docker` | Run Envoy as a Docker container instead of using func-e. | `bool` | `false` | `BOE_RUN_DOCKER` | No |
 | `--pull` | Pull policy for the BOE Docker image (missing, always, never). Only applicable when running with --docker. | `string` | `missing` | - | No |
 | `--docker-image-version` | Override the BOE Docker image tag to use when running with --docker. By default, the image version matches the BOE version. | `string` | - | - | No |
+| `--docker-network` | Container network mode when running with --docker. With 'host' the container shares the host network namespace and no ports are published, which removes container network isolation. | `string` | `bridge` | - | No |
 

--- a/website/src/pages/docs/reference/extensions.mdx
+++ b/website/src/pages/docs/reference/extensions.mdx
@@ -1262,6 +1262,118 @@ Match strings ending with this value.
 
 
 
+<a id="multicast-relay"></a>
+## Multicast Relay Configuration
+
+
+
+### groups
+
+IPv4 multicast groups to join. Groups sharing a port share one socket.
+
+| | |
+|---|---|
+| **Type** | `[]object` |
+| **Required** | Yes |
+| **Min items** | 1 |
+
+[↑ Top](#) | [↑ Multicast Relay Configuration](#multicast-relay)
+
+
+
+#### groups.address
+
+IPv4 multicast group address, e.g. 239.1.1.1.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | Yes |
+| **Min length** | 1 |
+
+[↑ Top](#) | [↑ Multicast Relay Configuration](#multicast-relay)
+
+
+
+#### groups.interface
+
+Interface name to join on, e.g. en0 or lo0. Pin this explicitly; leaving it empty lets the routing table choose, which is rarely what you want on a multi-homed host.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ Multicast Relay Configuration](#multicast-relay)
+
+
+
+#### groups.port
+
+UDP port the group sends on.
+
+| | |
+|---|---|
+| **Type** | `integer` |
+| **Required** | Yes |
+
+[↑ Top](#) | [↑ Multicast Relay Configuration](#multicast-relay)
+
+   {/* range .SubProperties */} {/* if .SubProperties */}
+
+### read_buffer_size
+
+Receive buffer and maximum datagram size in bytes.
+
+| | |
+|---|---|
+| **Type** | `integer` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ Multicast Relay Configuration](#multicast-relay) {/* if .SubProperties */}
+
+### target
+
+The local Envoy UDP listener that relayed datagrams are sent to.
+
+| | |
+|---|---|
+| **Type** | `object` |
+| **Required** | Yes |
+
+[↑ Top](#) | [↑ Multicast Relay Configuration](#multicast-relay)
+
+
+
+#### target.address
+
+Unicast address to forward to. Keep this on loopback: a unicast source address is what makes udp_proxy's reply path valid.
+
+| | |
+|---|---|
+| **Type** | `string` |
+| **Required** | No |
+
+[↑ Top](#) | [↑ Multicast Relay Configuration](#multicast-relay)
+
+
+
+#### target.port
+
+Port of Envoy's UDP listener. With BOE this is the same port number as the main TCP listener.
+
+| | |
+|---|---|
+| **Type** | `integer` |
+| **Required** | Yes |
+
+[↑ Top](#) | [↑ Multicast Relay Configuration](#multicast-relay)
+
+   {/* range .SubProperties */} {/* if .SubProperties */} {/* range .Properties */} {/* if .CustomTypes */}
+
+
+
+
 <a id="opa"></a>
 ## OPA Authorization Configuration
 


### PR DESCRIPTION
test https://github.com/AntonKanug/udp-multicast-relay

```
==> Waiting for Envoy admin on 127.0.0.1:9901 to report LIVE
    [envoy] [2026-07-28 15:24:19.662][9422637][info][dynamic_modules] [source/extensions/dynamic_modules/dynamic_modules.cc:80] Dynamic module ABI version v0.1.0 matched.
    [envoy] [2026-07-28 15:24:19.663][9422637][info][dynamic_modules] [source/extensions/dynamic_modules/abi_impl.cc:54] multicast-relay: joined 239.1.1.1:5000 on interface "lo0"
    [envoy] [2026-07-28 15:24:19.663][9422637][info][dynamic_modules] [source/extensions/dynamic_modules/abi_impl.cc:54] multicast-relay: joined 1 group(s) on 1 socket(s), forwarding to 127.0.0.1:10000

==> Sending 5 datagram(s) to 239.1.1.1:5000 via lo0

==> Reading from the upstream sink

Envoy udp stats:
  cluster.multicast_upstream.udp.sess_rx_datagrams: 5
  cluster.multicast_upstream.udp.sess_tx_datagrams: 5
  udp.multicast_relay.downstream_sess_active: 1
  udp.multicast_relay.downstream_sess_rx_bytes: 75
  udp.multicast_relay.downstream_sess_rx_datagrams: 5
  udp.multicast_relay.downstream_sess_total: 1
  udp.multicast_relay.downstream_sess_tx_bytes: 95
  udp.multicast_relay.downstream_sess_tx_datagrams: 5

==> Verifying udp_proxy's downstream reply path
  udp.multicast_relay.downstream_sess_tx_datagrams: 5
  downstream replies delivered, no EINVAL in Envoy's log

PASS: 5/5 datagrams traversed multicast -> relay -> udp_proxy -> upstream
  boe-multicast-0        from 127.0.0.1:64088
  boe-multicast-1        from 127.0.0.1:64088
  boe-multicast-2        from 127.0.0.1:64088
  boe-multicast-3        from 127.0.0.1:64088
  boe-multicast-4        from 127.0.0.1:64088
```