### PR TITLE
QoL: Introduce generic targets for check, format, lint, test, and test-coverage for golang 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,8 @@ All of the following are required:
 
 ### Ensure `make check` passes
 
-Please run `make check` locally before opening a PR and ensure that it passes.
+When contributing to the CLI or website, please run `make -C cli check` locally before opening a PR and ensure that it passes.
+When contributing to an extension, please run `make -C ../ check` (for extensions outside composer) or `make -C ../.. check` (for extensions inside composer) locally before opening a PR and ensure that it passes.
 If anything goes wrong, please do not open a PR or at least mark it as a draft PR. This is helpful to save time for the reviewers.
 
 ### Write Tests

--- a/extensions/Makefile
+++ b/extensions/Makefile
@@ -18,6 +18,19 @@ endif
 BOE_DATA_HOME ?= $(HOME)/.local/share/boe
 
 EXTENSION_PATH ?=
+# Try to automatically detect the EXTENSION_PATH if PWD is set from the shell
+ifneq ($(PWD),)
+	MAKEFILE_DIR = $(realpath $(dir $(firstword $(MAKEFILE_LIST))))
+	CWD          = $(realpath $(PWD))
+	ifneq ($(CWD), $(MAKEFILE_DIR)) # check that we are in a subdirectory and not the extension directory itself
+	ifneq ($(filter $(MAKEFILE_DIR)/%,$(CWD)), )
+	ifneq ($(wildcard $(CWD)/manifest.yaml),) # Check whether manifest.yaml exists by resolves to a file which yields the path or empty string
+		EXTENSION_PATH := $(CWD)
+	endif
+	endif
+	endif
+endif
+
 # Ensure the EXTENSION_PATH always be set
 ifeq ($(EXTENSION_PATH),)
   $(error "EXTENSION_PATH is not set. Please set it to the path of the extension.")

--- a/extensions/Makefile
+++ b/extensions/Makefile
@@ -49,6 +49,8 @@ TIMESTAMP        := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 COMMIT_SHA       := $(shell git rev-parse HEAD 2>/dev/null || echo "unknown")
 AUTHOR           := $(shell $(GO_TOOL) yq '.author' manifest.yaml)
 LICENSE          := Apache-2.0
+HAS_GOLANG       := $(if $(strip $(shell find "$(EXTENSION_PATH)" -type f -name '*.go' -print -quit 2>/dev/null)),true,false)
+HAS_RUST         := $(if $(strip $(shell find "$(EXTENSION_PATH)" -type f -name '*.rs' -print -quit 2>/dev/null)),true,false)
 
 HUB    := $(or $(BOE_REGISTRY),$(OCI_REGISTRY)/built-on-envoy)
 IMAGE  := $(HUB)/extension-$(NAME):$(VERSION)$(IMAGE_NONCE)
@@ -100,49 +102,51 @@ build-wasm:
 
 .PHONY: check
 check: format lint test-coverage
+	# In addition to checking the extension code also generate the datasource files for the portal
+	# to ensure that the manifest.yaml is filled in "correctly".
 	$(MAKE) -C ../cli check
 
 .PHONY: format
 format:
-	@if [ "$(TYPE)" = "go" ]; then \
+	@if [ "$(HAS_GOLANG)" = "true" ]; then \
 		$(MAKE) format-go EXTENSION_PATH=$(EXTENSION_PATH); \
-	elif [ "$(TYPE)" = "rust" ]; then \
+	elif [ "$(HAS_RUST)" = "true" ]; then \
 		$(MAKE) format-rust EXTENSION_PATH=$(EXTENSION_PATH); \
 	else \
-		echo "Unsupported extension type: $(TYPE). Use 'make format-go' or 'make format-rust' explicitly."; \
+		echo "Unable to detect Go or Rust sources under $(EXTENSION_PATH). Use 'make format-go' or 'make format-rust' explicitly."; \
 		exit 1; \
 	fi
 
 .PHONY: lint
 lint:
-	@if [ "$(TYPE)" = "go" ]; then \
+	@if [ "$(HAS_GOLANG)" = "true" ]; then \
 		$(MAKE) lint-go EXTENSION_PATH=$(EXTENSION_PATH); \
-	elif [ "$(TYPE)" = "rust" ]; then \
+	elif [ "$(HAS_RUST)" = "true" ]; then \
 		$(MAKE) lint-rust EXTENSION_PATH=$(EXTENSION_PATH); \
 	else \
-		echo "Unsupported extension type: $(TYPE). Use 'make lint-go' or 'make lint-rust' explicitly."; \
+		echo "Unable to detect Go or Rust sources under $(EXTENSION_PATH). Use 'make lint-go' or 'make lint-rust' explicitly."; \
 		exit 1; \
 	fi
 
 .PHONY: test
 test:
-	@if [ "$(TYPE)" = "go" ]; then \
+	@if [ "$(HAS_GOLANG)" = "true" ]; then \
 		$(MAKE) test-go EXTENSION_PATH=$(EXTENSION_PATH); \
-	elif [ "$(TYPE)" = "rust" ]; then \
+	elif [ "$(HAS_RUST)" = "true" ]; then \
 		$(MAKE) test-rust EXTENSION_PATH=$(EXTENSION_PATH); \
 	else \
-		echo "Unsupported extension type: $(TYPE). Use 'make test-go' or 'make test-rust' explicitly."; \
+		echo "Unable to detect Go or Rust sources under $(EXTENSION_PATH). Use 'make test-go' or 'make test-rust' explicitly."; \
 		exit 1; \
 	fi
 
 .PHONY: test-coverage
 test-coverage:
-	@if [ "$(TYPE)" = "go" ]; then \
+	@if [ "$(HAS_GOLANG)" = "true" ]; then \
 		$(MAKE) test-go-coverage EXTENSION_PATH=$(EXTENSION_PATH); \
-	elif [ "$(TYPE)" = "rust" ]; then \
+	elif [ "$(HAS_RUST)" = "true" ]; then \
 		$(MAKE) test-rust-coverage EXTENSION_PATH=$(EXTENSION_PATH); \
 	else \
-		echo "Unsupported extension type: $(TYPE). Use 'make test-go-coverage' or 'make test-rust-coverage' explicitly."; \
+		echo "Unable to detect Go or Rust sources under $(EXTENSION_PATH). Use 'make test-go-coverage' or 'make test-rust-coverage' explicitly."; \
 		exit 1; \
 	fi
 
@@ -239,7 +243,6 @@ push_rust: create_builder
 		--file Dockerfile.rust ./$(EXTENSION_PATH)
 
 .PHONY: push_extproc
-push_extproc:
 push_extproc: create_builder
 	@echo "Building and pushing ExtProc extension image for multiple architectures: $(IMAGE)"
 	@GO_VERSION=$$(sed -ne 's/^go //gp' $(EXTENSION_PATH)/go.mod); \

--- a/extensions/Makefile
+++ b/extensions/Makefile
@@ -98,6 +98,54 @@ build-extproc:
 build-wasm:
 	@GOOS=wasip1 GOARCH=wasm CGO_ENABLED=0 go -C $(EXTENSION_PATH) build -buildmode=c-shared -o ./out/plugin.wasm .
 
+.PHONY: check
+check: format lint test-coverage
+	$(MAKE) -C ../cli check
+
+.PHONY: format
+format:
+	@if [ "$(TYPE)" = "go" ]; then \
+		$(MAKE) format-go EXTENSION_PATH=$(EXTENSION_PATH); \
+	elif [ "$(TYPE)" = "rust" ]; then \
+		$(MAKE) format-rust EXTENSION_PATH=$(EXTENSION_PATH); \
+	else \
+		echo "Unsupported extension type: $(TYPE). Use 'make format-go' or 'make format-rust' explicitly."; \
+		exit 1; \
+	fi
+
+.PHONY: lint
+lint:
+	@if [ "$(TYPE)" = "go" ]; then \
+		$(MAKE) lint-go EXTENSION_PATH=$(EXTENSION_PATH); \
+	elif [ "$(TYPE)" = "rust" ]; then \
+		$(MAKE) lint-rust EXTENSION_PATH=$(EXTENSION_PATH); \
+	else \
+		echo "Unsupported extension type: $(TYPE). Use 'make lint-go' or 'make lint-rust' explicitly."; \
+		exit 1; \
+	fi
+
+.PHONY: test
+test:
+	@if [ "$(TYPE)" = "go" ]; then \
+		$(MAKE) test-go EXTENSION_PATH=$(EXTENSION_PATH); \
+	elif [ "$(TYPE)" = "rust" ]; then \
+		$(MAKE) test-rust EXTENSION_PATH=$(EXTENSION_PATH); \
+	else \
+		echo "Unsupported extension type: $(TYPE). Use 'make test-go' or 'make test-rust' explicitly."; \
+		exit 1; \
+	fi
+
+.PHONY: test-coverage
+test-coverage:
+	@if [ "$(TYPE)" = "go" ]; then \
+		$(MAKE) test-go-coverage EXTENSION_PATH=$(EXTENSION_PATH); \
+	elif [ "$(TYPE)" = "rust" ]; then \
+		$(MAKE) test-rust-coverage EXTENSION_PATH=$(EXTENSION_PATH); \
+	else \
+		echo "Unsupported extension type: $(TYPE). Use 'make test-go-coverage' or 'make test-rust-coverage' explicitly."; \
+		exit 1; \
+	fi
+
 .PHONY: format-go
 format-go:
 	@echo "format => ./$(EXTENSION_PATH)/..."
@@ -115,7 +163,7 @@ GO_TEST_ARGS ?=
 test-go:
 	@go test -C $(EXTENSION_PATH) $(GO_TEST_ARGS) ./...
 
-.PHONY: test-coverage
+.PHONY: test-go-coverage
 test-go-coverage:
 	@mkdir -p ./$(EXTENSION_PATH)/out
 	@$(MAKE) test-go GO_TEST_ARGS="-coverprofile=./out/go-test-coverage.out \

--- a/extensions/Makefile
+++ b/extensions/Makefile
@@ -25,7 +25,7 @@ ifneq ($(PWD),)
 	ifneq ($(CWD), $(MAKEFILE_DIR)) # check that we are in a subdirectory and not the extension directory itself
 	ifneq ($(filter $(MAKEFILE_DIR)/%,$(CWD)), )
 	ifneq ($(wildcard $(CWD)/manifest.yaml),) # Check whether manifest.yaml exists by resolves to a file which yields the path or empty string
-		EXTENSION_PATH := $(CWD)
+		EXTENSION_PATH := $(patsubst $(MAKEFILE_DIR)/%,%,$(CWD))
 	endif
 	endif
 	endif

--- a/extensions/Makefile
+++ b/extensions/Makefile
@@ -25,7 +25,7 @@ ifneq ($(PWD),)
 	ifneq ($(CWD), $(MAKEFILE_DIR)) # check that we are in a subdirectory and not the extension directory itself
 	ifneq ($(filter $(MAKEFILE_DIR)/%,$(CWD)), )
 	ifneq ($(wildcard $(CWD)/manifest.yaml),) # Check whether manifest.yaml exists by resolves to a file which yields the path or empty string
-		EXTENSION_PATH := $(patsubst $(MAKEFILE_DIR)/%,%,$(CWD))
+		EXTENSION_PATH ?= $(patsubst $(MAKEFILE_DIR)/%,%,$(CWD))
 	endif
 	endif
 	endif

--- a/extensions/Makefile
+++ b/extensions/Makefile
@@ -18,21 +18,23 @@ endif
 BOE_DATA_HOME ?= $(HOME)/.local/share/boe
 
 EXTENSION_PATH ?=
-# Try to automatically detect the EXTENSION_PATH if PWD is set from the shell
+# Try to automatically detect EXTENSION_PATH from PWD when it was not supplied.
+ifeq ($(strip $(EXTENSION_PATH)),)
 ifneq ($(PWD),)
-	MAKEFILE_DIR = $(realpath $(dir $(firstword $(MAKEFILE_LIST))))
-	CWD          = $(realpath $(PWD))
-	ifneq ($(CWD), $(MAKEFILE_DIR)) # check that we are in a subdirectory and not the extension directory itself
-	ifneq ($(filter $(MAKEFILE_DIR)/%,$(CWD)), )
+	MAKEFILE_DIR := $(realpath $(dir $(firstword $(MAKEFILE_LIST))))
+	CWD          := $(realpath $(PWD))
+	ifneq ($(CWD),$(MAKEFILE_DIR)) # check that we are in a subdirectory and not the extension directory itself
+	ifneq ($(filter $(MAKEFILE_DIR)/%,$(CWD)),)
 	ifneq ($(wildcard $(CWD)/manifest.yaml),) # Check whether manifest.yaml exists by resolves to a file which yields the path or empty string
-		EXTENSION_PATH ?= $(patsubst $(MAKEFILE_DIR)/%,%,$(CWD))
+		EXTENSION_PATH := $(patsubst $(MAKEFILE_DIR)/%,%,$(CWD))
 	endif
 	endif
 	endif
 endif
+endif
 
 # Ensure the EXTENSION_PATH always be set
-ifeq ($(EXTENSION_PATH),)
+ifeq ($(strip $(EXTENSION_PATH)),)
   $(error "EXTENSION_PATH is not set. Please set it to the path of the extension.")
 endif
 
@@ -106,49 +108,46 @@ check: format lint test-coverage
 	# to ensure that the manifest.yaml is filled in "correctly".
 	$(MAKE) -C ../cli check
 
+FORMAT_TARGETS := $(strip \
+	$(if $(filter true,$(HAS_GOLANG)),format-go) \
+	$(if $(filter true,$(HAS_RUST)),format-rust))
+LINT_TARGETS := $(strip \
+	$(if $(filter true,$(HAS_GOLANG)),lint-go) \
+	$(if $(filter true,$(HAS_RUST)),lint-rust))
+TEST_TARGETS := $(strip \
+	$(if $(filter true,$(HAS_GOLANG)),test-go) \
+	$(if $(filter true,$(HAS_RUST)),test-rust))
+TEST_COVERAGE_TARGETS := $(strip \
+	$(if $(filter true,$(HAS_GOLANG)),test-go-coverage) \
+	$(if $(filter true,$(HAS_RUST)),test-rust-coverage))
+
 .PHONY: format
-format:
-	@if [ "$(HAS_GOLANG)" = "true" ]; then \
-		$(MAKE) format-go EXTENSION_PATH=$(EXTENSION_PATH); \
-	elif [ "$(HAS_RUST)" = "true" ]; then \
-		$(MAKE) format-rust EXTENSION_PATH=$(EXTENSION_PATH); \
-	else \
-		echo "Unable to detect Go or Rust sources under $(EXTENSION_PATH). Use 'make format-go' or 'make format-rust' explicitly."; \
-		exit 1; \
-	fi
+format: $(FORMAT_TARGETS)
+ifeq ($(FORMAT_TARGETS),)
+	@echo "Unable to detect Go or Rust sources under $(EXTENSION_PATH). Use 'make format-go' or 'make format-rust' explicitly."
+	@exit 1
+endif
 
 .PHONY: lint
-lint:
-	@if [ "$(HAS_GOLANG)" = "true" ]; then \
-		$(MAKE) lint-go EXTENSION_PATH=$(EXTENSION_PATH); \
-	elif [ "$(HAS_RUST)" = "true" ]; then \
-		$(MAKE) lint-rust EXTENSION_PATH=$(EXTENSION_PATH); \
-	else \
-		echo "Unable to detect Go or Rust sources under $(EXTENSION_PATH). Use 'make lint-go' or 'make lint-rust' explicitly."; \
-		exit 1; \
-	fi
+lint: $(LINT_TARGETS)
+ifeq ($(LINT_TARGETS),)
+	@echo "Unable to detect Go or Rust sources under $(EXTENSION_PATH). Use 'make lint-go' or 'make lint-rust' explicitly."
+	@exit 1
+endif
 
 .PHONY: test
-test:
-	@if [ "$(HAS_GOLANG)" = "true" ]; then \
-		$(MAKE) test-go EXTENSION_PATH=$(EXTENSION_PATH); \
-	elif [ "$(HAS_RUST)" = "true" ]; then \
-		$(MAKE) test-rust EXTENSION_PATH=$(EXTENSION_PATH); \
-	else \
-		echo "Unable to detect Go or Rust sources under $(EXTENSION_PATH). Use 'make test-go' or 'make test-rust' explicitly."; \
-		exit 1; \
-	fi
+test: $(TEST_TARGETS)
+ifeq ($(TEST_TARGETS),)
+	@echo "Unable to detect Go or Rust sources under $(EXTENSION_PATH). Use 'make test-go' or 'make test-rust' explicitly."
+	@exit 1
+endif
 
 .PHONY: test-coverage
-test-coverage:
-	@if [ "$(HAS_GOLANG)" = "true" ]; then \
-		$(MAKE) test-go-coverage EXTENSION_PATH=$(EXTENSION_PATH); \
-	elif [ "$(HAS_RUST)" = "true" ]; then \
-		$(MAKE) test-rust-coverage EXTENSION_PATH=$(EXTENSION_PATH); \
-	else \
-		echo "Unable to detect Go or Rust sources under $(EXTENSION_PATH). Use 'make test-go-coverage' or 'make test-rust-coverage' explicitly."; \
-		exit 1; \
-	fi
+test-coverage: $(TEST_COVERAGE_TARGETS)
+ifeq ($(TEST_COVERAGE_TARGETS),)
+	@echo "Unable to detect Go or Rust sources under $(EXTENSION_PATH). Use 'make test-go-coverage' or 'make test-rust-coverage' explicitly."
+	@exit 1
+endif
 
 .PHONY: format-go
 format-go:


### PR DESCRIPTION
There are actually two improvements:

1. The ability to "just" call `make test` to run the proper tests, regardless of the type of the extension. (Fortunately, this type determination was already in place.
2. The ability to forego having to set the EXTENSION_PATH when calling the makefile from the root directory of an extension.

Maybe a tiny 3rd improvement:

The check of the individual extension now *also* calls the cli/check as there might be something wrong in the manifest.yaml which is otherwise not found, and the extensions need to be committed as well. So makes it easier to check all requirements in one go.